### PR TITLE
help-inline is not supported anymore, using form-group and help-block instead

### DIFF
--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -138,7 +138,7 @@
             {{ form.need_finance.label.text }}
           </label>
           {% for error in form.need_finance.errors %}
-          <span class="help-inline">{{ error }}</span>
+          <div class="help-block">{{ error }}</div>
           {% endfor %}
         </div>
 
@@ -149,7 +149,7 @@
             {{ form.one_day.label.text }}
           </label>
           {% for error in form.one_day.errors %}
-          <span class="help-inline">{{ error }}</span>
+          <div class="help-block">{{ error }}</div>
           {% endfor %}
         </div>
       {% endif %}

--- a/templates/tickets/accessible.html
+++ b/templates/tickets/accessible.html
@@ -4,7 +4,7 @@
       I have accessibility requirements <a data-toggle="collapse" href="#a-blurb{{ i }}"></a>
     </label>
     {% for error in accessible.errors %}
-    <span class="help-inline">{{ error }}</span>
+    <div class="help-block">{{ error }}</div>
     {% endfor %}
     <div id="a-blurb{{ i }}" class="collapse {% if i==1 %}in{% endif %}">
       <p>We want to make EMF as inclusive as possible, if you have any specific requirements please let us know and we'll be in touch for more information.</p>

--- a/templates/tickets/email.html
+++ b/templates/tickets/email.html
@@ -1,17 +1,19 @@
  <div>
   {% if i==1 and is_anonymous %}
+    <div class="form-group {% if email.errors %}has-error{% endif %}">
 
-    {% for error in email.errors %}
-    <span class="help-inline">{{ error }}</span>
-    {% endfor %}
+      <p>
+        <label for="{{ email.id }}">Your email address:</label>
+        {{ email(class_='form-control')|safe }}
+      </p>
 
-    <p>
-    <label for="{{ email.id }}">Your email address:</label>
-    {{ email(class_='form-control')|safe }}
-    </p>
+      {% for error in email.errors %}
+      <div class="help-block">{{ error }}</div>
+      {% endfor %}
 
-    <div id="a-blurb{{ i }}">
-      <p>We need your email address to send you your tickets, please make sure it's correct. Should you decide to sign up for workshops or edit the wiki later please use this email address and we'll automatically add the tickets to your account.</p>
+      <div id="a-blurb{{ i }}">
+        <p>We need your email address to send you your tickets, please make sure it's correct. Should you decide to sign up for workshops or edit the wiki later please use this email address and we'll automatically add the tickets to your account.</p>
+      </div>
     </div>
   {% endif %}
 
@@ -22,7 +24,7 @@
     </label>
 
     {% for error in email.errors %}
-    <span class="help-inline">{{ error }}</span>
+    <div class="help-block">{{ error }}</div>
     {% endfor %}
 
     {% if i==2 %}

--- a/templates/tickets/full.html
+++ b/templates/tickets/full.html
@@ -13,7 +13,7 @@
       I'm interested in volunteering <a data-toggle="collapse" href="#v-blurb{{ i }}"></a>
     </label>
     {% for error in volunteer.errors %}
-    <span class="help-inline">{{ error }}</span>
+    <div class="help-block">{{ error }}</div>
     {% endfor %}
     <!-- use 'i' to mangle the namespace, if it's the first ticket display the blurb -->
     <div id="v-blurb{{ i }}" class="collapse {% if i==1 %}in{% endif %}">
@@ -30,7 +30,7 @@
         We'll get in touch by email about volunteering
       </label>
       {% for error in phone.errors %}
-      <span class="help-inline">{{ error }}</span>
+      <div class="help-block">{{ error }}</div>
       {% endfor %}
       <p>But to save time later, feel free to add your mobile/phone number now:</p>
       <div class="form-group{% if phone.errors %} error{% endif %}">
@@ -39,7 +39,7 @@
         <div class="controls col-sm-4">{{ phone(class_='form-control')|safe }}
           {% if phone.errors %}
               {% for error in phone.errors %}
-                <span class="help-inline">{{ error }}</span>
+                <div class="help-block">{{ error }}</div>
               {% endfor %}
           {% endif %}
         </div>


### PR DESCRIPTION
See #234 and http://code.divshot.com/bootstrap3_upgrader/
 
I've also replaced ```help-inline``` with ```help-block``` everywhere else, but I haven't managed to test them (how can you trigger an error on a checkbox? How can I trigger an error on the phone number field?)

![error](https://cloud.githubusercontent.com/assets/158185/11169451/8f7e3cec-8bb0-11e5-9dc2-01ae540885e0.png)