### PR TITLE
Make user lookup by email case insensitive

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -1,6 +1,6 @@
 from main import db
-from models import exists
 from permission import UserPermission, Permission
+from sqlalchemy import func
 from sqlalchemy.orm.exc import NoResultFound
 from flask.ext.login import UserMixin
 
@@ -97,8 +97,16 @@ class User(db.Model, UserMixin):
         return '<User %s>' % self.email
 
     @classmethod
+    def get_by_email(cls, email):
+        return User.query.filter(func.lower(User.email) == func.lower(email)).one()
+
+    @classmethod
     def does_user_exist(cls, email):
-        return exists(User.query.filter_by(email=email))
+        try:
+            User.get_by_email(email)
+            return True
+        except NoResultFound:
+            return False
 
     @classmethod
     def get_by_code(cls, key, code):


### PR DESCRIPTION
If a user signs up on a device that happens to capitalise the first letter of the email alias, then later attempts to login on a device that _doesn't_ happen to capitalise it, we'd like them to be able to login.

We do this rather than lowercasing all email addresses because email aliases can be case sensitive.

Appears to work as expected in a VM.