### PR TITLE
Update vagrantfile, use debian 8, use postgres 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 Starting
 ========
 ```
-sudo apt-get install python-dev python-virtualenv libxml2-dev libxslt-dev libffi-dev postgresql-server-dev-9.1
+sudo apt-get install -y python-dev python-virtualenv libxml2-dev libxslt1-dev libffi-dev postgresql-server-dev-9.4 git
 make init
 make update # may take a few minutes if you don't have cached .whl files
 make data
@@ -25,6 +25,17 @@ To set up easy\_install go [here](https://pythonhosted.org/setuptools/easy_insta
 sudo easy_install virtualenv
 make init
 ```
+
+Using vagrant
+=======
+
+```
+vagrant up
+vagrant ssh
+cd /vagrant
+```
+This is running all the necassary provisioning steps (see ```provision.sh```), only the final ```make``` and
+```make admin``` is needed. Port 5000 is forwarded.
 
 Running
 =======

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,99 +1,11 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
-  # All Vagrant configuration is done here. The most common configuration
-  # options are documented and commented below. For a complete reference,
-  # please see the online documentation at vagrantup.com.
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian8"
+  config.vm.box_url = "https://f458271790152e424d62-0ee3ea466698a63342545f1433b44e51.ssl.cf3.rackcdn.com/debian8.box"
 
-  # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "debian_squeeze_32"
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
 
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
-  config.vm.box_url = "http://mathie-vagrant-boxes.s3.amazonaws.com/debian_squeeze_32.box"
-
-  # Boot with a GUI so you can see the screen. (Default is headless)
-  # config.vm.boot_mode = :gui
-
-  # Assign this VM to a host-only network IP, allowing you to access it
-  # via the IP. Host-only networks can talk to the host machine as well as
-  # any other machines on the same network, but cannot be accessed (through this
-  # network interface) by any external networks.
-  # config.vm.network :hostonly, "192.168.33.10"
-
-  # Assign this VM to a bridged network, allowing you to connect directly to a
-  # network using the host's network device. This makes the VM appear as another
-  # physical device on your network.
-  # config.vm.network :bridged
-
-  # Forward a port from the guest to the host, which allows for outside
-  # computers to access the VM, whereas host only networking does not.
-  # config.vm.forward_port 80, 8080
-
-  # Share an additional folder to the guest VM. The first argument is
-  # an identifier, the second is the path on the guest to mount the
-  # folder, and the third is the path on the host to the actual folder.
-  # config.vm.share_folder "v-data", "/vagrant_data", "../data"
-
-  # Enable provisioning with Puppet stand alone.  Puppet manifests
-  # are contained in a directory path relative to this Vagrantfile.
-  # You will need to create the manifests directory and a manifest in
-  # the file base.pp in the manifests_path directory.
-  #
-  # An example Puppet manifest to provision the message of the day:
-  #
-  # # group { "puppet":
-  # #   ensure => "present",
-  # # }
-  # #
-  # # File { owner => 0, group => 0, mode => 0644 }
-  # #
-  # # file { '/etc/motd':
-  # #   content => "Welcome to your Vagrant-built virtual machine!
-  # #               Managed by Puppet.\n"
-  # # }
-  #
-  # config.vm.provision :puppet do |puppet|
-  #   puppet.manifests_path = "manifests"
-  #   puppet.manifest_file  = "base.pp"
-  # end
-
-  # Enable provisioning with chef solo, specifying a cookbooks path, roles
-  # path, and data_bags path (all relative to this Vagrantfile), and adding 
-  # some recipes and/or roles.
-  #
-  # config.vm.provision :chef_solo do |chef|
-  #   chef.cookbooks_path = "../my-recipes/cookbooks"
-  #   chef.roles_path = "../my-recipes/roles"
-  #   chef.data_bags_path = "../my-recipes/data_bags"
-  #   chef.add_recipe "mysql"
-  #   chef.add_role "web"
-  #
-  #   # You may also specify custom JSON attributes:
-  #   chef.json = { :mysql_password => "foo" }
-  # end
-
-  # Enable provisioning with chef server, specifying the chef server URL,
-  # and the path to the validation key (relative to this Vagrantfile).
-  #
-  # The Opscode Platform uses HTTPS. Substitute your organization for
-  # ORGNAME in the URL and validation key.
-  #
-  # If you have your own Chef Server, use the appropriate URL, which may be
-  # HTTP instead of HTTPS depending on your configuration. Also change the
-  # validation key to validation.pem.
-  #
-  # config.vm.provision :chef_client do |chef|
-  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
-  #   chef.validation_key_path = "ORGNAME-validator.pem"
-  # end
-  #
-  # If you're using the Opscode platform, your validator client is
-  # ORGNAME-validator, replacing ORGNAME with your organization name.
-  #
-  # IF you have your own Chef Server, the default validation client name is
-  # chef-validator, unless you changed the configuration.
-  #
-  #   chef.validation_client_name = "ORGNAME-validator"
+  config.vm.provision "shell", path: "provision.sh"
 end

--- a/main.py
+++ b/main.py
@@ -73,4 +73,4 @@ if __name__ == "__main__":
                 request.environ['wsgi.url_scheme'] = 'https'
                 _request_ctx_stack.top.url_adapter.url_scheme = 'https'
 
-    app.run(processes=2)
+    app.run(processes=2, host="0.0.0.0")

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,5 @@
+cd /vagrant
+sudo apt-get install -y python-dev python-virtualenv libxml2-dev libxslt1-dev libffi-dev postgresql-server-dev-9.4 git
+make init
+make update
+make data


### PR DESCRIPTION
The Vagrantfile looked a bit derelict, I've update it to make setting up a dev environment easier. 

* Uses debian 8 (the url is a minimal debian image a colleague of mine has created)
* Uses Postgres 9.4 - because debian 8 doesn't support 9.1 out of the box and why not
* Uses Vagrant config type 2
* Makes flask bind to all interfaces instead of just localhost - I guess the production box will be firewalled off and it makes port forwarding in vagrant a lot easier.