### PR TITLE
Restore proposal type filter shortcuts

### DIFF
--- a/templates/cfp_review/_nav.html
+++ b/templates/cfp_review/_nav.html
@@ -20,6 +20,11 @@
             </a>
             <ul class="dropdown-menu">
                 {{ menuitem("All", ".proposals") }}
+                {{ menuitem("Talks", ".proposals", type="talk") }}
+                {{ menuitem("Workshops", ".proposals", type="workshop") }}
+                {{ menuitem("Installations", ".proposals", type="installation") }}
+                {{ menuitem("Performances", ".proposals", type="performance") }}
+                {{ menuitem("Youth Workshops", ".proposals", type="youthworkshop") }}
                 <li role="separator" class="divider"></li>
                 {{ menuitem('Anon-blocked', ".proposals", proposal_counts['anon-blocked'], state='anon-blocked')}}
                 {{ menuitem('New', ".proposals", proposal_counts['new'], state='new')}}


### PR DESCRIPTION
This is driving me up the wall, so bringing back the shortcuts in addition to the more powerful filtering.