### PR TITLE
Admin page: Associate 'Manual tasks' block with GoCardless

### DIFF
--- a/templates/admin/payment-config-verify.html
+++ b/templates/admin/payment-config-verify.html
@@ -23,17 +23,18 @@
 {% endfor %}
 </ul>
 
+<h4>Manual tasks:</h4>
+<ul>
+  <li>Ensure a webhook is configured for the URL <code>{{external_url('payments.gocardless_webhook')}}</code> and the secret matches the <code>GOCARDLESS_WEBHOOK_SECRET</code> config variable.</li>
+  <li>Ensure bank statement reference in GoCardless settings is set correctly (it has the year in).</li>
+</ul>
+
 <h3>TransferWise</h3>
 <ul>
 {% for success, message in transferwise %}
   <li>{% if success %}✅{% else %}❌<strong>{% endif %}
       {{message}}{% if not success %}</strong>{% endif %}</li>
 {% endfor %}
-</ul>
-<h4>Manual tasks:</h4>
-<ul>
-  <li>Ensure a webhook is configured for the URL <code>{{external_url('payments.gocardless_webhook')}}</code> and the secret matches the <code>GOCARDLESS_WEBHOOK_SECRET</code> config variable.</li>
-  <li>Ensure bank statement reference in GoCardless settings is set correctly (it has the year in).</li>
 </ul>
 
 <h3>Bank Transfer</h3>


### PR DESCRIPTION
Relocate the manual tasks which relate to GoCardless to sit underneath the relevant heading on the `payment-config-verify` admin page.  This is to reduce a little bit of visual confusion and felt worthwhile during some page edits in other branches.