### PR TITLE
Allow setting of categories on all proposals

### DIFF
--- a/models/cfp.py
+++ b/models/cfp.py
@@ -120,7 +120,7 @@ class ProposalCategory(db.Model):
     __tablename__ = 'category'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String, nullable=False)
-    proposals = db.relationship(TalkProposal, backref='category')
+    proposals = db.relationship(Proposal, backref='category')
     users = db.relationship('User', secondary=category_reviewers, backref='review_categories')
 
 

--- a/templates/cfp_review/anonymise_proposal.html
+++ b/templates/cfp_review/anonymise_proposal.html
@@ -12,10 +12,8 @@
             <dd>{{ proposal.type }}</dd>
             <dt>Submitter</dt>
             <dd>{{ proposal.user.name }}</dd>
-            {% if proposal.type == 'talk' %}
-                <dt>Category</dt>
-                <dd>{{ proposal.category.name }}</dd>
-            {% endif %}
+            <dt>Category</dt>
+            <dd>{{ proposal.category.name }}</dd>
 
             {{ render_dl_field(form.title, tabindex=1) }}
             {{ render_dl_field(form.description, tabindex=2, rows=10) }}

--- a/templates/cfp_review/update_proposal.html
+++ b/templates/cfp_review/update_proposal.html
@@ -48,11 +48,7 @@
     </div>
     <div class="col-md-4 col-xs-12 btn-group-vertical" role="group">
         <div>&nbsp;</div>
-        {% if proposal.type == 'talk' %}
-            {{ render_field(form.category, tabindex=1) }}
-        {% else %}
-            <div>&nbsp;</div><div>&nbsp;</div><div>&nbsp;</div>
-        {% endif %}
+        {{ render_field(form.category, tabindex=1) }}
         {% if proposal.state == 'locked' %}
             {{ form.checked(class_="btn btn-success", tabindex=2) }}
             {{ form.reject(class_="btn btn-danger", tabindex=3) }}


### PR DESCRIPTION
Turns out that only setting categories on talks is daft. This way workshops (of which there will hopefully be more than last time) are also reviewed by people who understand the material better.