### PR TITLE
Add options for notification & rejection to close

### DIFF
--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -583,10 +583,17 @@ def rank():
                 if score >= min_score:
                     count += 1
                     prop.set_state('accepted')
-                    send_email_for_proposal(prop, reason="accepted")
+                    if form.confirm_type.data in ('accepted_unaccepted', 'accepted', 'accepted_reject'):
+                        send_email_for_proposal(prop, reason="accepted")
 
                 else:
-                    send_email_for_proposal(prop, reason="still-considered")
+                    if form.confirm_type.data == 'accepted_unaccepted':
+                        send_email_for_proposal(prop, reason="still-considered")
+
+                    elif form.confirm_type.data == 'accepted_reject':
+                        prop.set_state('rejected')
+                        prop.has_rejected_email = True
+                        send_email_for_proposal(prop, reason="rejected")
 
                 db.session.commit()
 

--- a/apps/cfp_review/forms.py
+++ b/apps/cfp_review/forms.py
@@ -205,7 +205,13 @@ class CloseRoundForm(Form):
 
 class AcceptanceForm(Form):
     min_score = FloatField('Minimum score for acceptance')
-    set_score = SubmitField('Accept Proposals...')
+    set_score = SubmitField('Preview proposals to be selected...')
+    confirm_type = SelectField('Messaging', choices=[
+        ('accepted_unaccepted', 'Email accepted, notify unaccepted about the next round'),
+        ('accepted', 'Email accepted, do not email unaccepted'),
+        ('nobody', 'Email nobody'),
+        ('accepted_reject', 'Email accepted, reject all unaccepted'),
+    ], default='accepted')
     confirm = SubmitField('Confirm')
     cancel = SubmitField('Cancel')
 

--- a/templates/cfp_review/rank.html
+++ b/templates/cfp_review/rank.html
@@ -7,9 +7,8 @@
 </p>
 
 <p>
-    Proposals listed below will be accepted or rejected, with an email sent to the proposer.
-    If there are proposals that shouldn't be rejected or accepted at this point,
-    please set their state back to "anonymised" from "reviewed".
+    Proposals listed below will be accepted. Notification or rejection is controlled by the dropdown selector.
+    If there are proposals that shouldn't be accepted at this point, please set their state back to "anonymised" from "reviewed".
 </p>
 
 <p>Show 
@@ -23,7 +22,7 @@
 
 {% if preview %}
     <p>
-        <span class="bg-info">Proposals</span> will be accepted. Other proposals will be entered into the next round.
+        <span class="bg-info">Proposals</span> will be accepted.
     </p>
 {% endif %}
 <p>
@@ -56,6 +55,7 @@
     {{ form.hidden_tag() }}
 
     {% if preview %}
+        {{ form.confirm_type() }}
         {{ form.confirm(class_='btn btn-success debounce') }}
         {{ form.cancel(class_='btn btn-danger debounce') }}
     {% else %}


### PR DESCRIPTION
This means we no longer need to use the CLI tool to mass-reject at the end, and we can close the final rounds selectively without annoyingly notifying people.