### PR TITLE
Show approximate allocated/remaining time on rank

### DIFF
--- a/apps/cfp.py
+++ b/apps/cfp.py
@@ -19,28 +19,12 @@ from main import db, mail
 from models.user import User, UserDiversity
 from models.cfp import (
     TalkProposal, WorkshopProposal, YouthWorkshopProposal, PerformanceProposal,
-    InstallationProposal, Proposal, CFPMessage, LENGTH_OPTIONS
+    InstallationProposal, Proposal, CFPMessage, LENGTH_OPTIONS, PROPOSAL_TIMESLOTS
 )
 from .common import feature_flag, create_current_user
 from .common.forms import Form, TelField
 
 import collections
-
-# This needs to go very far away
-proposal_timeslots = {
-    'talk':             ('fri_13_16', 'fri_16_20',
-                            'sat_10_13', 'sat_13_16', 'sat_16_20',
-                            'sun_10_13', 'sun_13_16', 'sun_16_20'),
-    'workshop':         ('fri_13_16', 'fri_16_20', 'fri_20_22', 'fri_22_24',
-                            'sat_10_13', 'sat_13_16', 'sat_16_20', 'sat_20_22', 'sat_22_24',
-                            'sun_10_13', 'sun_13_16', 'sun_16_20'),
-    'youthworkshop':    ('fri_13_16', 'fri_16_20',
-                            'sat_10_13', 'sat_13_16', 'sat_16_20',
-                            'sun_10_13', 'sun_13_16', 'sun_16_20'),
-    'performance':      ('fri_20_22', 'fri_22_24',
-                            'sat_20_22', 'sat_22_24',
-                            'sun_20_22', 'sun_22_24')
-}
 
 cfp = Blueprint('cfp', __name__)
 
@@ -456,7 +440,7 @@ def finalise_proposal(proposal_id):
         class F(AcceptedForm):
             pass
 
-        F._available_slots = proposal_timeslots[proposal.type]
+        F._available_slots = PROPOSAL_TIMESLOTS[proposal.type]
         for timeslot in F._available_slots:
             setattr(F, timeslot, BooleanField(default=True))
         form = F()

--- a/apps/cfp.py
+++ b/apps/cfp.py
@@ -519,9 +519,14 @@ def finalise_proposal(proposal_id):
         day, start, end = slot.split('_')
         slot_hour_str = "%s_%s" % (start, end)
         day_form_slots[day][slot_hour_str] = getattr(form, slot)(class_='form-control')
+        headings[int(start)] = (int(start), int(end))
 
-        start = int(start)
-        end = int(end)
+    slot_times = []
+    slot_titles = []
+    for start in sorted(headings.keys()):
+        start, end = headings[start]
+        slot_times.append("%s_%s" % (start, end))
+
         start_ampm = end_ampm = 'am'
         if start > 12:
             start_ampm = 'pm'
@@ -529,10 +534,7 @@ def finalise_proposal(proposal_id):
         if end > 12:
             end_ampm = 'pm'
             end -= 12
-        headings[slot_hour_str] = "%s%s - %s%s" % (start, start_ampm, end, end_ampm)
-
-    slot_times = sorted(headings.keys())
-    slot_titles = [headings[slot] for slot in slot_times]
+        slot_titles.append("%s%s - %s%s" % (start, start_ampm, end, end_ampm))
 
     return render_template('cfp/accepted.html',
             form=form, proposal=proposal, slot_times=slot_times, slot_titles=slot_titles, day_form_slots=day_form_slots)

--- a/templates/cfp_review/rank.html
+++ b/templates/cfp_review/rank.html
@@ -1,10 +1,52 @@
 {% extends "cfp_review/base.html" %}
 {% block body %}
-<h2>Ranked proposals</h2>
 
+<h2>Current allocations</h2>
+<table class="table table-condensed table-striped">
+    <th></th><th>Talk</th><th>Workshop</th><th>Youth Workshop</th><th>Performance</th>
+    <tr>
+        <td><strong>Num accepted</strong></td>
+        <td>{{accepted_counts.get('talk')}}</td>
+        <td>{{accepted_counts.get('workshop')}}</td>
+        <td>{{accepted_counts.get('youthworkshop')}}</td>
+        <td>{{accepted_counts.get('performance')}}</td>
+    </tr>
+    <tr>
+        <td><strong>Missing durations</strong></td>
+        <td>{{unknown_lengths.get('talk')}}</td>
+        <td>{{unknown_lengths.get('workshop')}}</td>
+        <td>{{unknown_lengths.get('youthworkshop')}}</td>
+        <td>{{unknown_lengths.get('performance')}}</td>
+    </tr>
+    <tr>
+        <td><strong>Available mins</strong></td>
+        <td>{{available_minutes.get('talk')}}</td>
+        <td>{{available_minutes.get('workshop')}}</td>
+        <td>{{available_minutes.get('youthworkshop')}}</td>
+        <td>{{available_minutes.get('performance')}}</td>
+    </tr>
+    <tr>
+        <td><strong>Allocated mins</strong></td>
+        <td>{{allocated_minutes.get('talk')}}</td>
+        <td>{{allocated_minutes.get('workshop')}}</td>
+        <td>{{allocated_minutes.get('youthworkshop')}}</td>
+        <td>{{allocated_minutes.get('performance')}}</td>
+    </tr>
+    <tr>
+        <td><strong>Remaining mins</strong></td>
+        <td>{{remaining_minutes.get('talk')}}</td>
+        <td>{{remaining_minutes.get('workshop')}}</td>
+        <td>{{remaining_minutes.get('youthworkshop')}}</td>
+        <td>{{remaining_minutes.get('performance')}}</td>
+    </tr>
+</table>
+
+<h2>Ranked proposals</h2>
+{% if not preview %}
 <p>
     Set the score to determine which proposals will be accepted this round.
 </p>
+{% endif %}
 
 <p>
     Proposals listed below will be accepted. Notification or rejection is controlled by the dropdown selector.
@@ -26,11 +68,7 @@
     </p>
 {% endif %}
 <p>
-<strong>Already accepted: </strong>
-{% for type, count in accepted_counts.items() %}
-<i>{{type}}</i>: {{count}},
-{% endfor %}
-</p>
+
 
 <table class="table">
     <tr>


### PR DESCRIPTION
Because we keep accepting too much content.

This also contains fixes for a heading sort problem on the finalisation page due to youth content starting at 9am.