### PR TITLE
Added EMFM redirect to wiki

### DIFF
--- a/views/basic.py
+++ b/views/basic.py
@@ -94,6 +94,12 @@ def badge():
     return redirect('http://wiki-archive.emfcamp.org/2012/wiki/TiLDA')
 
 
+@app.route('/radio')
+@app.route('/emfm')
+def badge():
+    return redirect('https://wiki.emfcamp.org/wiki/EMFM')
+
+
 @app.route("/code-of-conduct")
 def code_of_conduct():
     return render_template('code-of-conduct.html')


### PR DESCRIPTION
This is to allow a simple emfcamp.org URL to be read on air. Just a redirect to the wiki under the same domain. No visual impact on the site.