### PR TITLE
Less confusing not-accepted emails on round close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ emailspeakersaboutslot:
 emailspeakersaboutfinalising:
 	SETTINGS_FILE=$(SETTINGS) pipenv run python ./utils.py emailspeakersaboutfinalising
 
-rejectunacceptedtalks:
-	SETTINGS_FILE=$(SETTINGS) pipenv run python ./utils.py rejectunacceptedtalks
+rejectunacceptedproposals:
+	SETTINGS_FILE=$(SETTINGS) pipenv run python ./utils.py rejectunacceptedproposals
 
 importvenues:
 	SETTINGS_FILE=$(SETTINGS) pipenv run python ./utils.py importvenues

--- a/apps/cfp_review.py
+++ b/apps/cfp_review.py
@@ -362,12 +362,12 @@ def update_proposal(proposal_id):
             prop.set_state('rejected')
 
             if form.reject_with_message.data:
-                send_email_for_proposal(prop, accepted=False)
+                send_email_for_proposal(prop, reason="rejected")
 
         elif form.accept.data:
             msg = 'Manually accepting proposal %s' % proposal_id
             prop.set_state('accepted')
-            send_email_for_proposal(prop, accepted=True)
+            send_email_for_proposal(prop, reason="accepted")
 
         elif form.checked.data:
             if prop.type in MANUAL_REVIEW_TYPES:
@@ -1028,17 +1028,25 @@ class AcceptanceForm(Form):
     confirm = SubmitField('Confirm')
     cancel = SubmitField('Cancel')
 
-def send_email_for_proposal(proposal, accepted):
-    if accepted:
+def send_email_for_proposal(proposal, reason="still-considered"):
+    if reason == "accepted":
         app.logger.info('Sending accepted email for proposal %s', proposal.id)
         subject = 'Your EMF proposal "%s" has been accepted!' % proposal.title
         template = 'cfp_review/email/accepted_msg.txt'
 
-    else:
-        app.logger.info('Sending not-accepted email for proposal %s', proposal.id)
+    elif reason == "still-considered":
+        app.logger.info('Sending still-considered email for proposal %s', proposal.id)
+        subject = 'We\'re still considering your EMF proposal "%s"' % proposal.title
+        template = 'cfp_review/email/not_accepted_msg.txt'
+
+    elif reason == "rejected":
+        app.logger.info('Sending rejected email for proposal %s', proposal.id)
         proposal.has_rejected_email = True
         subject = 'Your EMF %s proposal "%s" was not accepted.' % (proposal.type, proposal.title)
         template = 'emails/cfp-rejected.txt'
+
+    else:
+        raise Exception("Unknown cfp proposal email type %s" % reason)
 
     msg = Message(subject, sender=app.config['CONTENT_EMAIL'],
                   recipients=[proposal.user.email])
@@ -1072,10 +1080,10 @@ def rank():
                 if score >= min_score:
                     count += 1
                     prop.set_state('accepted')
-                    send_email_for_proposal(prop, accepted=True)
+                    send_email_for_proposal(prop, reason="accepted")
 
                 else:
-                    send_email_for_proposal(prop, accepted=False)
+                    send_email_for_proposal(prop, reason="still-considered")
 
             db.session.commit()
             del session['min_score']

--- a/templates/cfp_review/email/not_accepted_msg.txt
+++ b/templates/cfp_review/email/not_accepted_msg.txt
@@ -1,10 +1,8 @@
 Hi {{ user.name }},
 
-Just to let you know your EMF {{ proposal.human_type }} "{{ proposal.title}}" is still up for selection, but was not chosen in today's batch.
+Just to let you know your EMF {{ proposal.human_type }} "{{ proposal.title}}" is still being considered!
 
-To be very clear: your submission has NOT been rejected yet!
-
-There's still plenty of time for your {{ proposal.human_type }} to be chosen, and we'll be in touch to let you know for certain in the next three weeks.
+There's still plenty of time for your {{ proposal.human_type }} to be chosen, and we'll be in touch to let you know for certain at least one month before the event.
 
 If you have any questions, don't hesitate to get in contact:
 

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,7 @@ from main import create_app
 from tasks.admin import MakeAdmin, CreatePermissions, SendEmails
 from tasks.banking import CreateBankAccounts, LoadOfx, Reconcile
 from tasks.cfp import (
-    ImportCFP, EmailSpeakersAboutSlot, EmailSpeakersAboutFinalising, RejectUnacceptedTalks
+    ImportCFP, EmailSpeakersAboutSlot, EmailSpeakersAboutFinalising, RejectUnacceptedProposals
 )
 from tasks.dev import MakeFakeData
 from tasks.external_calendars import (
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 
     manager.add_command('emailspeakersaboutslot', EmailSpeakersAboutSlot())
     manager.add_command('emailspeakersaboutfinalising', EmailSpeakersAboutFinalising())
-    manager.add_command('rejectunacceptedtalks', RejectUnacceptedTalks())
+    manager.add_command('rejectunacceptedproposals', RejectUnacceptedProposals())
 
     manager.add_command('importvenues', ImportVenues())
     manager.add_command('runscheduler', RunScheduler())


### PR DESCRIPTION
Not-accepted email sending was removed in 2016 by accident when introducing mass rejected email sending.  This also cleans up the handling of CFP emails so we have a single function to handle it.