### PR TITLE
Display EUR bank details as an EPC QR code

### DIFF
--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -110,7 +110,7 @@ def make_epc_qrfile(payment, **kwargs):
         name="Electromagnetic Field Ltd",
         iban="GB21BARC20716472954433",
         amount=payment.amount,
-        text=payment.bankref,
+        reference=payment.bankref,
     )
     qr.save(qrfile, **kwargs)
     qrfile.seek(0)

--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -111,6 +111,7 @@ def make_epc_qrfile(payment, **kwargs):
         iban="GB21BARC20716472954433",
         amount=payment.amount,
         reference=payment.bankref,
+        encoding=1,
     )
     qr.save(qrfile, **kwargs)
     qrfile.seek(0)

--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -117,9 +117,7 @@ def make_epc_qrfile(payment, **kwargs):
     return qrfile
 
 
-def format_inline_qr(data):
-    qrfile = make_qrfile(data, kind="svg", svgclass=None)
-
+def qrfile_to_svg(qrfile):
     root = etree.XML(qrfile.read())
     # Allow us to scale it with CSS
     root.attrib["viewBox"] = "0 0 %s %s" % (root.attrib["width"], root.attrib["height"])
@@ -128,19 +126,16 @@ def format_inline_qr(data):
     root.attrib["preserveAspectRatio"] = "none"
 
     return Markup(etree.tostring(root).decode("utf-8"))
+
+
+def format_inline_qr(data):
+    qrfile = make_qrfile(data, kind="svg", svgclass=None)
+    return qrfile_to_svg(qrfile)
 
 
 def format_inline_epc_qr(payment):
     qrfile = make_epc_qrfile(payment, kind="svg", svgclass=None)
-
-    root = etree.XML(qrfile.read())
-    # Allow us to scale it with CSS
-    root.attrib["viewBox"] = "0 0 %s %s" % (root.attrib["width"], root.attrib["height"])
-    del root.attrib["width"]
-    del root.attrib["height"]
-    root.attrib["preserveAspectRatio"] = "none"
-
-    return Markup(etree.tostring(root).decode("utf-8"))
+    return qrfile_to_svg(qrfile)
 
 
 def make_qr_png(url):

--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -119,8 +119,7 @@ def make_epc_qrfile(payment, **kwargs):
 
 
 def qrfile_to_svg(qrfile):
-    root = etree.XML(qrfile.read())
-    return Markup(etree.tostring(root).decode("utf-8"))
+    return Markup(qrfile.getvalue().decode("utf-8"))
 
 
 def format_inline_qr(data):

--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -123,12 +123,28 @@ def qrfile_to_svg(qrfile):
 
 
 def format_inline_qr(data):
-    qrfile = make_qrfile(data, kind="svg", svgclass=None, omitsize=True)
+    qrfile = make_qrfile(
+        data,
+        kind="svg",
+        svgclass=None,
+        omitsize=True,
+        xmldecl=False,
+        svgns=False,
+        nl=False,
+    )
     return qrfile_to_svg(qrfile)
 
 
 def format_inline_epc_qr(payment):
-    qrfile = make_epc_qrfile(payment, kind="svg", svgclass=None, omitsize=True)
+    qrfile = make_epc_qrfile(
+        payment,
+        kind="svg",
+        svgclass=None,
+        omitsize=True,
+        xmldecl=False,
+        svgns=False,
+        nl=False,
+    )
     return qrfile_to_svg(qrfile)
 
 

--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -120,22 +120,16 @@ def make_epc_qrfile(payment, **kwargs):
 
 def qrfile_to_svg(qrfile):
     root = etree.XML(qrfile.read())
-    # Allow us to scale it with CSS
-    root.attrib["viewBox"] = "0 0 %s %s" % (root.attrib["width"], root.attrib["height"])
-    del root.attrib["width"]
-    del root.attrib["height"]
-    root.attrib["preserveAspectRatio"] = "none"
-
     return Markup(etree.tostring(root).decode("utf-8"))
 
 
 def format_inline_qr(data):
-    qrfile = make_qrfile(data, kind="svg", svgclass=None)
+    qrfile = make_qrfile(data, kind="svg", svgclass=None, omitsize=True)
     return qrfile_to_svg(qrfile)
 
 
 def format_inline_epc_qr(payment):
-    qrfile = make_epc_qrfile(payment, kind="svg", svgclass=None)
+    qrfile = make_epc_qrfile(payment, kind="svg", svgclass=None, omitsize=True)
     return qrfile_to_svg(qrfile)
 
 

--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -110,7 +110,7 @@ def make_epc_qrfile(payment, **kwargs):
         name="Electromagnetic Field Ltd",
         iban="GB21BARC20716472954433",
         amount=payment.amount,
-        reference=payment.bankref,
+        text=payment.bankref,
     )
     qr.save(qrfile, **kwargs)
     qrfile.seek(0)

--- a/apps/payments/invoice.py
+++ b/apps/payments/invoice.py
@@ -18,7 +18,7 @@ from sqlalchemy.sql.functions import func
 from wtforms import TextAreaField, SubmitField
 
 from main import external_url, db
-from ..common.receipt import render_pdf
+from ..common.receipt import format_inline_epc_qr, render_pdf
 from models.product import Product, PriceTier
 from models.purchase import Purchase
 from ..common.forms import Form
@@ -113,6 +113,7 @@ def invoice(payment_id, fmt=None):
         vat=vat,
         edit_company=edit_company,
         invoice_number=invoice_number,
+        format_inline_epc_qr=format_inline_epc_qr,
     )
 
     url = external_url(".invoice", payment_id=payment_id)

--- a/templates/payments/_invoicehelpers.html
+++ b/templates/payments/_invoicehelpers.html
@@ -1,0 +1,7 @@
+{% macro render_epc_qr(payment) %}
+<div class="qrcode">
+  {# Preferred format is SVG because it scales #}
+  {{ format_inline_epc_qr(payment) }}
+</div>
+{% endmacro -%}
+

--- a/templates/payments/invoice.html
+++ b/templates/payments/invoice.html
@@ -1,3 +1,5 @@
+{% from 'payments/_invoicehelpers.html' import render_epc_qr with context %}
+
 {% extends 'base.html' %}
 
 {% block css %}
@@ -171,6 +173,9 @@
     <dt>IBAN</dt><dd>GB21 BARC 2071 6472 9544 33</dd>
     {% endif %}
     <dt>Reference</dt><dd>{{ payment.bankref | bankref }}</dd>
+    {% if payment.provider == 'banktransfer' and payment.currency == 'EUR' and payment.state == 'inprogress' %}
+    <dt>EPC QR Code</dt><dd>{{ render_epc_qr(payment) }}</dd>
+    {% endif %}
   </dl>
   {% elif payment.provider == 'gocardless' and payment.state != 'inprogress' %}
   <div>Payment to be made online at {{ external_url('payments.gocardless_tryagain', payment_id=payment.id) }}</div>

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -7,13 +7,15 @@ from pyzbar.pyzbar import decode
 
 from apps.common.receipt import (
     format_inline_qr,
+    format_inline_epc_qr,
     make_qr_png,
 )
+from models.payment import BankPayment
 
 
 def render_svg(svg):
-    # pyzbar fails to decode qr codes under 52x52
-    png = svg2png(bytestring=svg, parent_width=64, parent_height=64)
+    # pyzbar fails to decode qr codes under 52x52 and epc qr codes under 72x72
+    png = svg2png(bytestring=svg, parent_width=80, parent_height=80)
     png_file = io.BytesIO(png)
     image = Image.open(png_file)
 
@@ -35,6 +37,31 @@ def test_format_inline_qr():
     assert len(decoded) == 1
     content = decoded[0].data.decode("utf-8")
     assert content == data
+
+
+def test_format_inline_epc_qr():
+    payment = BankPayment(currency="EUR", amount=10)
+
+    qr_inline = format_inline_epc_qr(payment)
+    qr_image = render_svg(qr_inline)
+
+    expected = [
+        "BCD",
+        "002",
+        "2",
+        "SCT",
+        "",
+        "Electromagnetic Field Ltd",
+        "GB21BARC20716472954433",
+        "EUR10",
+        "",
+        payment.bankref,
+    ]
+
+    decoded = decode(qr_image)
+    assert len(decoded) == 1
+    content = decoded[0].data.decode("utf-8")
+    assert content == "\n".join(expected)
 
 
 def test_make_qr_png():

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -48,7 +48,7 @@ def test_format_inline_epc_qr():
     expected = [
         "BCD",
         "002",
-        "2",
+        "1",
         "SCT",
         "",
         "Electromagnetic Field Ltd",


### PR DESCRIPTION
This change updates the invoice rendering code to include an [EPC QR code](https://www.europeanpaymentscouncil.eu/sites/default/files/KB/files/EPC069-12%20v2.1%20Quick%20Response%20Code%20-%20Guidelines%20to%20Enable%20the%20Data%20Capture%20for%20the%20Initiation%20of%20a%20SCT.pdf) as [rendered by segno](https://segno.readthedocs.io/en/stable/epc-qrcodes.html) for the purposes of fast and accurate payment submission.

These codes are rendered into invoices only when payment is pending as a bank transfer in Euros (EUR).

![image](https://user-images.githubusercontent.com/55152140/74944300-bd822900-53ed-11ea-9dee-fbed023b0a34.png)

Todo list:

- [x] Remove code duplication between QR & EPC QR generation
- [ ] Test with Transferwise account details
- [ ] Reduce left-padding around QR code?
- [x] Add test coverage

Resolves #841 

[epc_structured_reference.pdf](https://github.com/emfcamp/Website/files/4231247/epc_structured_reference.pdf)