### PR TITLE
Content update for new location/dates etc.

### DIFF
--- a/apps/payments/stripe.py
+++ b/apps/payments/stripe.py
@@ -63,7 +63,7 @@ def charge_stripe(payment):
             currency=payment.currency.lower(),
             card=payment.token,
             description=payment.description,
-            statement_description='Tickets 2014',  # max 15 chars, appended to company name
+            statement_description='Tickets 2016',  # max 15 chars, appended to company name
         )
     except stripe.CardError as e:
         logger.warn('Card payment failed with exception "%s"', e)

--- a/models/payment.py
+++ b/models/payment.py
@@ -251,7 +251,7 @@ class StripePayment(Payment):
 
     @property
     def description(self):
-        return 'EMF 2014 tickets'
+        return 'EMF 2016 tickets'
 
 
 class PaymentChange(db.Model):

--- a/static/hackerspace_email.txt
+++ b/static/hackerspace_email.txt
@@ -1,4 +1,4 @@
-Subject: Hackerspace ticket discount for Electromagnetic Field 2014!
+Subject: Hackerspace ticket discount for Electromagnetic Field 2016!
 
 Hello!
 
@@ -13,10 +13,11 @@ Electromagnetic Field is a non-profit three day camping festival for
 people with an inquisitive mind or an interest in making things:
 hackers, geeks, scientists, engineers, artists, and craftspeople.
 
-It's taking place in Milton Keynes between the 31st August and the 2nd
-September and is inspired by European camps such as the Chaos
-Communication Camp and Hacking At Random, which means that we have an
-absurd internet connection to a field, and power to every tent.
+It's taking place in Guildford between the 5th August and the 7th
+August and is inspired by European camps such as the Chaos
+Communication Camp (CCC camp) and Observe, Hack, Make (OHM) which
+means that we have an absurd internet connection to a field, and
+power to every tent.
 
 There will be talks and workshops on everything from genetic
 modification to lockpicking, blacksmithing to high-energy physics,

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -62,7 +62,7 @@
     </div>
     <footer>
         <p>
-        Electromagnetic Field Ltd. 2014.
+        Electromagnetic Field Ltd. 2016.
         <a href="{{url_for('base.company')}}">Company details</a>.
         Kindly hosted by <a href="http://bitfolk.com/">Bitfolk</a>.
         {% if current_user.is_authenticated() %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,7 +66,7 @@
                     <div style="clear: both"></div>
                 </div>
                 <div id="credits">
-                    <p>&copy; 2014 <a href="{{url_for('base.company')}}">Electromagnetic Field</a>.
+                    <p>&copy; 2016 <a href="{{url_for('base.company')}}">Electromagnetic Field</a>.
                         Kindly hosted by <a href="http://bitfolk.com/">Bitfolk</a>.</p>
                 </div>
             </footer>

--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -12,8 +12,8 @@
   scientists, and engineers. It's happening near
   <a href="http://wiki.emfcamp.org/wiki/Getting_Here">Bletchley, Buckinghamshire</a> on
   August 29<sup>th</sup>&mdash;31<sup>st</sup>, and tickets are <a href="/">on sale now</a> for
-  £{{ full_price }}. Our last festival in 2012 had 600 attendees; this year we'll have over
-  1,200.</p>
+  £{{ full_price }}. Our last festival in 2014 had 1,300 attendees; this year we'll have over
+  1,500.</p>
 
   <p>We're looking for people to talk, share, and demonstrate the things they
   love. We're especially keen to hear from people with <a

--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -10,8 +10,8 @@
   <p class="emphasis">Electromagnetic Field is a UK camping festival for those with an inquisitive
   mind or an interest in making things: hackers, artists, geeks, crafters,
   scientists, and engineers. It's happening near
-  <a href="http://wiki.emfcamp.org/wiki/Getting_Here">Bletchley, Buckinghamshire</a> on
-  August 29<sup>th</sup>&mdash;31<sup>st</sup>, and tickets are <a href="/">on sale now</a> for
+  <a href="http://wiki.emfcamp.org/wiki/Getting_Here">Guildford, Surrey</a> on
+  August 5th<sup>th</sup>&mdash;7<sup>th</sup>, and tickets are <a href="/">on sale now</a> for
   £{{ full_price }}. Our last festival in 2014 had 1,300 attendees; this year we'll have over
   1,500.</p>
 

--- a/templates/emails/tickets-paid-email-banktransfer.txt
+++ b/templates/emails/tickets-paid-email-banktransfer.txt
@@ -3,7 +3,7 @@ Hi {{ user.name }},
 This is to confirm that we've received {{ payment.amount | price(payment.currency) }} for transaction {{ payment.bankref | bankref }} from
 you as payment for {% if payment.tickets.all() | count > 1 %}{{ payment.tickets.all() |count }} tickets{% else %}a ticket{% endif %} for Electromagnetic Field.
 
-See you soon at Electromagnetic Field 2014!
+See you soon at Electromagnetic Field 2016!
 
 Love,
 

--- a/templates/emails/tickets-paid-email-gocardless.txt
+++ b/templates/emails/tickets-paid-email-gocardless.txt
@@ -3,7 +3,7 @@ Hi {{ user.name }},
 We've just received confirmation from GoCardless that your payment for
 {{ payment.amount | price(payment.currency) }} has cleared.
 
-See you soon at Electromagnetic Field 2014!
+See you soon at Electromagnetic Field 2016!
 
 Love,
 

--- a/templates/emails/tickets-paid-email-stripe.txt
+++ b/templates/emails/tickets-paid-email-stripe.txt
@@ -7,7 +7,7 @@ We've just received confirmation from Stripe that your payment for
 {% include 'receipt-blurb.txt' %}
 {% endif %}
 
-See you soon at Electromagnetic Field 2014!
+See you soon at Electromagnetic Field 2016!
 
 Love,
 

--- a/templates/emails/tickets-purchased-email-banktransfer.txt
+++ b/templates/emails/tickets-purchased-email-banktransfer.txt
@@ -1,15 +1,15 @@
 Hi {{ user.name }},
 
 {% if payment.tickets.all() |count == 1 -%}
-This is to confirm that you've reserved a ticket for {{ payment.amount | price(payment.currency) }} for 
-Electromagnetic Field 2014!
+This is to confirm that you've reserved a ticket for {{ payment.amount | price(payment.currency) }} for
+Electromagnetic Field 2016!
 
 This ticket will be reserved for you for 10 days while you send the money
 by bank transfer. We'll let you know by email when your payment has been
 received.
 {%- else -%}
 This is to confirm that you've reserved {{ payment.tickets.all() |count }} tickets for {{ payment.amount | price(payment.currency) }}
-for Electromagnetic Field 2014!
+for Electromagnetic Field 2016!
 
 These tickets will be reserved for you for 10 days while you send the money
 by bank transfer. We'll let you know by email when your payment has been

--- a/templates/emails/tickets-purchased-email-gocardless.txt
+++ b/templates/emails/tickets-purchased-email-gocardless.txt
@@ -2,7 +2,7 @@ Hi {{ user.name }},
 
 This is to confirm that you've bought
 {%- if payment.tickets.all() | count == 1 %} a ticket {%- else %} {{ payment.tickets.all() |count }} tickets
-{%- endif %} for Electromagnetic Field 2014.
+{%- endif %} for Electromagnetic Field 2016.
 
 Your tickets are:
 

--- a/templates/emails/tickets-purchased-email-stripe.txt
+++ b/templates/emails/tickets-purchased-email-stripe.txt
@@ -2,7 +2,7 @@ Hi, {{ user.name }},
 
 This is to confirm that you've bought
 {%- if payment.tickets.all() | count == 1 %} a ticket {%- else %} {{ payment.tickets.all() | count }} tickets
-{%- endif %} for Electromagnetic Field 2014.
+{%- endif %} for Electromagnetic Field 2016.
 
 {% if payment.state == 'paid' and config.get('RECEIPTS') %}
 {% include 'receipt-blurb.txt' %}

--- a/templates/emails/tickets-reminder.txt
+++ b/templates/emails/tickets-reminder.txt
@@ -1,7 +1,7 @@
 Hi {{ payment.user.name }},
 
 Just to warn you that we have not yet received payment for the tickets you
-reserved for Electromagnetic Field 2014.
+reserved for Electromagnetic Field 2016.
 
 The tickets will expire in a few days if not paid for.
 

--- a/templates/emails/tickets-signup-email.txt
+++ b/templates/emails/tickets-signup-email.txt
@@ -12,7 +12,7 @@ You can keep track of your ticket purchases here:
 
 {{ external_url('tickets.main') }}
 
-See you soon at Electromagnetic Field 2014!
+See you soon at Electromagnetic Field 2016!
 
 Love,
 

--- a/templates/emails/welcome-email.txt
+++ b/templates/emails/welcome-email.txt
@@ -15,7 +15,7 @@ If you forget your password you can reset it here:
 
 {{ external_url('users.forgot_password') }}
 
-See you soon at Electromagnetic Field 2014!
+See you soon at Electromagnetic Field 2016!
 
 Love,
 

--- a/templates/payment-choose.html
+++ b/templates/payment-choose.html
@@ -5,7 +5,7 @@
 
 {% if config.get('STRIPE') %}
 <p>Taking card payments for a small event like us is really expensive, so our
-   preferred payment methods are bank-to-bank, but these are not available after 20th August.
+   preferred payment methods are bank-to-bank, but these are not available after 28th July.
    We charge <strong>5%</strong> extra for card payments.</p>
 {% else %}
 <p>Taking card payments for a small event like us is really expensive, so the only

--- a/templates/receipt-blurb.txt
+++ b/templates/receipt-blurb.txt
@@ -14,7 +14,7 @@ need to buy one before you arrive:
   https://www.emfcamp.org/tickets/choose
 
 If you're travelling by public transport, we will be running shuttle
-buses between Guildford Station and the festival site.
+buses between a local train station and the festival site.
 
 For more details about how to get to EMF, including shuttle bus times
 and driving directions, please see the Travel section of our wiki:

--- a/templates/receipt-blurb.txt
+++ b/templates/receipt-blurb.txt
@@ -14,7 +14,7 @@ need to buy one before you arrive:
   https://www.emfcamp.org/tickets/choose
 
 If you're travelling by public transport, we will be running shuttle
-buses between Bletchley Railway Station and the festival site.
+buses between Guildford Station and the festival site.
 
 For more details about how to get to EMF, including shuttle bus times
 and driving directions, please see the Travel section of our wiki:
@@ -32,6 +32,4 @@ updates on EMF:
 
 And lastly, EMF is entirely volunteer-run. Please consider
 contributing a few hours of your time at the festival to help the
-event run smoothly. You can sign up to volunteer here:
-
-  https://timecounts.org/o/emcamp/forms/66
+event run smoothly.

--- a/templates/receipt.html
+++ b/templates/receipt.html
@@ -32,7 +32,7 @@
 
   <h2>
     <img src="{{ url_for('static', filename='images/logo_only_black.png') }}" class="logo" width="90"/>
-    Electromagnetic Field 2014
+    Electromagnetic Field 2016
   </h2>
   <div>
     <h3>{{ user.name }} &ndash; {{ user.email }}</h2>

--- a/templates/receipt.txt
+++ b/templates/receipt.txt
@@ -2,8 +2,8 @@ Hello {{ user.name }}!
 
 With Electromagnetic Field fast approaching, here are your tickets
 and some more details about the event. The gates will open at 9am on
-Friday August 29th, and (unless you're helping out with teardown) you
-should aim to leave by midday on Monday September 1st.
+Friday August 5th, and (unless you're helping out with teardown) you
+should aim to leave by midday on Monday August 8th.
 
 {% include 'receipt-blurb.txt' %}
 

--- a/templates/sponsors/sponsors.html
+++ b/templates/sponsors/sponsors.html
@@ -50,6 +50,6 @@
 
 <p>Special thanks to: Aruba Networks, Bytemark, the Chaos Computer Club,
    Flexoptix, Individual Pubs, IRCCloud, LONAP, Milton Brewery, OHM 2013
-   and the entire EMF 2014 organising team.</p>
+   and the entire EMF 2016 organising team.</p>
 </div>
 {% endblock %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -10,7 +10,7 @@
 <li>You will not receive a physical ticket: you will be sent an e-ticket which will be checked on arrival.</li>
 <li>Proof of age may be requested at the point of entry and at the bars.</li>
 <li>The event schedule may be changed or amended at any time.</li>
-<li>EMF will be open from 10:00 on Friday 29th August, until 14:00 on Monday 1st September.</li>
+<li>EMF will be open from 10:00 on Friday 5th August, until 14:00 on Monday 8st August.</li>
 <li>The festival may refuse admission or eject a ticket holder for unreasonable or dangerous behaviour, or violation of the <a href="{{url_for('base.code_of_conduct')}}">Code of Conduct</a>.</li>
 <li>Camping in the festival grounds is included in the ticket price.</li>
 <li>All vehicles are parked at the owner's risk.</li>

--- a/templates/ticket-blurb.html
+++ b/templates/ticket-blurb.html
@@ -1,15 +1,15 @@
 
-<h4>A ticket to Electromagnetic Field 2014 will get you:</h4>
+<h4>A ticket to Electromagnetic Field 2016 will get you:</h4>
 <ul>
     <li>A secure place to camp for three days</li>
-    <li>Power to your tent</li>
+    <li>Power to your tent (you'll need an extension lead)</li>
     <li>Very fast internet access (both wired and wireless)</li>
     <li>Access to running water and hot showers</li>
     <li>A <a href="{{url_for('base.talks')}}">whole pile of awesome talks and workshops</a></li>
     <li>Access to a well-stocked bar, and multiple food vendors</li>
-    <li>One <a href="http://blog.emfcamp.org/post/94157161753/announcing-tilda-mke-the-incredible-emf-2014-camp">fully programmable camp badge</a>, equipped with wireless communications and screen</li>
-    <li>A campsite equipped with <a href="http://blog.emfcamp.org/post/94720188773/announcing-the-shiny-things">weird and wonderful things</a> to play with</li>
-    <li><a href="http://blog.emfcamp.org/post/94368735073/emf-2014-childcare-welcoming-the-nanotechs">Free childcare</a></li>
+    {# <li>One <a href="http://blog.emfcamp.org/post/94157161753/announcing-tilda-mke-the-incredible-emf-2014-camp">fully programmable camp badge</a>, equipped with wireless communications and screen</li> #}
+    {# <li>A campsite equipped with <a href="http://blog.emfcamp.org/post/94720188773/announcing-the-shiny-things">weird and wonderful things</a> to play with</li> #}
+    {# <li><a href="http://blog.emfcamp.org/post/94368735073/emf-2014-childcare-welcoming-the-nanotechs">Free childcare</a></li> #}
     <li>A weekend unlike any other in the UK</li>
 </ul>
 

--- a/templates/tickets-cutoff.html
+++ b/templates/tickets-cutoff.html
@@ -2,6 +2,6 @@
 
 {% block body %}
 <div class="col-md-6">
-  <p>Tickets for EMF 2014 are not currently on sale online. Please check our <a href="https://twitter.com/emfcamp">Twitter feed</a> for the latest sales information. Unfortunately we cannot reserve any tickets.</p>
+  <p>Tickets for EMF 2016 are not currently on sale online. Please check our <a href="https://twitter.com/emfcamp">Twitter feed</a> for the latest sales information. Unfortunately we cannot reserve any tickets.</p>
 </div>
 {% endblock %}

--- a/utils.py
+++ b/utils.py
@@ -56,7 +56,7 @@ class LoadOfx(Command):
 
         for txn in ofx.account.statement.transactions:
             # date is actually dtposted and is a datetime
-            if txn.date < datetime(2014, 1, 1):
+            if txn.date < datetime(2015, 1, 1):
                 app.logger.debug('Ignoring historic transaction from %s', txn.date)
                 continue
             if txn.amount <= 0:

--- a/utils.py
+++ b/utils.py
@@ -238,11 +238,11 @@ class CreateTickets(Command):
                 "All money will go towards making EMF more awesome."),
 
             (5, 10, 'kid', 'Under-16 Camp Ticket', 500, 10, 40.00, 50.00, True,
-                "For visitors born after August 28th, 1998. "
+                "For visitors born after August 5th, 2000. "
                 "All under-16s  must be accompanied by an adult."),
 
             (6, 15, 'kid', 'Under-5 Camp Ticket', 200, 4, 0, 0, False,
-                "For children born after August 28th, 2009. "
+                "For children born after August 5th, 2011. "
                 "All children must be accompanied by an adult."),
 
             (7, 30, 'car', 'Parking Ticket', 400, 4, 15.00, 20.00, False,


### PR DESCRIPTION
Major changes:
* Updated 'historic transaction' to ignore things from before 2015/1/1
* Stripe cut-off of 28th July
* U16 is now < 2000/8/5
* U5 is now < 2011/8/5
* 2014 -> 2016 (& weekend dates)
* Bletchley -> Guildford
* Removed references to unconfirmed things (childcare, badges etc.)