### PR TITLE
Make it so under 18s can sign up for volunteer roles (fixes #934)

### DIFF
--- a/templates/volunteer/role.html
+++ b/templates/volunteer/role.html
@@ -27,7 +27,17 @@
         {{ description }}
     {% endif %}
 
-    {% if current_volunteer.over_18 %}
+    {% if role.over_18_only %}
+        {% if current_volunteer.over_18 %}
+            <form class="form-inline" method="POST">
+                <input id="csrf_token" name=_csrf_token type=hidden value="{{ csrf_token() }}">
+
+                <button class="btn btn-primary debounce">
+                    Sign up for this role
+                </button>
+            </form>
+        {% endif %}
+    {% else %}
         <form class="form-inline" method="POST">
             <input id="csrf_token" name=_csrf_token type=hidden value="{{ csrf_token() }}">
 


### PR DESCRIPTION
As above, and per issue #934, this should ensure that over 18s can sign up for all roles, and under 18s can only sign up for roles that are applicable to them.