### PR TITLE
Initial work for 2016 CFP

### DIFF
--- a/apps/cfp.py
+++ b/apps/cfp.py
@@ -83,7 +83,12 @@ def main(cfp_type='talk'):
     (form,) = [f for f in forms if f.type == cfp_type]
 
     if request.method == 'POST':
-        app.logger.info('Checking %s proposal for %s (%s)', cfp_type, form.name.data, form.email.data)
+        # If the user is already logged in set their name & email for the form
+        if current_user.is_authenticated():
+            form.name.data = current_user.name
+            form.email.data = current_user.email
+        app.logger.info('Checking %s proposal for %s (%s)', cfp_type,
+                        form.name.data, form.email.data)
 
     if form.validate_on_submit():
         if cfp_type == 'talk':
@@ -102,6 +107,7 @@ def main(cfp_type='talk'):
 
         cfp.name = form.name.data
         cfp.email = form.email.data
+
         cfp.title = form.title.data
         cfp.description = form.description.data
         cfp.need_finance = form.need_finance.data

--- a/apps/cfp.py
+++ b/apps/cfp.py
@@ -2,7 +2,7 @@ from flask import (
     render_template, redirect, request, flash,
     url_for, abort, current_app as app, Blueprint
 )
-from flask.ext.login import current_user
+from flask.ext.login import current_user, login_required
 from flask_mail import Message
 from wtforms.validators import Required, Email, ValidationError
 from wtforms import (
@@ -157,3 +157,10 @@ def main(cfp_type='talk'):
 @feature_flag('CFP')
 def complete():
     return render_template('cfp_complete.html')
+
+
+@cfp.route('/cfp/proposals')
+@feature_flag('CFP')
+@login_required
+def proposals():
+    return render_template('cfp_proposals.html')

--- a/apps/tickets.py
+++ b/apps/tickets.py
@@ -4,7 +4,7 @@ from flask import (
     url_for, session, send_file, abort, current_app as app
 )
 from flask.ext.login import login_required, current_user
-from wtforms.validators import Required, Optional, ValidationError
+from wtforms.validators import Required, Optional, Email, ValidationError
 from wtforms import (
     SubmitField, StringField,
     FieldList, FormField, HiddenField,
@@ -206,7 +206,7 @@ def choose():
 
 
 class TicketPaymentForm(Form):
-    email = EmailField('Email', [Required()])
+    email = EmailField('Email', [Email(), Required()])
     name = StringField('Name', [Required()])
     basket_total = HiddenField('basket total')
 

--- a/apps/users.py
+++ b/apps/users.py
@@ -181,7 +181,8 @@ def set_currency():
     return redirect(url_for('tickets.choose'))
 
 
-class DiversityForm(Form):
+class AccountForm(Form):
+    name = StringField('Name', [Required()])
     age = StringField('Age')
     gender = StringField('Gender')
     ethnicity = StringField('Ethnicity')
@@ -191,19 +192,23 @@ class DiversityForm(Form):
 @users.route("/account", methods=['GET', 'POST'])
 @login_required
 def account():
-    form = DiversityForm()
+    form = AccountForm()
 
-    if request.method == 'POST' and any(form.data.values()):
+    if form.validate_on_submit():
         if not current_user.diversity:
             current_user.diversity = UserDiversity()
             current_user.diversity.user_id = current_user.id
             db.session.add(current_user.diversity)
 
+        current_user.name = form.name.data
         current_user.diversity.age = form.age.data
         current_user.diversity.gender = form.gender.data
         current_user.diversity.ethnicity = form.ethnicity.data
 
         db.session.commit()
+
+    # This is a required field so should always be set
+    form.name.data = current_user.name
 
     if current_user.diversity:
         form.age.data = current_user.diversity.age

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -11,7 +11,6 @@ class Proposal(db.Model):
     need_finance = db.Column(db.Boolean)
     one_day = db.Column(db.Boolean)
     type = db.Column(db.String, nullable=False)
-    diversity = db.relationship('ProposalDiversity', uselist=False, backref='cfp')
     __mapper_args__ = {'polymorphic_on': type}
 
 class TalkProposal(Proposal):
@@ -25,12 +24,4 @@ class WorkshopProposal(Proposal):
 class InstallationProposal(Proposal):
     __mapper_args__ = {'polymorphic_identity': 'installation'}
     size = db.Column(db.String)
-
-class ProposalDiversity(db.Model):
-    __tablename__ = 'diversity'
-    cfp_id = db.Column(db.Integer, db.ForeignKey('proposal.id'), nullable=False, primary_key=True)
-    age = db.Column(db.String)
-    gender = db.Column(db.String)
-    ethnicity = db.Column(db.String)
-
 

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -1,10 +1,13 @@
 from main import db
+from datetime import datetime
 
 
 class Proposal(db.Model):
     __tablename__ = 'proposal'
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    created = db.Column(db.DateTime, default=datetime.utcnow)
+    state = db.Column(db.String, nullable=False, default='new')
     title = db.Column(db.String, nullable=False)
     description = db.Column(db.String)
     length = db.Column(db.String)

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -4,8 +4,7 @@ from main import db
 class Proposal(db.Model):
     __tablename__ = 'proposal'
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String, nullable=False)
-    email = db.Column(db.String, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     title = db.Column(db.String, nullable=False)
     description = db.Column(db.String)
     length = db.Column(db.String)

--- a/models/user.py
+++ b/models/user.py
@@ -43,6 +43,7 @@ class User(db.Model, UserMixin):
     admin = db.Column(db.Boolean, default=False, nullable=False)
     arrivals = db.Column(db.Boolean, default=False, nullable=False)
     phone = db.Column(db.String, nullable=True)
+    proposals = db.relationship('Proposal', lazy='dynamic', backref='user', cascade='all, delete, delete-orphan')
     tickets = db.relationship('Ticket', lazy='dynamic', backref='user', cascade='all, delete, delete-orphan')
     payments = db.relationship('Payment', lazy='dynamic', backref='user', cascade='all')
 

--- a/models/user.py
+++ b/models/user.py
@@ -43,6 +43,7 @@ class User(db.Model, UserMixin):
     admin = db.Column(db.Boolean, default=False, nullable=False)
     arrivals = db.Column(db.Boolean, default=False, nullable=False)
     phone = db.Column(db.String, nullable=True)
+    diversity = db.relationship('UserDiversity', uselist=False, backref='user', cascade='all, delete, delete-orphan')
     proposals = db.relationship('Proposal', lazy='dynamic', backref='user', cascade='all, delete, delete-orphan')
     tickets = db.relationship('Ticket', lazy='dynamic', backref='user', cascade='all, delete, delete-orphan')
     payments = db.relationship('Payment', lazy='dynamic', backref='user', cascade='all')
@@ -87,6 +88,14 @@ class User(db.Model, UserMixin):
             return None
 
         return User.query.filter_by(id=uid).one()
+
+
+class UserDiversity(db.Model):
+    __tablename__ = 'diversity'
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, primary_key=True)
+    age = db.Column(db.String)
+    gender = db.Column(db.String)
+    ethnicity = db.Column(db.String)
 
 
 class PasswordReset(db.Model):

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,0 +1,43 @@
+{% from "_formhelpers.html" import render_field %}
+{% extends "base.html" %}
+{% block title %}My Account{% endblock %}
+{% block body %}
+<h2>Account</h2>
+
+<nav>
+  <ul class="nav nav-pills">
+    <li><a href="{{ url_for('tickets.main') }}">Your tickets</a></li>
+    <li><a href="{{ url_for('tickets.choose') }}">Buy tickets</a></li>
+    {# <li><a href="{{ url_for('cfp.proposals') }}">Your CFP proposals</a></li> #}
+    <li><a href="{{ url_for('cfp.proposals') }}">Submit a CFP proposal</a></li>
+  </ul>
+</nav>
+<p>&nbsp;</p>
+<h3>Your details</h3>
+<div class="col-md-12">
+  <p><strong>Email</strong> {{ current_user.email }}</p>
+  <p><strong>Name</strong> {{ current_user.name }}</p>
+</div>
+
+<form method="post" class="form-horizontal col-md-12">
+  {{ form.hidden_tag() }}
+  <fieldset>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        If you're comfortable telling us a little bit about yourself, we'd appreciate it.
+        This information won't be available to the selection panel &ndash; we'll only use it to help find out
+        how well we're doing with outreach.
+      </div>
+      <div class="row">
+        <div id="diversity" class="col-md-11">
+          <p></p>
+          {{ render_field(form.age, True) }}
+          {{ render_field(form.gender, True) }}
+          {{ render_field(form.ethnicity, True) }}
+          {{ form.forward(class_="btn btn-default pull-right") }}
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</form>
+{% endblock %}

--- a/templates/account.html
+++ b/templates/account.html
@@ -8,7 +8,7 @@
   <ul class="nav nav-pills">
     <li><a href="{{ url_for('tickets.main') }}">Your tickets</a></li>
     <li><a href="{{ url_for('tickets.choose') }}">Buy tickets</a></li>
-    {# <li><a href="{{ url_for('cfp.proposals') }}">Your CFP proposals</a></li> #}
+    <li><a href="{{ url_for('cfp.proposals') }}">Your CFP proposals</a></li>
     <li><a href="{{ url_for('cfp.proposals') }}">Submit a CFP proposal</a></li>
   </ul>
 </nav>
@@ -34,7 +34,7 @@
           {{ render_field(form.age, True) }}
           {{ render_field(form.gender, True) }}
           {{ render_field(form.ethnicity, True) }}
-          {{ form.forward(class_="btn btn-default pull-right") }}
+          {{ form.forward(class_="btn btn-default pull-right", style="margin-bottom: 15px;") }}
         </div>
       </div>
     </div>

--- a/templates/account.html
+++ b/templates/account.html
@@ -9,7 +9,7 @@
     <li><a href="{{ url_for('tickets.main') }}">Your tickets</a></li>
     <li><a href="{{ url_for('tickets.choose') }}">Buy tickets</a></li>
     <li><a href="{{ url_for('cfp.proposals') }}">Your CFP proposals</a></li>
-    <li><a href="{{ url_for('cfp.proposals') }}">Submit a CFP proposal</a></li>
+    <li><a href="{{ url_for('cfp.main') }}">Submit a CFP proposal</a></li>
   </ul>
 </nav>
 <p>&nbsp;</p>

--- a/templates/account.html
+++ b/templates/account.html
@@ -14,23 +14,26 @@
 </nav>
 <p>&nbsp;</p>
 <h3>Your details</h3>
-<div class="col-md-12">
-  <p><strong>Email</strong> {{ current_user.email }}</p>
-  <p><strong>Name</strong> {{ current_user.name }}</p>
-</div>
 
 <form method="post" class="form-horizontal col-md-12">
   {{ form.hidden_tag() }}
   <fieldset>
     <div class="panel panel-default">
       <div class="panel-heading">
-        If you're comfortable telling us a little bit about yourself, we'd appreciate it.
-        This information won't be available to the selection panel &ndash; we'll only use it to help find out
-        how well we're doing with outreach.
+        <p>If you've made a submission to the CFP then your name (as it's set here) will be used
+                in the schedule.</p>
+        <p>If you're comfortable telling us a little bit about yourself, we'd appreciate it.
+                This information will only be used it to find out how well we're doing with outreach.</p>
       </div>
       <div class="row">
         <div id="diversity" class="col-md-11">
-          <p></p>
+          <div class="form-group">
+            <label for="fake-email-field" class="horizontal col-sm-2 control-label">Email</label>
+            <div class="col-sm-10 ">
+              <p class="form-control-static">{{ current_user.email }}</p>
+            </div>
+          </div>
+          {{ render_field(form.name, True) }}
           {{ render_field(form.age, True) }}
           {{ render_field(form.gender, True) }}
           {{ render_field(form.ethnicity, True) }}

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,7 @@
 
                       {% if config.get('TICKET_SALES') %}
                       {% if current_user.is_authenticated() %}
-                        <li><a href="{{ url_for('tickets.main') }}">My tickets</a></li>
+                        <li><a href="{{ url_for('users.account') }}">My account</a></li>
                         <li><a href="{{ url_for('users.logout') }}">Log out</a></li>
                       {% else %}
                         <li><a href="{{ url_for('users.login') }}">Log in</a></li>

--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -7,56 +7,63 @@
   {% endif %}
 
   <h2>Call for Participation</h2>
-  <p class="emphasis">Electromagnetic Field is a UK camping festival for those with an inquisitive
-  mind or an interest in making things: hackers, artists, geeks, crafters,
-  scientists, and engineers. It's happening near
-  <a href="http://wiki.emfcamp.org/wiki/Getting_Here">Guildford, Surrey</a> on
-  August 5th<sup>th</sup>&mdash;7<sup>th</sup>, and tickets are <a href="/">on sale now</a> for
-  £{{ full_price }}. Our last festival in 2014 had 1,300 attendees; this year we're aiming for
-  1,500.</p>
+  <a class="collapse-toggle" role="button" data-toggle="collapse" href="#what" aria-expanded="false" aria-controls="payments-table">
+    <h3>What we're looking for<small class="glyphicon glyphicon-chevron-down"></small></h3>
+  </a>
+  <div class="collapse in" id="what">
+    <p class="emphasis">Electromagnetic Field is a UK camping festival for those
+      with an inquisitive mind or an interest in making things: hackers, artists,
+      geeks, crafters, scientists, and engineers. It's happening near
+      <a href="http://wiki.emfcamp.org/wiki/Getting_Here">Guildford, Surrey</a>
+      on August 5th<sup>th</sup>&mdash;7<sup>th</sup>, and tickets are
+      <a href="/">on sale now</a> for £{{ full_price }}. Our last festival in
+      2014 had 1,300 attendees; this year we're aiming for 1,500.</p>
 
-  <p>We're looking for people to talk, share, and demonstrate the things they
-  love. We're especially keen to hear from people with <a
-  href="{{ url_for('base.diversity') }}">different backgrounds</a> than you'd expect to find at a
-  technology conference. We're not just looking for talks: we also want
-  installations, workshops, and games.</p>
+    <p>We're looking for people to talk, share, and demonstrate the things they
+      love. We're especially keen to hear from people with
+      <a href="{{ url_for('base.diversity') }}">different backgrounds</a> than
+      you'd expect to find at a technology conference. We're not just looking
+      for talks: we also want installations, workshops, and games.</p>
 
-  <p>At previous events we've heard about everything from <b>genetic
-    modification</b> to <b>electronics</b>, <b>blacksmithing</b> to
-  <b>high-energy physics</b>, <b>reverse engineering</b> to <b>lock picking</b>,
-  <b>computer security</b> to <b>crocheting</b>, and <b>quadcopters</b> to
-  <b>beer brewing</b>.  </p>
+    <p>At previous events we've heard about everything from genetic modification
+      to electronics, blacksmithing to high-energy physics, reverse engineering
+      to lock picking, computer security to crocheting, and quadcopters to beer
+      brewing.  </p>
 
-  <p>If you're enthusiastic about it, we are too! You don't need to be a
-  professional or an expert to present: <strong>impostors are
-  welcome</strong>.</p>
+    <p>If you're enthusiastic about it, we are too! You don't need to be a
+      professional or an expert to present: <strong>impostors are
+      welcome</strong>.</p>
+  </div>
 
-  <h3>Selection</h3>
+  <a class="collapse-toggle" role="button" data-toggle="collapse" href="#selection" aria-expanded="false" aria-controls="payments-table">
+    <h3>Selection<small class="glyphicon glyphicon-chevron-down"></small></h3>
+  </a>
+  <div class="collapse" id="selection">
+    <p>After you submit a proposal, it will be considered anonymously by a diverse
+      selection panel. We may take into account other factors later on in the process
+      to see where we can support you.</p>
+  </div>
 
-  <p>After you submit a proposal, it will be considered anonymously by a diverse
-  selection panel. We may take into account other factors later on in the process
-  to see where we can support you.</p>
+  <a class="collapse-toggle" role="button" data-toggle="collapse" href="#money" aria-expanded="false" aria-controls="payments-table">
+    <h3>Money<small class="glyphicon glyphicon-chevron-down"></small></h3>
+  </a>
+  <div class="collapse" id="money">
+    <p>EMF is a non-profit community event, entirely run by unpaid volunteers. All of
+      the ticket cost goes directly towards turning a field into a habitable and amazing place
+      to spend a weekend, and everyone who attends contributes to making it a success.</p>
 
-  <h3>Money</h3>
-
-  <p>EMF is a non-profit community event, entirely run by unpaid volunteers. All of
-  the ticket cost goes directly towards turning a field into a habitable and amazing place
-  to spend a weekend, and everyone who attends contributes to making it a success.</p>
-
-  <p>Because of this, we'd like everyone who participates to buy a ticket and stick around for
-  the whole event. We don't have the budget to pay speakers, although we have a
-  limited amount of money set aside to help those who otherwise can't to afford to come, or
-  who can only attend for the day of their talk. Please let us know if that's the case.</p>
+    <p>Because of this, we'd like everyone who participates to buy a ticket and stick around for
+      the whole event. We don't have the budget to pay speakers, although we have a
+      limited amount of money set aside to help those who otherwise can't to afford to come, or
+      who can only attend for the day of their talk. Please let us know if that's the case.</p>
+  </div>
 
   <h3>Submit a proposal</h3>
   <p>We need a rough idea of what you want to present at EMF, what sort of
-  resources you'll need, and how long you'll expect it to last. If you need some
-  help writing your proposal, <a href="mailto:content@emfcamp.org">we're happy to
-  help</a>. If you're not confident speaking, we'll help you out however we
-  can.</p>
-
-  <p>The first round of proposals has now <strong>closed</strong>, but we're still accepting
-     late submissions.</p>
+    resources you'll need, and how long you'll expect it to last. If you need some
+    help writing your proposal, <a href="mailto:content@emfcamp.org">we're happy to
+   help</a>. If you're not confident speaking, we'll help you out however we
+   can.</p>
 
   {% if not current_user.is_authenticated() %}
   <p>If you've already bought a ticket for this year, please <a href="{{ url_for('users.login') }}">log in</a>

--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -166,6 +166,7 @@
       </div>
       {% endif %}
 
+      {% if current_user.is_anonymous() or not current_user.diversity %}
       <fieldset>
         <div class="col-md-11 col-md-offset-1">
         <div class="panel panel-warning">
@@ -185,6 +186,7 @@
         </div>
         </div>
       </fieldset>
+      {% endif %}
 
       <div class="form-actions">
         <button type="submit" name="Create" class="btn btn-success btn-lg pull-right debounce">Submit proposal</button>

--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -12,7 +12,7 @@
   scientists, and engineers. It's happening near
   <a href="http://wiki.emfcamp.org/wiki/Getting_Here">Guildford, Surrey</a> on
   August 5th<sup>th</sup>&mdash;7<sup>th</sup>, and tickets are <a href="/">on sale now</a> for
-  £{{ full_price }}. Our last festival in 2014 had 1,300 attendees; this year we'll have over
+  £{{ full_price }}. Our last festival in 2014 had 1,300 attendees; this year we're aiming for
   1,500.</p>
 
   <p>We're looking for people to talk, share, and demonstrate the things they
@@ -95,14 +95,17 @@
     <form action={{ url_for('cfp.main', cfp_type=form.type) }} method="post" class="form-horizontal cfp-form" role="form">
       <fieldset>
       {{ form.hidden_tag() }}
-      {{ render_field(form.name, True, glyphicon='globe', placeholder="Your name to include in the schedule") }}
 
-      {% if form.type == 'talk' %}
-        {{ render_field(form.email, True, placeholder="We'll only use this to contact you about the talk") }}
-      {% elif form.type == 'workshop' %}
-        {{ render_field(form.email, True, placeholder="We'll only use this to contact you about the workshop") }}
-      {% elif form.type == 'installation' %}
-        {{ render_field(form.email, True, placeholder="We'll only use this to contact you about the installation") }}
+      {% if not current_user.is_authenticated() %}
+        {{ render_field(form.name, True, glyphicon='globe', placeholder="Your name to include in the schedule") }}
+
+        {% if form.type == 'talk' %}
+          {{ render_field(form.email, True, placeholder="We'll only use this to contact you about the talk") }}
+        {% elif form.type == 'workshop' %}
+          {{ render_field(form.email, True, placeholder="We'll only use this to contact you about the workshop") }}
+        {% elif form.type == 'installation' %}
+          {{ render_field(form.email, True, placeholder="We'll only use this to contact you about the installation") }}
+        {% endif %}
       {% endif %}
 
       {{ render_field(form.title, True, glyphicon='globe', placeholder="A one-sentence summary (it should fit in a tweet)") }}

--- a/templates/cfp.html
+++ b/templates/cfp.html
@@ -110,7 +110,9 @@
 
       {{ render_field(form.title, True, glyphicon='globe', placeholder="A one-sentence summary (it should fit in a tweet)") }}
       <div class="text-right help-block hidden show-remaining" data-for="title" data-max="140">
-        Characters remaining: <span class="remaining"></span><span class="too-long"> (but don't worry)</span>
+        <small>
+          Characters remaining: <span class="remaining"></span><span class="too-long"> (but don't worry)</span>
+        </small>
       </div>
       </fieldset>
 
@@ -126,10 +128,6 @@
       {% elif form.type == 'installation' %}
         {{ render_field(form.size, True, placeholder="We need to know how much space to reserve") }}
       {% endif %}
-
-      {#
-      {{ render_field(form.days, True, placeholder="I can only come on these days") }}
-      #}
 
       </fieldset>
       <fieldset>

--- a/templates/cfp_proposals.html
+++ b/templates/cfp_proposals.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Your Proposals{% endblock %}
+{% block body %}
+
+<h1>Your CFP Proposals</h1>
+
+<a href="{{ url_for('cfp.main') }}" class="btn btn-lg btn-primary">Submit a CFP proposal</a>
+
+<table class="table">
+  <tr>
+    <th>Type</th>
+    <th>Length</th>
+    <th>Capacity</th>
+    <th>Size</th>
+    <th>Description</th>
+  </tr>
+  {% for sub in current_user.proposals %}
+  <tr class="{{- loop.cycle('odd', 'even') }}">
+    <td colspan="5">{{ sub.title }}</td>
+  </tr>
+  <tr class="{{- loop.cycle('odd', 'even') }}">
+    <td>{{ sub.type | title }}</td>
+    <td>{{ sub.length or 'N/A'}}</td>
+    <td>{{ sub.attendees or 'N/A'}}</td>
+    <td>{{ sub.size or 'N/A'}}</td>
+    <td>{{ sub.description }}</td>
+  </tr>
+  {% endfor %}
+
+</table>
+
+{% endblock %}

--- a/templates/emails/cfp-submission.txt
+++ b/templates/emails/cfp-submission.txt
@@ -1,4 +1,4 @@
-Hi {{ cfp.name }},
+Hi {{ cfp.user.name }},
 
 This is to confirm your submission to our call for participation. We'll try to process your submission as quickly as possible. So you know this was your submission:
 
@@ -20,6 +20,10 @@ You also indicated that you would only be able to attend for one day and you wil
 You also indicated that you would only be able to attend for one day.
 {% elif cfp.need_finance %}
 You also indicated that you will need financial support to attend.
+{%- endif %}
+
+{%- if new_user %}
+As you've not previously registered with us we've created an account for you that is tied to this email address.
 {%- endif %}
 
 Any problems please contact us.


### PR DESCRIPTION
* Replace separate name/email columns in proposals table with user_id
* Roll user creation/use of current into the cfp form
* Make the diversity table a concern of the user rather than the proposal
* Add an 'account' page for modifying diversity values and user name
* Add a 'proposals' page which list all of a user's cfp proposals
* Add 'state' and 'created' columns to proposal table (for later use, default to 'new' and 'now' respectively)
* Reduce 'wall of text' effect on cfp page with collapse blocks