### PR TITLE
Dynamically display the next sales date

### DIFF
--- a/apps/base/__init__.py
+++ b/apps/base/__init__.py
@@ -17,6 +17,7 @@ from flask import (
 
 from main import cache
 from ..common import feature_flag
+from models import next_sales_date, next_sales_date_timezone
 from models.product import Product, ProductView, ProductViewProduct, PriceTier
 from models.site_state import get_site_state
 
@@ -47,7 +48,7 @@ def main():
     if app.config.get("DEBUG"):
         state = request.args.get("site_state", state)
 
-    return render_template("home/%s.html" % state, full_price=get_full_price())
+    return render_template("home/%s.html" % state, full_price=get_full_price(), next_sales_date=next_sales_date(), next_sales_date_timezone=next_sales_date_timezone())
 
 
 @base.route("/", methods=["POST"])

--- a/apps/tickets/choose.py
+++ b/apps/tickets/choose.py
@@ -13,6 +13,7 @@ from flask_mail import Message
 from sqlalchemy.orm import joinedload
 
 from main import db, mail
+from models import next_sales_date, next_sales_date_timezone
 from models.exc import CapacityException
 from models.product import PriceTier, ProductViewProduct, Product, Voucher
 from models.basket import Basket
@@ -126,7 +127,7 @@ def main(flow="main"):
 
     form.currency_code.data = get_user_currency()
     return render_template(
-        "tickets/choose.html", form=form, flow=flow, view=view, available=available
+        "tickets/choose.html", form=form, flow=flow, view=view, available=available, next_sales_date=next_sales_date(), next_sales_date_timezone=next_sales_date_timezone()
     )
 
 

--- a/config/development-example.cfg
+++ b/config/development-example.cfg
@@ -70,5 +70,6 @@ CHECKIN_BASE = "https://checkin.emf.camp/"
 RESERVE_LIST_TICKET_LINK = "fill in a reserve list ticket link"
 
 SALES_START = "2019-10-01 19:00:00"
+SALES_DATES = ("2020-02-19 19:00:00", "2020-03-14 11:00:00", "2020-04-02 21:00:00")
 EVENT_START = "2020-07-24 13:00:00"
 EVENT_END = "2020-07-26 23:00:00"

--- a/templates/home/sales_block.html
+++ b/templates/home/sales_block.html
@@ -6,7 +6,7 @@
 
 {% elif SALES_STATE == 'unavailable' %}
   {# FIXDATE #}
-  <p class="emphasis">The next public ticket sale will be on Wednesday 19 February at 19:00 GMT.</p>
+  <p class="emphasis">The next public ticket sale will be on {{next_sales_date.strftime("%A %-d %B at %H:%M")}} {{ next_sales_date_timezone }}.</p>
   <p>Keep an eye on
       <a href="https://www.twitter.com/emfcamp">Twitter</a> or join our
       mailing list for more updates:

--- a/templates/purchase/tickets.html
+++ b/templates/purchase/tickets.html
@@ -1,7 +1,11 @@
 {% if not available %}
 <div class="well">
-  <p class="emphasis">There are no tickets currently available. The next public ticket sale will be on
-    Wednesday 19 February at 19:00 GMT.</p>
+  <p class="emphasis">
+    There are no tickets currently available.
+    {% if next_sales_date %}
+      The next public ticket sale will be on {{next_sales_date.strftime("%A %-d %B at %H:%M")}} {{ next_sales_date_timezone }}.
+    {% endif %}
+  </p>
   <p>Please follow us <a href="https://twitter.com/emfcamp">on Twitter</a> or
   join our mailing list to be notified when more tickets are on sale:</p>
   {% include "home/_mailchimp_form.html" %}


### PR DESCRIPTION
I'm in no way proud of the hack to get the timezone into the date, but it works for this very specific purpose, and I was disappearing into a rabbit hole of Python timezone documentation.

Requires `SALES_DATES` to be added to the config as shown in `development-example.cfg`