### PR TITLE
Manual cfp accept

### DIFF
--- a/apps/cfp_review.py
+++ b/apps/cfp_review.py
@@ -193,13 +193,11 @@ def update_proposal(proposal_id):
             prop.set_state('rejected')
 
             if form.reject_with_message.data:
-                send_accepted_rejected_email(prop, accepted=False)
-                prop.has_rejected_email = True
+                accept_or_reject_proposal(prop, accepted=False)
 
         elif form.accept.data:
             msg = 'Manually accepting proposal %s' % proposal_id
-            send_accepted_rejected_email(prop, accepted=True)
-            prop.set_state('accepted')
+            accept_or_reject_proposal(prop, accepted=True)
 
         elif form.checked.data:
             msg = 'Sending proposal %s for anonymisation' % proposal_id
@@ -715,15 +713,17 @@ class AcceptanceForm(Form):
     confirm = SubmitField('Confirm')
     cancel = SubmitField('Cancel')
 
-def send_accepted_rejected_email(proposal, accepted=False):
+def accept_or_reject_proposal(proposal, accepted=False):
     if not accepted and proposal.has_rejected_email:
         return
 
     elif accepted:
+        proposal.set_state('accepted')
         subject = 'Your EMF proposal has been accepted'
         template = 'cfp_review/email/accepted_msg.txt'
 
     else:
+        proposal.has_rejected_email = True
         subject = 'Your EMF proposal has been reviewed'
         template = 'cfp_review/email/not_accepted_msg.txt'
 
@@ -757,12 +757,10 @@ def rank():
 
                 if score >= min_score:
                     count += 1
-                    send_accepted_rejected_email(prop, accepted=True)
-                    prop.set_state('accepted')
+                    accept_or_reject_proposal(prop, accepted=True)
 
                 else:
-                    send_accepted_rejected_email(prop, accepted=False)
-                    prop.has_rejected_email = True
+                    accept_or_reject_proposal(prop, accepted=False)
 
             db.session.commit()
             del session['min_score']

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -6,11 +6,11 @@ CFP_STATES = { 'edit': ['accepted', 'rejected', 'new'],
                'new': ['accepted', 'rejected', 'locked'],
                'locked': ['accepted', 'rejected', 'checked', 'edit'],
                'checked': ['accepted', 'rejected', 'anonymised', 'anon-blocked', 'edit'],
-               'rejected': ['accepted', 'edit'],
+               'rejected': ['accepted', 'rejected', 'edit'],
                'anonymised': ['accepted', 'rejected', 'reviewed', 'edit'],
                'anon-blocked': ['accepted', 'rejected', 'reviewed', 'edit'],
                'reviewed': ['accepted', 'rejected', 'edit'],
-               'accepted': ['rejected', 'finished'],
+               'accepted': ['accepted', 'rejected', 'finished'],
                'finished': ['accepted', 'rejected'] }
 
 # Most of these states are the same they're kept distinct for semantic reasons

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -2,16 +2,16 @@ from main import db
 from datetime import datetime
 
 # state: [allowed next state, ] pairs
-CFP_STATES = { 'edit': ['new'],
-               'new': ['locked'],
-               'locked': ['checked', 'rejected', 'edit'],
-               'checked': ['anonymised', 'anon-blocked', 'edit'],
-               'rejected': ['edit'],
-               'anonymised': ['reviewed', 'edit'],
-               'anon-blocked': ['reviewed', 'edit'],
-               'reviewed': ['accepted', 'edit'],
-               'accepted': ['finished'],
-               'finished': ['accepted'] }
+CFP_STATES = { 'edit': ['accepted', 'rejected', 'new'],
+               'new': ['accepted', 'rejected', 'locked'],
+               'locked': ['accepted', 'rejected', 'checked', 'edit'],
+               'checked': ['accepted', 'rejected', 'anonymised', 'anon-blocked', 'edit'],
+               'rejected': ['accepted', 'edit'],
+               'anonymised': ['accepted', 'rejected', 'reviewed', 'edit'],
+               'anon-blocked': ['accepted', 'rejected', 'reviewed', 'edit'],
+               'reviewed': ['accepted', 'rejected', 'edit'],
+               'accepted': ['rejected', 'finished'],
+               'finished': ['accepted', 'rejected'] }
 
 # Most of these states are the same they're kept distinct for semantic reasons
 # and because I'm lazy

--- a/templates/cfp_review/update_proposal.html
+++ b/templates/cfp_review/update_proposal.html
@@ -53,6 +53,8 @@
             {{ form.reject(class_="btn btn-danger debounce", tabindex=3) }}
         {% endif %}
         {{ form.update(class_="btn btn-danger debounce", tabindex=4) }}
+        {{ form.accept(class_="btn btn-danger debounce", tabindex=4) }}
+        {{ form.reject_with_message(class_="btn btn-danger debounce", tabindex=4) }}
 
         {% if next_id %}
             <a href="{{ url_for('.update_proposal', proposal_id=next_id) }}"


### PR DESCRIPTION
Adds to buttons 'Accept with standard message' and 'Reject with standard message' to the update proposals page. This also makes transitions to 'accepted' or 'rejected' always valid.

closes #360 and #361 