### PR TITLE
Tests: don't create fixtures or run the web app

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,9 @@
-# Override for CI to pass coveralls variables through
 version: "3.7"
 services:
   app:
     environment:
+      SETTINGS_FILE: ./config/test.cfg
+      TESTS_ONLY: 1
+      # Override for CI to pass coveralls variables through
       COVERALLS_REPO_TOKEN: ${COVERALLS_REPO_TOKEN}
       COVERALLS_GIT_BRANCH: ${COVERALLS_GIT_BRANCH}

--- a/docker/dev_entrypoint.sh
+++ b/docker/dev_entrypoint.sh
@@ -25,6 +25,13 @@ fi;
 
 echo "Initialising database..."
 poetry run flask db upgrade
+
+if [ ! -z "$TESTS_ONLY" ]; then
+  # This container is just being used to host the tests
+  sleep infinity
+  exit 1
+fi
+
 echo "Creating base data..."
 poetry run flask create_perms
 poetry run flask createbankaccounts


### PR DESCRIPTION
To stop the tests silently failing after an undefined number of seconds if the web app or fixtures themselves throw errors.