### PR TITLE
Add telephone number validation to user-facing inputs

### DIFF
--- a/apps/common/forms.py
+++ b/apps/common/forms.py
@@ -8,6 +8,7 @@ from wtforms.widgets.html5 import EmailInput
 from wtforms.compat import string_types
 from wtforms.widgets.core import html_params
 from email_validator import validate_email, EmailNotValidError
+import re
 
 
 class EmailField(StringField):
@@ -55,6 +56,19 @@ class TelInput(Input):
 
 class TelField(StringField):
     widget = TelInput()
+
+    def pre_validate(form, field):
+        if re.search(r"^\s*$", form.data):
+            # Allow empty field or only whitespace in field, this can be handled by Required()
+            return
+
+        if not re.search(r"^\+?[0-9 \-]+$", form.data):
+            raise ValidationError(
+                "A telephone number may only contain numbers, spaces or dashes."
+            )
+
+        if not 7 < len(form.data) < 21:
+            raise ValidationError("A telephone number must be between 8 and 20 digits.")
 
 
 class JSONField(StringField):

--- a/apps/volunteer/sign_up.py
+++ b/apps/volunteer/sign_up.py
@@ -30,7 +30,7 @@ class VolunteerSignUpForm(Form):
     nickname = StringField("Name", [Required()])
     volunteer_email = StringField("Email", [Email(), Required()])
     over_18 = BooleanField("I'm at least 18 years old")
-    volunteer_phone = TelField("Phone", [Required()])
+    volunteer_phone = TelField("Phone")
     arrival = SelectField("Arrival")
     departure = SelectField("Departure")
     allow_comms = BooleanField(

--- a/apps/volunteer/sign_up.py
+++ b/apps/volunteer/sign_up.py
@@ -22,7 +22,7 @@ from models.volunteer import Volunteer as VolunteerUser
 from models.user import User
 
 from . import volunteer, v_user_required
-from ..common.forms import Form
+from ..common.forms import Form, TelField
 from ..common import create_current_user, feature_flag
 
 
@@ -30,7 +30,7 @@ class VolunteerSignUpForm(Form):
     nickname = StringField("Name", [Required()])
     volunteer_email = StringField("Email", [Email(), Required()])
     over_18 = BooleanField("I'm at least 18 years old")
-    volunteer_phone = StringField("Phone", [Required()])
+    volunteer_phone = TelField("Phone", [Required()])
     arrival = SelectField("Arrival")
     departure = SelectField("Departure")
     allow_comms = BooleanField(


### PR DESCRIPTION
As per an earlier discussion in #emfcamp-web, user facing telephone input fields were not validated and the user could enter any value, even alphabetical characters.

I have modified the existing `TelField()` class to add basic validation. It will allow a `+` at the start of the input to permit international numbers, and beyond that only checks that the input is numeric (whitespace allowed) and between 10 and 15 characters.

I updated the volunteer sign up form to use `TelField()` instead of `StringField()`. I chose not to update the CfP admin portal to use `TelField()` as it seems that administrators should be able to do as they please. I couldn't find any other instances of telephone input besides the three listed in this paragraph.