### PR TITLE
Add a utils task that locks proposals after 2 days

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ reallyreconcile:
 sendtickets:
 	$(ENV) SETTINGS_FILE=$(SETTINGS) python ./utils.py sendtickets
 
+lockproposals:
+	$(ENV) SETTINGS_FILE=$(SETTINGS) python ./utils.py lockproposals
+
 
 shell:
 	$(ENV) SETTINGS_FILE=$(SETTINGS) python ./utils.py shell

--- a/templates/cfp/proposals.html
+++ b/templates/cfp/proposals.html
@@ -14,6 +14,14 @@
       <dl class="dl-horizontal">
         <dt>Submitted</dt>
         <dd>{{ proposal.created.strftime('%d %B') }}</dd>
+        <dt>Status</dt>
+        <dd>
+        {% if proposal.state == 'new' %}
+          Open for edits
+        {% elif proposal.state == 'locked' %}
+          Locked for edits (being anonymised)
+        {% endif %}
+        </dd>
         {% if proposal.type == 'talk' %}
         <dt>Duration</dt>
         <dd>{{ proposal.length }}</dd>


### PR DESCRIPTION
When this is run any cfp-proposal that is older than 2 days has its
state set to 'locked' this indicates that it is ready to go an
anoymiser.

This commit also adds this information to the /proposals page so that
users can track the progress of their submissions.