### PR TITLE
Add and wire up Purchase.cancel

### DIFF
--- a/models/basket.py
+++ b/models/basket.py
@@ -199,9 +199,7 @@ class Basket(MutableMapping):
         with db.session.no_autoflush:
             for line in self._lines:
                 for purchase in line.purchases:
-                    purchase.set_state('cancelled')
-
-                line.tier.return_instances(len(line.purchases))
+                    purchase.cancel()
 
         self._lines = []
 
@@ -214,10 +212,8 @@ class Basket(MutableMapping):
         with db.session.no_autoflush:
             for line in self._lines:
                 if line.count < len(line.purchases):
-                    line.tier.return_instances(len(line.purchases) - line.count)
-
                     for purchase in line.purchases[line.count:]:
-                        purchase.set_state('cancelled')
+                        purchase.cancel()
 
                     line.purchases = line.purchases[:line.count]
 

--- a/models/payment.py
+++ b/models/payment.py
@@ -149,10 +149,12 @@ class Payment(db.Model):
         elif self.state == 'refunded':
             raise StateException('Refunded payments cannot be cancelled')
 
-        for purchase in self.purchases:
-            purchase.set_state('cancelled')
+        with db.session.no_autoflush:
+            for purchase in self.purchases:
+                purchase.cancel()
 
         self.state = 'cancelled'
+        db.session.flush()
 
     def manual_refund(self):
         # Only to be called for full out-of-band refunds, for book-keeping.

--- a/models/purchase.py
+++ b/models/purchase.py
@@ -115,6 +115,12 @@ class Purchase(db.Model):
 
         self.state = new_state
 
+    def cancel(self):
+        if self.state == 'cancelled':
+            raise PurchaseStateException('{} is already cancelled'.format(self))
+        self.set_state('cancelled')
+        self.price_tier.return_instances(1)
+
     def change_currency(self, currency):
         self.price = self.price_tier.get_price(currency)
 


### PR DESCRIPTION
This fixes the capacity counting issues in #637. Purchase.cancel now does the work of returning capacity, and Payment.cancel does the right thing.