### PR TITLE
Clear vote notes when making votes stale/resolved

### DIFF
--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -450,6 +450,7 @@ def proposal_votes(proposal_id):
             for vote in all_votes.values():
                 if vote.state in states_to_set:
                     vote.set_state('stale')
+                    vote.note = None
                     stale_count += 1
 
             if stale_count:
@@ -461,6 +462,7 @@ def proposal_votes(proposal_id):
                 vote = all_votes[form_vote['id'].data]
                 if form_vote.resolve.data and vote.state in ['blocked']:
                     vote.set_state('resolved')
+                    vote.note = None
                     update_count += 1
 
             if update_count:
@@ -471,6 +473,7 @@ def proposal_votes(proposal_id):
             for vote in all_votes.values():
                 if vote.state == 'blocked':
                     vote.set_state('resolved')
+                    vote.note = None
                     resolved_count += 1
 
         if msg:

--- a/apps/cfp_review/review.py
+++ b/apps/cfp_review/review.py
@@ -179,6 +179,7 @@ def review_proposal(proposal_id):
             vote.note = form.note.data
             vote.has_been_read = False
         else:
+            vote.note = None
             vote.has_been_read = True
 
         vote_value = 2 if form.vote_excellent.data else\


### PR DESCRIPTION
This doesn't remove vote notes, they'll still be visible on the old vote versions, but they won't be propagated forward to new versions.

I _think_ this is correct, but I've not actually tested it.