### PR TITLE
Remove the team list

### DIFF
--- a/templates/about/volunteering.html
+++ b/templates/about/volunteering.html
@@ -19,20 +19,6 @@
 <li>Get in touch and say you'd like to volunteer, either on <a href="https://wiki.emfcamp.org/wiki/IRC">IRC</a>, or by emailing <a href="mailto:contact@emfcamp.org">contact@emfcamp.org</a>.</li>
 </ul>
 <p>Please remember that everyone is a volunteer so you may not get an immediate response. Some teams are a lot more popular than others so may not need your assistance, but many others will be grateful for your help.</p>
-<h3 id="teams-seeking-help">Volunteer teams currently seeking help</h3>
-<p>These are the volunteer teams that currently need volunteers, each team has a list of vacant roles.</p>
-<ul>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Decoration">Decoration</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Construction">Construction</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Youth">Youth</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Content">Content</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:InfoDesk">InfoDesk</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Villages">Villages</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Badge">Badge</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Volunteering">Volunteering</a></li>
-    <li><a href="https://wiki.emfcamp.org/wiki/Team:Web">Web</a></li>
-</ul>
-<p>To volunteer for any of these teams, contact us on <a href="https://wiki.emfcamp.org/wiki/IRC">IRC</a>, or by emailing <a href="mailto:contact@emfcamp.org">contact@emfcamp.org</a>.<p>
 <h3 id="how-to-volunteer">How volunteering works</h3>
 <p>We understand that everyone who helps with EMF has other commitments and we plan ahead to cope with this.</p>
 <p>We have two golden rules for you:</p>


### PR DESCRIPTION
If the wiki pages acquire some useful content around what teams need help with then we should add them back, but right now they come off as contradicting the earlier paragraphs about needing help.