### PR TITLE
abstract and description should not be redundant

### DIFF
--- a/apps/schedule_xml.py
+++ b/apps/schedule_xml.py
@@ -82,7 +82,7 @@ def add_event(room, event):
     _add_sub_with_text(event_node, 'duration', duration)
 
     _add_sub_with_text(event_node, 'abstract', event['description'])
-    _add_sub_with_text(event_node, 'description', event['description'])
+    _add_sub_with_text(event_node, 'description', '')
 
     _add_sub_with_text(event_node, 'slug', 'emf%s-%s-%s' % (event_start().year, event['id'], event['slug']))
 


### PR DESCRIPTION
typically they are appended by consuming clients. 

For the sake of completeness:
Frab defines '_abstract_' as  
> "One short paragraph that succinctly describes the event."

and '_description_' as 
> "A longer description of the event. Use this to give additional details that did not fit in the abstract. Both, abstract and description, will be shown on the conference website. (HTML)"