### PR TITLE
Make line-up order random but user-deterministic

### DIFF
--- a/apps/schedule.py
+++ b/apps/schedule.py
@@ -2,6 +2,7 @@
 import json
 import cgi
 import pytz
+import random
 
 from flask import (
     Blueprint, render_template, redirect, url_for, flash,
@@ -283,6 +284,10 @@ def line_up():
     proposals = Proposal.query.filter(Proposal.scheduled_duration.isnot(None)).\
         filter(Proposal.state.in_(['accepted', 'finished'])).\
         filter(Proposal.type.in_(['talk', 'workshop', 'youthworkshop'])).all()
+
+    # Shuffle the order, but keep it fixed per-user
+    # (Because we don't want a bias in starring)
+    random.Random(current_user.get_id()).shuffle(proposals)
 
     externals = CalendarSource.get_enabled_events()
 

--- a/templates/schedule/_proposal_lister.html
+++ b/templates/schedule/_proposal_lister.html
@@ -2,7 +2,7 @@
     {% for human_type, human_type_proposals in proposals | groupby('human_type') %}
         <h2>{{ human_type | title }}</h2>
         <ul>
-          {% for prop in human_type_proposals | sort(attribute='display_title') %}
+          {% for prop in human_type_proposals %}
             <li>
                 <a href="{{ url_for('.line_up_proposal', proposal_id=prop.id, slug=prop.slug) }}">
                     {{ prop.display_title }} &mdash; <em>{{ prop.published_names or prop.user.name }}</em>


### PR DESCRIPTION
This is because we don't want to have a bias in talk starring, and frankly so many people have similar prefixes it looks bad.