### PR TITLE
Transferable tickets

### DIFF
--- a/apps/admin.py
+++ b/apps/admin.py
@@ -283,6 +283,7 @@ class NewTicketTypeForm(Form):
     price_gbp = IntegerField('Price (GBP)')
     price_eur = IntegerField('Price (EUR)')
     has_badge = BooleanField('Issue Badge')
+    is_transferable = BooleanField('Transferable')
     discount_token = StringField('Discount token', [Optional(), Regexp('^[-_0-9a-zA-Z]+$')])
     description = StringField('Description', [Optional()], widget=TextArea())
     submit = SubmitField('Create')
@@ -295,6 +296,7 @@ class NewTicketTypeForm(Form):
         self.personal_limit.data = ticket_type.personal_limit
         self.expires.data = ticket_type.expires
         self.has_badge.data = ticket_type.has_badge
+        self.is_transferable.data = ticket_type.is_transferable
         self.price_gbp.data = ticket_type.get_price('GBP')
         self.price_eur.data = ticket_type.get_price('EUR')
         self.description.data = ticket_type.description
@@ -317,7 +319,9 @@ def new_ticket_type(copy_id):
         tt = TicketType(new_id, form.order.data, form.admits.data,
                         form.name.data, form.type_limit.data, expires=expires,
                         discount_token=token, description=description,
-                        personal_limit=form.personal_limit.data, has_badge=form.has_badge.data)
+                        personal_limit=form.personal_limit.data,
+                        has_badge=form.has_badge.data,
+                        is_transferable=form.is_transferable.data)
 
         tt.prices = [TicketPrice('GBP', form.price_gbp.data),
                      TicketPrice('EUR', form.price_eur.data)]

--- a/apps/common/__init__.py
+++ b/apps/common/__init__.py
@@ -62,6 +62,11 @@ def load_utility_functions(app_obj):
         currency = get_user_currency()
         return {'user_currency': currency}
 
+def send_template_email(subject, to, sender, template, **kwargs):
+    msg = Message(subject, recipients=[to], sender=sender)
+    msg.body = render_template(template, **kwargs)
+    mail.send(msg)
+
 
 def create_current_user(email, name, password=None):
     user = User(email, name)
@@ -81,11 +86,8 @@ def create_current_user(email, name, password=None):
     current_user.id = user.id
 
     # Send the welcome message
-    msg = Message('Welcome to Electromagnetic Field',
-                  sender=app.config['TICKETS_EMAIL'],
-                  recipients=[user.email])
-    msg.body = render_template(signup_template, user=user)
-    mail.send(msg)
+    send_template_email('Welcome to Electromagnetic Field', user.email,
+                        app.config['TICKETS_EMAIL'], signup_template, user=user)
 
     return user
 

--- a/apps/tickets.py
+++ b/apps/tickets.py
@@ -371,14 +371,7 @@ def transfer(ticket_id):
             to_user = User.query.filter_by(email=email).one()
             email_template = 'ticket-transfer-new-owner.txt'
 
-        # Transfer the ticket
-        ticket.user = to_user
-        # Make sure the ticket can't be double-used
-        ticket.emailed = False
-        ticket.qrcode = None
-        ticket.create_qrcode()
-        ticket.receipt = None
-        ticket.create_receipt()
+        ticket.transfer_to(to_user)
         # Log the transfer in an SQL parse-able manner (e.g. ids only)
         transfer_str = '%d -> %d' % (current_user.id, to_user.id)
         ticket.attribs.append(TicketAttrib('transfer', transfer_str))

--- a/apps/tickets.py
+++ b/apps/tickets.py
@@ -17,11 +17,12 @@ from wtforms import (
 )
 from wtforms.fields.html5 import EmailField
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
 
 from main import db
 from .common import (
     get_user_currency, set_user_currency, get_basket_and_total, process_basket,
-    CURRENCY_SYMBOLS, feature_flag, create_current_user)
+    CURRENCY_SYMBOLS, feature_flag, create_current_user, send_template_email)
 from .common.forms import IntegerSelectField, HiddenIntegerField, Form
 from models.user import User
 from models.ticket import (
@@ -345,37 +346,82 @@ class TicketTransferForm(Form):
 @tickets.route('/tickets/<ticket_id>/transfer', methods=['GET', 'POST'])
 @login_required
 def transfer(ticket_id):
-    ticket = current_user.tickets.filter_by(id=ticket_id).one()
+    try:
+        ticket = current_user.tickets.filter_by(id=ticket_id).one()
+    except NoResultFound:
+        return redirect(url_for('tickets.main'))
 
     if not ticket or not ticket.paid:
-        redirect('tickets.main')
+        return redirect(url_for('tickets.main'))
 
     form = TicketTransferForm()
 
     if form.validate_on_submit():
+        assert ticket.user_id == current_user.id
         email = form.email.data
-        from_user_id = ticket.user_id
 
         if not User.does_user_exist(email):
+            # Create a new user to transfer the ticket to
             to_user = User(email, form.name.data)
             to_user.generate_random_password()
-            # TODO: send signup email
             db.session.add(to_user)
             db.session.commit()
+            email_template = 'ticket-transfer-new-owner-and-user.txt'
         else:
-            # TODO: send transfer confirmation email
             to_user = User.query.filter_by(email=email).one()
+            email_template = 'ticket-transfer-new-owner.txt'
 
+        # Transfer the ticket
         ticket.user = to_user
         # Make sure the ticket can't be double-used
         ticket.emailed = False
+        ticket.qrcode = None
         ticket.create_qrcode()
+        ticket.receipt = None
         ticket.create_receipt()
-        # Log the transfer
-        ticket.attribs.append(TicketAttrib('transfer', str(from_user_id)))
+        # Log the transfer in an SQL parse-able manner (e.g. ids only)
+        transfer_str = '%d -> %d' % (current_user.id, to_user.id)
+        ticket.attribs.append(TicketAttrib('transfer', transfer_str))
+
+        app.logger.info('Ticket %s transferred from %s to %s', ticket,
+                        current_user, to_user)
+        # Save everything
         db.session.commit()
+        # Alert the users via email
+        send_template_email("You've been sent a ticket to EMF 2016!",
+                            to_user.email, current_user.email,
+                            'emails/' + email_template,
+                            to_user=to_user, from_user=current_user)
+
+        send_template_email("You sent someone an EMF 2016 ticket",
+                            to_user.email, current_user.email,
+                            'emails/ticket-transfer-original-owner.txt',
+                            to_user=to_user, from_user=current_user)
+
+        return redirect(url_for('tickets.transferred'))
 
     return render_template('ticket-transfer.html', ticket=ticket, form=form)
+
+
+@tickets.route("/tickets/transferred")
+@login_required
+def transferred():
+    # Build a 'like' query string to find transfers from this user.
+    id_str = '{0:d}%'.format(current_user.id)
+    transfer_logs = TicketAttrib.query.filter_by(name='transfer').\
+                                 filter(TicketAttrib.value.like(id_str)).all()
+
+    transferred = []
+    for ta in transfer_logs:
+        ticket = ta.ticket
+        # Because we log both ends of the transfer we can make sure we only show
+        # people the transfers they have made (and not any subsequent transfers)
+        to_user_id = int(ta.value.split('->')[1])
+        to_user = User.query.get(to_user_id)
+        transferred.append((ticket, to_user))
+
+    return render_template('tickets-transferred.html', transferred=transferred)
+
 
 
 @tickets.route("/tickets/receipt")

--- a/apps/tickets.py
+++ b/apps/tickets.py
@@ -351,7 +351,7 @@ def transfer(ticket_id):
     except NoResultFound:
         return redirect(url_for('tickets.main'))
 
-    if not ticket or not ticket.paid:
+    if not ticket or not ticket.paid or not ticket.type.is_transferable:
         return redirect(url_for('tickets.main'))
 
     form = TicketTransferForm()

--- a/models/payment.py
+++ b/models/payment.py
@@ -16,7 +16,6 @@ class StateException(Exception):
 
 
 class Payment(db.Model):
-
     __tablename__ = 'payment'
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
@@ -240,6 +239,7 @@ class GoCardlessPayment(Payment):
         )
 
         return bill_url
+
 
 class StripePayment(Payment):
     name = 'Stripe payment'

--- a/models/ticket.py
+++ b/models/ticket.py
@@ -34,6 +34,7 @@ class TicketType(db.Model):
     type_limit = db.Column(db.Integer, nullable=False)
     personal_limit = db.Column(db.Integer, nullable=False)
     has_badge = db.Column(db.Boolean, nullable=False)
+    is_transferable = db.Column(db.Boolean, default=True, nullable=False)
     # Nullable fields
     expires = db.Column(db.DateTime)
     description = db.Column(db.String)
@@ -43,7 +44,8 @@ class TicketType(db.Model):
     admits_types = ('full', 'kid', 'campervan', 'car', 'other')
 
     def __init__(self, id, order, admits, name, type_limit, personal_limit,
-                 expires=None, discount_token=None, description=None, has_badge=True):
+                 expires=None, discount_token=None, description=None,
+                 has_badge=True, is_transferable=True):
         if admits not in self.admits_types:
             raise Exception('unknown admission type')
 
@@ -57,6 +59,7 @@ class TicketType(db.Model):
         self.description = description
         self.discount_token = discount_token
         self.personal_limit = personal_limit
+        self.is_transferable = is_transferable
 
     def __repr__(self):
         return "<TicketType: (Name: %s, Admits: %s, Token: %s)>" % \
@@ -272,6 +275,8 @@ class Ticket(db.Model):
         Change the user a ticket is assigned to and remove the qrcode/receipt so
         that the old values can't be used.
         """
+        if not self.type.is_transferable:
+            raise Exception('This ticket cannot be transferred.')
         self.user = user
         self.emailed = False
         self.qrcode = None

--- a/models/ticket.py
+++ b/models/ticket.py
@@ -19,8 +19,10 @@ def validate_safechars(val):
 class TicketError(Exception):
     pass
 
+
 class CheckinStateException(Exception):
     pass
+
 
 class TicketType(db.Model):
     __tablename__ = 'ticket_type'
@@ -273,6 +275,7 @@ class Ticket(db.Model):
             attrs.append('expired')
         return "<Ticket %s: %s>" % (self.id, ', '.join(attrs))
 
+
 class TicketAttrib(db.Model):
     __tablename__ = 'ticket_attrib'
     id = db.Column(db.Integer, primary_key=True)
@@ -286,6 +289,7 @@ class TicketAttrib(db.Model):
 
     def __repr__(self):
         return "<TicketAttrib %s: %s>" % (self.name, self.value)
+
 
 class TicketCheckin(db.Model):
     __tablename__ = 'ticket_checkin'

--- a/models/ticket.py
+++ b/models/ticket.py
@@ -267,6 +267,16 @@ class Ticket(db.Model):
             except IntegrityError:
                 db.session.rollback()
 
+    def transfer_to(self, user):
+        """
+        Change the user a ticket is assigned to and remove the qrcode/receipt so
+        that the old values can't be used.
+        """
+        self.user = user
+        self.emailed = False
+        self.qrcode = None
+        self.receipt = None
+
     def __repr__(self):
         attrs = [self.type.admits]
         if self.paid:

--- a/models/user.py
+++ b/models/user.py
@@ -42,7 +42,8 @@ class User(db.Model, UserMixin):
 
     @classmethod
     def does_user_exist(cls, email):
-        return exists(User.query.filter_by(email=email))
+        return exists(User.query.filter_by( email=email ))
+
 
 class PasswordReset(db.Model):
     __tablename__ = 'password_reset'

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -41,9 +41,14 @@
                     Expiring payments <span class="badge">{{ expiring_count }}</span>
                 </a></li>
                 <li {% if nav_active == 'ticket_types' -%} class="active" {%- endif %}><a href="{{ url_for('.ticket_types') }}">
-                    Ticket Types</a></li>
+                    Ticket Types
+                </a></li>
+                <li {% if nav_active == 'ticket_transfers' -%} class="active" {%- endif %}><a href="{{ url_for('.ticket_transfers') }}">
+                    Ticket Transfers
+                </a></li>
                 <li {% if nav_active == 'make_admin' -%} class="active" {%- endif %}><a href="{{ url_for('.make_admin') }}">
-                    Make someone an admin</a></li>
+                    Make someone an admin
+                </a></li>
                 {% endif %}
                 {% if current_user.arrivals %}
                 <li {% if nav_active == 'make_arrivals' -%} class="active" {%- endif %}><a href="{{ url_for('.make_arrivals') }}">

--- a/templates/admin/new-ticket-type.html
+++ b/templates/admin/new-ticket-type.html
@@ -33,6 +33,9 @@
 <div class="form-group">{{ form.has_badge.label(class_="col-sm-4 control-label") }}
   <div class="col-sm-8">{{ form.has_badge(class_="form-control") }}</div>
 </div>
+<div class="form-group">{{ form.is_transferable.label(class_="col-sm-4 control-label") }}
+  <div class="col-sm-8">{{ form.is_transferable(class_="form-control") }}</div>
+</div>
 <div class="form-group">{{ form.discount_token.label(class_="col-sm-4 control-label") }}
   <div class="col-sm-8">{{ form.discount_token(class_="form-control") }}</div>
 </div>

--- a/templates/admin/ticket-transfers.html
+++ b/templates/admin/ticket-transfers.html
@@ -1,0 +1,22 @@
+{% extends "admin/base.html" %}
+{% set nav_active = 'ticket_transfers' %}
+{% block body %}
+
+<h2>Ticket Transfers</h2>
+<table class="table table-condensed table-striped">
+  <tr>
+    <th>Ticket Type</th>
+    <th>From</th>
+    <th>To</th>
+  </tr>
+  {% for ticket, from_user, to_user in transfers %}
+  <tr>
+    <td>{{ ticket.type.name }}</td>
+    <td>{{ from_user.name }}</td>
+    <td>{{ to_user.name }}</td>
+  </tr>
+
+  {% endfor %}
+</table>
+
+{% endblock %}

--- a/templates/emails/ticket-transfer-new-owner-and-user.txt
+++ b/templates/emails/ticket-transfer-new-owner-and-user.txt
@@ -1,0 +1,20 @@
+Hi {{ to_user.name }},
+
+You're friend ({{ from_user.name }}) has transferred a ticket to you for
+Electromagnetic Field 2016.
+
+To allow this to happen we've created an account for you. To manage your ticket
+you'll need to set a password via the password reset page:
+
+{{ external_url('users.forgot_password') }}
+
+You can view (and print) your tickets here:
+
+{{ external_url('tickets.main') }}
+
+See you soon at Electromagnetic Field 2016!
+
+Love,
+
+All the EMF team
+

--- a/templates/emails/ticket-transfer-new-owner.txt
+++ b/templates/emails/ticket-transfer-new-owner.txt
@@ -1,0 +1,15 @@
+Hi {{ to_user.name }},
+
+You're friend ({{ from_user.name }}) has transferred a ticket to you for
+Electromagnetic Field 2016.
+
+You can view (and print) your tickets here:
+
+{{ external_url('tickets.main') }}
+
+See you soon at Electromagnetic Field 2016!
+
+Love,
+
+All the EMF team
+

--- a/templates/emails/ticket-transfer-original-owner.txt
+++ b/templates/emails/ticket-transfer-original-owner.txt
@@ -1,0 +1,16 @@
+Hi {{ from_user.name }},
+
+We just want to confirm with you that you intended to transfer one of your
+tickets to:
+
+email: {{ to_user.email }}
+name: {{ to_user.name }}
+
+If this is correct that's excellent! You don't need to do anything. If this
+isn't correct or was done in error, don't worry! Just send us a message at:
+
+tickets@emfcamp.org
+
+Love,
+
+All the EMF team

--- a/templates/emails/tickets-signup-email.txt
+++ b/templates/emails/tickets-signup-email.txt
@@ -12,7 +12,7 @@ You can keep track of your ticket purchases here:
 
 {{ external_url('tickets.main') }}
 
-See you soon at Electromagnetic Field 2014!
+See you soon at Electromagnetic Field 2016!
 
 Love,
 

--- a/templates/ticket-transfer.html
+++ b/templates/ticket-transfer.html
@@ -7,7 +7,7 @@
   You can transfer a ticket to another person if you have bought it for them. This will automatically create them an account on this website from which they can manage their ticket(s). It will also allow them to use other features of this site such as scheduling, receive our (infrequent) updates and sign-up for volunteering shifts.
 </p>
 <p>
-  By filling in this form you will transfer ownership of the ticket. You will no longer see it in your list of tickets (although the cost of it will still be listed as part of your purchase).
+  By filling in this form you will transfer ownership of the ticket. You will no longer see it in your list of tickets. You will instead see it in the <a href="{{ url_for('.transferred') }}">transferred tickets</a> page.
 </p>
 
 <form method="post" class="form-horizontal ticket-info">

--- a/templates/ticket-transfer.html
+++ b/templates/ticket-transfer.html
@@ -1,0 +1,27 @@
+{% from "_formhelpers.html" import render_field  %}
+{% extends "base.html" %}
+{% block body %}
+
+<h3>Transfer Ticket</h3>
+<p>
+  You can transfer a ticket to another person if you have bought it for them. This will automatically create them an account on this website from which they can manage their ticket(s). It will also allow them to use other features of this site such as scheduling, receive our (infrequent) updates and sign-up for volunteering shifts.
+</p>
+<p>
+  By filling in this form you will transfer ownership of the ticket. You will no longer see it in your list of tickets (although the cost of it will still be listed as part of your purchase).
+</p>
+
+<form method="post" class="form-horizontal ticket-info">
+{{ form.hidden_tag() }}
+<fieldset>
+  <div class="well">
+    <div class="row">
+      <div class="col-md-12">{{ render_field(form.email, autofocus=True) }}</div>
+      <div class="col-md-12">{{ render_field(form.name) }}</div>
+    </div>
+  </div>
+  <a class="btn btn-default" href="{{ url_for('tickets.main') }}">Back</a>
+  {{ form.transfer(class_="btn btn-success") }}
+</fieldset>
+</form>
+
+{% endblock %}

--- a/templates/tickets-transferred.html
+++ b/templates/tickets-transferred.html
@@ -10,6 +10,7 @@
   This will show you any tickets that you have transferred to others.
 </p>
 
+<p>
 <table>
 <tr>
   <th>Type</th>
@@ -26,5 +27,10 @@
 
 {% endfor %}
 </table>
+</p>
+
+<p>
+<a class="btn btn-default" href="{{ url_for('tickets.main') }}">Back</a>
+</p>
 
 {% endblock %}

--- a/templates/tickets-transferred.html
+++ b/templates/tickets-transferred.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h3>
+  Your transferred tickets
+</h3>
+
+<p>
+  This will show you any tickets that you have transferred to others.
+</p>
+
+<table>
+<tr>
+  <th>Type</th>
+  <th>Receiver's name</th>
+  <th>Receiver's email</th>
+</tr>
+
+{% for ticket, to_user in transferred %}
+<tr class="{{- loop.cycle('odd', 'even') }}">
+<td>{{ ticket.type.name }}</td>
+<td>{{ to_user.name }}</td>
+<td>{{ to_user.email }}</td>
+</tr>
+
+{% endfor %}
+</table>
+
+{% endblock %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -53,7 +53,7 @@
     {%- endif %}
 </td>
 <td>
-  {% if t.paid %}
+  {% if t.paid and t.type.is_transferable %}
     <a class="btn btn-default" href="{{ url_for('.transfer', ticket_id=t.id) }}">Transfer</a>
   {% endif %}
 </td>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -52,6 +52,11 @@
     Pending
     {%- endif %}
 </td>
+<td>
+  {% if t.paid %}
+    <a class="btn btn-default" href="{{ url_for('.transfer', ticket_id=t.id) }}">Transfer</a>
+  {% endif %}
+</td>
 </tr>
 {% endif -%}
 {% endfor -%}

--- a/utils.py
+++ b/utils.py
@@ -194,7 +194,8 @@ def add_ticket_types(ticket_list):
 
     for row in ticket_list:
         tt = TicketType(*row[:5], personal_limit=row[5], description=row[9],
-            has_badge=row[8], discount_token=row[10], expires=row[11])
+            has_badge=row[8], discount_token=row[10], expires=row[11],
+            is_transferable=row[12])
         tt.prices = [TicketPrice('GBP', row[6]), TicketPrice('EUR', row[7])]
         types.append(tt)
 
@@ -254,7 +255,7 @@ class CreateTickets(Command):
                 "If you bring a caravan, you won't need a separate parking ticket for the towing car."),
         ]
         # none of these tickets have tokens or expiry dates
-        type_data = [ t + (None, None) for t in type_data]
+        type_data = [ t + (None, None, None) for t in type_data]
 
         add_ticket_types(type_data)
 
@@ -267,7 +268,7 @@ class CreateTicketTokens(Command):
             (10, 1, 'full', 'Discount Full Camp Ticket', 10, 1, 70.00, 90.00, True, None, 'lucky')
         ]
 
-        discount_ticket_types = [ tt + (datetime.utcnow() + timedelta(days=7), )
+        discount_ticket_types = [ tt + (datetime.utcnow() + timedelta(days=7), False)
             for tt in discount_ticket_types]
 
         add_ticket_types(discount_ticket_types)


### PR DESCRIPTION
Closes (most) of #243.

Implements:

* Simple form that transfers tickets (name + email)
  * If the email corresponds to a user in the db the ticket is assigned to that user
  * Otherwise a new user is created (and emailed), the ticket assigned to them
* When a ticket is transferred the qrcode and receipt fields are set to None to stop the ticket being used multiple times
* A new endpoint (/tickets/transferred) which lists all the tickets that that user has transferred. This lists who the user transferred the ticket to but no subsequent transfers of the ticket.
* An admin view that shows all transfers that have occurred
* Ticket types can be marked as transferable or not (the default is transferable). The ticket type admin views have been updated to account for this.

Does not implement:
* There is currently no way for an admin to create and directly transfer a ticket to a user, either completely 'silently' or otherwise
* There is no detailed admin view or control of the list (i.e. you can't track a single ticket, only the transfers that have occurred)

These will be added as new issues