### PR TITLE
Add a note about docker compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Join with IRCCloud: <a href="https://www.irccloud.com/invite?channel=%23emfcamp-
 
 ## Getting Started
 
-The only supported way to develop is to use [Docker](https://docker.com/) with Docker Compose (on Linux you'll need to install [Docker Compose](https://docs.docker.com/compose/install/) separately).
+The only supported way to develop is to use [Docker](https://docker.com/) with Docker Compose (on Linux you'll need to install [Docker Compose](https://docs.docker.com/compose/install/) separately) version 1.24.0 or newer.
 
 [Lazydocker](https://github.com/jesseduffield/lazydocker) is highly recommended
 to monitor the containers.


### PR DESCRIPTION
Add mention of which version of Docker Compose is needed in the README. Spent a bit of time trying to debug an issue that turned out to be too old a version.