### PR TITLE
Add space so that users with multiple permissions are readable

### DIFF
--- a/templates/admin/users/users.html
+++ b/templates/admin/users/users.html
@@ -27,7 +27,7 @@
 <tr class="{{ loop.cycle('odd', 'even') }}">
     <td><a href="{{ url_for('.user', user_id=u.id) }}">{{ u.name }}</a></td>
     <td>{{ u.email }}</td>
-    <td>{% for permission in u.permissions %}{{ permission.name }}{% endfor %}</td>
+    <td>{% for permission in u.permissions %}{{ permission.name }}&nbsp;{% endfor %}</td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
Feel free to ignore this, implement it a different way, etc, but it's hard to read when a user has more than one permission.