### PR TITLE
Allow users to buy tickets without having to register first

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -4,7 +4,7 @@ import bcrypt
 import os
 import base64
 from datetime import datetime, timedelta
-
+from random import choice
 
 class User(db.Model, UserMixin):
     __tablename__ = 'user'
@@ -27,6 +27,12 @@ class User(db.Model, UserMixin):
 
     def check_password(self, password):
         return bcrypt.hashpw(password.encode('utf8'), self.password) == self.password
+
+    def generate_random_password(self):
+        chars = "ABCDEFGHKLMNPRSTUVWXYZ23456789"
+        password = ''.join(choice(chars) for _ in range(10))
+        self.set_password(password)
+        return password
 
     def __repr__(self):
         return '<User %s>' % self.email

--- a/templates/emails/tickets-signup-email.txt
+++ b/templates/emails/tickets-signup-email.txt
@@ -1,0 +1,20 @@
+Hi {{ user.name }},
+
+Thanks for your interest in purchasing tickets for Electromagnetic Field.
+You're ticket is not confirmed yet, but you're getting closer!
+
+To manage your ticket payment process we've created you an account. Your
+temporary password is: {{temporary_password}}
+
+You can log in on {{ external_url('login') }} and change your password if
+you want to.
+
+You can keep track of your ticket purchases here:
+
+{{ external_url('tickets') }}
+
+See you soon at Electromagnetic Field 2014!
+
+Love,
+
+All the EMF team

--- a/templates/emails/tickets-signup-email.txt
+++ b/templates/emails/tickets-signup-email.txt
@@ -3,11 +3,10 @@ Hi {{ user.name }},
 Thanks for your interest in purchasing tickets for Electromagnetic Field.
 You're ticket is not confirmed yet, but you're getting closer!
 
-To manage your ticket payment process we've created you an account. Your
-temporary password is: {{temporary_password}}
+To manage your ticket payment process we've created you an account. To set a
+password please visit the password reset page:
 
-You can log in on {{ external_url('login') }} and change your password if
-you want to.
+{{ external_url('forgot_password') }}
 
 You can keep track of your ticket purchases here:
 

--- a/templates/tickets/email.html
+++ b/templates/tickets/email.html
@@ -1,0 +1,34 @@
+ <div>
+  {% if i==1 and is_anonymous %}
+    <label>Your email address (required):
+       {{ email(class_='form-control')|safe }}
+    </label>
+
+    {% for error in email.errors %}
+    <span class="help-inline">{{ error }}</span>
+    {% endfor %}
+
+    <div id="a-blurb{{ i }}">
+      <p>We need your email address to send you your tickets, please make sure it's correct. Should you decide to sign up for workshops or edit the wiki later please use this email address and we'll automatically add the tickets to your account.</p>
+    </div>
+  {% endif %}
+
+<!-- ToDo: Uncomment for #212
+  {% if i>1 %}
+    <label>Email address of the ticket holder (optional):
+       {{ email(class_='form-control')|safe }}
+    </label>
+
+    {% for error in email.errors %}
+    <span class="help-inline">{{ error }}</span>
+    {% endfor %}
+
+    {% if i==2 %}
+      <div id="a-blurb{{ i }}">
+        <p>If you know who this ticket is for, please enter their email address. This will allow them to create an account for themselves to sign up for workshops and edit the wiki. Don't worry if you're not sure yet, you can always change this later.</p>
+      </div>
+    {% endif %}
+  {% endif %}
+-->
+
+</div>

--- a/templates/tickets/full.html
+++ b/templates/tickets/full.html
@@ -1,12 +1,15 @@
 {{ ticket.form.hidden_tag_without('csrf_token') }}
 {% set volunteer = ticket.form.volunteer %}
 {% set accessible = ticket.form.accessible %}
+{% set email = ticket.form.email %}
 {% set phone = ticket.form.phone %}
+
+{% include 'tickets/email.html' %}
 
 <div class="{% if volunteer.errors or accessible.errors -%} error {%- endif %}">
   <div class="controls">
     <label class="checkbox">
-      {{ volunteer()|safe }}  
+      {{ volunteer()|safe }}
       I'm interested in volunteering <a data-toggle="collapse" href="#v-blurb{{ i }}"></a>
     </label>
     {% for error in volunteer.errors %}

--- a/views/payment/__init__.py
+++ b/views/payment/__init__.py
@@ -52,7 +52,7 @@ def pay_choose():
         # ToDo: Make user.name optional. See #223
         email = session['anonymous_account_email']
         user = User(email, "NULL")
-        temporary_password = user.generate_random_password()
+        user.generate_random_password()
         db.session.add(user)
         print(1)
         try:
@@ -69,7 +69,7 @@ def pay_choose():
         msg = Message("Welcome to Electromagnetic Field",
                 sender=app.config['TICKETS_EMAIL'],
                 recipients=[user.email])
-        msg.body = render_template("emails/tickets-signup-email.txt", user=user, temporary_password=temporary_password)
+        msg.body = render_template("emails/tickets-signup-email.txt", user=user)
         mail.send(msg)
         print(3)
         app.logger.info('Created new user with email %s and id %s', email, user.id)

--- a/views/payment/__init__.py
+++ b/views/payment/__init__.py
@@ -54,15 +54,12 @@ def pay_choose():
         user = User(email, "NULL")
         user.generate_random_password()
         db.session.add(user)
-        print(1)
         try:
             db.session.commit()
-            print(1.1)
         except IntegrityError, e:
             app.logger.warn('Adding user raised %r, assuming duplicate email', e)
             flash("This email address %s is already in use. Please log in, or reset your password if you've forgotten it." % (email))
             return redirect(url_for('tickets_info'))
-        print(2)
         login_user(user)
 
         # send a welcome email.
@@ -71,7 +68,6 @@ def pay_choose():
                 recipients=[user.email])
         msg.body = render_template("emails/tickets-signup-email.txt", user=user)
         mail.send(msg)
-        print(3)
         app.logger.info('Created new user with email %s and id %s', email, user.id)
         current_user.id = user.id
 

--- a/views/payment/__init__.py
+++ b/views/payment/__init__.py
@@ -1,11 +1,16 @@
-from main import app
+from main import app, db, mail
 from models import Payment, StripePayment, TicketType, Ticket
+from models.user import User
 from views import get_basket
 
-from flask import render_template, redirect, url_for, abort, flash
-from flask.ext.login import login_required, current_user
+from flask import (
+    render_template, redirect, url_for, abort, session, flash
+)
+from flask.ext.login import login_required, current_user, login_user
+from flask_mail import Message
 
 from sqlalchemy.sql.functions import func
+from sqlalchemy.exc import IntegrityError
 
 from decimal import Decimal
 
@@ -36,12 +41,39 @@ def ticket_terms():
     return render_template('terms.html')
 
 @app.route("/pay/choose")
-@login_required
 def pay_choose():
     basket, total = get_basket()
 
     if not basket:
         redirect(url_for('tickets'))
+
+    # Implicit user signup
+    if current_user.is_anonymous():
+        # ToDo: Make user.name optional. See #223
+        email = session['anonymous_account_email']
+        user = User(email, "NULL")
+        temporary_password = user.generate_random_password()
+        db.session.add(user)
+        print(1)
+        try:
+            db.session.commit()
+            print(1.1)
+        except IntegrityError, e:
+            app.logger.warn('Adding user raised %r, assuming duplicate email', e)
+            flash("This email address %s is already in use. Please log in, or reset your password if you've forgotten it." % (email))
+            return redirect(url_for('tickets_info'))
+        print(2)
+        login_user(user)
+
+        # send a welcome email.
+        msg = Message("Welcome to Electromagnetic Field",
+                sender=app.config['TICKETS_EMAIL'],
+                recipients=[user.email])
+        msg.body = render_template("emails/tickets-signup-email.txt", user=user, temporary_password=temporary_password)
+        mail.send(msg)
+        print(3)
+        app.logger.info('Created new user with email %s and id %s', email, user.id)
+        current_user.id = user.id
 
     return render_template('payment-choose.html', basket=basket, total=total, StripePayment=StripePayment)
 


### PR DESCRIPTION
This removes the requirement for an user account from the ticket purchase process. 

These changes will lead to "silent" user account creation happening just before the payment page is displayed. An additional email is send to the user informing them of their temporary password. 
