### PR TITLE
Basic implemention of in-house bar training (in-progress)

### DIFF
--- a/apps/volunteer/bar_training.py
+++ b/apps/volunteer/bar_training.py
@@ -1,143 +1,184 @@
-from urllib.parse import urlencode
-from hashlib import sha256
-import hmac
 import json
-
-from flask import request, current_app as app, abort, render_template
-from flask_login import current_user
-import requests
-
-from main import csrf, db, external_url
-from models import event_year
-from models.user import User
-from models.volunteer.role import Role
-from models.volunteer.volunteer import Volunteer
+import os
+import markdown
 from . import v_user_required, volunteer
 
+from flask_login import current_user
+from flask import render_template, flash, redirect
+from flask import url_for, current_app as app, abort
+from main import db
 
-TYPEFORM_BASE = "https://api.typeform.com"
+from wtforms import SubmitField, RadioField, FormField, FieldList
+from wtforms.validators import InputRequired, ValidationError
+from ..common.forms import Form, HiddenIntegerField
+
+from models.volunteer.role import Role
+from models.volunteer.volunteer import Volunteer
 
 
-@volunteer.route("/bar-training")
+# TODO: Make template (bar-training.html) pretty
+# TODO: Paginate template using JavaScript
+# TODO: Add proper validation (using JavaScript?), at a minimum ensure that
+# the user can clearly see which questions are invalid.
+# TODO: Implement Jinja tags in Markdown content so that static images can be served
+
+
+def build_questions(training_json):
+    """
+    Assigns specific IDs to questions and answers so that we can determine which
+    questions need re-adding to WTForms when a POST submission is sent. Also helps
+    us determine the answers. WTForms is a bit of a nightmare with dynamic forms!
+    """
+    questions = {}
+    page_num = 1
+    question_id = 0
+    answer_id = 0
+
+    for page in training_json["pages"]:
+        for question in page["questions"]:
+            questions[question_id] = {}
+            questions[question_id]["question"] = question["question"]
+            questions[question_id]["page"] = page_num
+            questions[question_id]["choices"] = []
+
+            for a in question["answers"]:
+                answer = (
+                    str(answer_id),
+                    a["answer"],
+                )  # RadioField requires a tuple with (id, text)
+
+                if a["correct"]:
+                    questions[question_id]["correct"] = answer_id
+                answer_id += 1
+                questions[question_id]["choices"].append(answer)
+
+            question_id += 1
+
+        page_num += 1
+
+    return questions
+
+
+def load_training_json(path):
+    file_path = os.path.abspath(os.path.join(__file__, "..", "..", "..", path))
+    if not os.path.exists(file_path):
+        return None
+
+    return json.load(open(file_path, "r"))
+
+
+def load_training_markdown(path):
+    """
+    Takes a file path for a Markdown file (relative to project root)
+    and returns the HTML (from Markdown) for that file.
+    """
+    file_path = os.path.abspath(os.path.join(__file__, "..", "..", "..", path))
+    if not os.path.exists(file_path):
+        return None
+
+    with open(file_path) as md_file:
+        md_content = md_file.read()
+
+    return markdown.markdown(md_content)
+
+
+def check_answer_correct(form, question):
+    if not question_data[form.question_id.data]["correct"] == int(question.data):
+        raise ValidationError("This answer is not correct.")
+
+
+class QuestionForm(Form):
+    question_id = HiddenIntegerField("Answer ID")
+    answers = RadioField(
+        "Answers",
+        [InputRequired(message="This question is unanswered."), check_answer_correct],
+    )
+
+
+class TrainingForm(Form):
+    questions = FieldList(FormField(QuestionForm))
+    submit = SubmitField("Complete training")
+
+    def add_questions(self, question_data):
+        """
+        Check if a specific question already exists in the form (such as in a POST
+        request) and if not, add the question to the form. Then iterate through
+        all questions and enrich the question data.
+        """
+
+        # Check if the question already exists in the form, if not add it
+        for qid in question_data.keys():
+            question_exists = False
+            for q in self.questions:
+                if q.question_id.data == qid:
+                    question_exists = True
+
+            if not question_exists:
+                self.questions.append_entry()
+                self.questions[-1].question_id.data = qid
+
+        # We should now have a form with the right amount of questions, add data to them
+        for q in self.questions:
+            data = question_data[int(q.question_id.data)]
+            q.answers.choices = data["choices"]
+            q.question = data["question"]
+            q.page = data["page"]
+
+
+@volunteer.route("/bar-training", methods=["GET", "POST"])
 @v_user_required
 def bar_training():
     bar = Role.query.filter_by(name="Bar").one()
     volunteer = Volunteer.get_for_user(current_user)
-
     trained = bar in volunteer.trained_roles
 
-    params = {"token": current_user.bar_training_token, "name": current_user.name}
-    url = app.config["BAR_TRAINING_FORM"] + "?" + urlencode(params)
-    return render_template(
-        "volunteer/training/bar-training.html", url=url, trained=trained
-    )
-
-
-@volunteer.route("/bar-training/check")
-@v_user_required
-def bar_training_check():
-    volunteer = Volunteer.get_for_user(current_user)
-    bar = Role.query.filter_by(name="Bar").one()
-    return json.dumps(bar in volunteer.trained_roles)
-
-
-@csrf.exempt
-@volunteer.route("/bar-training/webhook/<tag>", methods=["GET", "POST"])
-def bar_training_webhook(tag):
-    if not hmac.compare_digest(get_auth_tag(), tag):
-        abort(401)
-
-    if request.method == "GET":
-        return ("", 200)
-
-    app.logger.debug("Bar training webhook called with %s", request.data)
-    json_data = json.loads(request.data.decode("utf-8"))
-    if json_data.get("event_type") != "form_response":
-        # Don't care about this event type
-        return ("", 200)
-
-    response = json_data["form_response"]
-    form_id = response["form_id"]
-    if form_id != app.config["BAR_TRAINING_FORM"].rsplit("/", 1)[1]:
-        return ("", 200)
-
-    app.logger.info("Received form with hidden parameters %s", response["hidden"])
-    token = response["hidden"].get("token")
-    if not token:
-        return ("", 200)
-    user = User.get_by_bar_training_token(token)
-
-    if not user.volunteer:
-        return ("", 200)
-
-    assert response["definition"]["id"] == form_id
-
-    # response['calculated']['score'] is the number of answered questions
-    # the "correct" answers have just been implemented as flow redirects
-
-    answers = response["answers"]
-    actual_answers = {
-        "IqrW3FemheSD": "More than 0.5%",
-        "tp0LL9XwEu41": "Protection of the environment",
-        "tb9aGkLhJCJ0": "In day-to-day control of a particular licensed premises",
-        "yB9izDMlu8N6": "No",
-        "xy8AJqMKZAOH": "PASS hologram",
-        "YHOch7ksAKax": "£90",
-        "YX1fDJQOKOmQ": "60 minutes",
-        "z5RRMJhZiYJG": "Details of the licensable activities to be held at the premises",
-        "bmfSCzY4xQHe": "Outside the times stated in the premises licence",
-        "ODyrmHU3XR2f": "2",
-        "lToop6d3nun2": "18",
-        "iZeKUVN9n33f": "Staggering or an inability to walk",
-    }
-    answers = {}
-    for answer in response["answers"]:
-        if answer["type"] == "choice":
-            answers[answer["field"]["id"]] = answer["choice"]["label"]
-
-    correct_answers = [id for id, a in answers.items() if actual_answers[id] == a]
-
-    if len(correct_answers) == len(actual_answers):
-        app.logger.info("%s passed the training", user)
-        bar = Role.query.filter_by(name="Bar").one()
-        bar.trained_volunteers.append(Volunteer.get_for_user(user))
-        db.session.commit()
-
-    app.logger.info("%s failed the training", user)
-
-    return ("", 200)
-
-
-def get_auth_tag():
-    tag = "emf-{}-".format(event_year())
-    msg = b"bar-training-" + tag.encode("utf-8")
-    tag += hmac.new(
-        app.config["SECRET_KEY"].encode("utf-8"), msg, digestmod=sha256
-    ).hexdigest()
-    return tag
-
-
-def typeform_headers(**kwargs):
-    kwargs.update({"Authorization": "Bearer " + app.config["BAR_TRAINING_TOKEN"]})
-    return kwargs
-
-
-def create_bar_training_webhook():
-    # This doesn't work, despite documentation and consistent return value
-
-    _, form_id = app.config["BAR_TRAINING_FORM"].rsplit("/", 1)
-
-    webhook_url = TYPEFORM_BASE + "/forms/{}/webhooks/{}".format(
-        form_id, get_auth_tag()
-    )
-    response = requests.get(webhook_url, headers=typeform_headers())
-    if response.status_code == 404:
-        url = external_url("volunteer.bar_training_webhook", tag=get_auth_tag())
-        args = {"url": url, "enabled": True}
-        response = requests.put(
-            webhook_url, json.dumps(args), headers=typeform_headers()
+    training_json = load_training_json(app.config.get("BAR_TRAINING_JSON"))
+    if training_json is None:  # Error loading training data
+        app.logger.error(
+            f"Bar training failed -- unable to load JSON: '{app.config.get('BAR_TRAINING_JSON')}'"
         )
+        abort(404)
 
-    response.raise_for_status()
-    if response.status_code == 200:
-        return response.json()["id"]
+    global question_data  # Otherwise we can't access it in the form validator
+    question_data = build_questions(training_json)
+    form = TrainingForm()
+    form.add_questions(question_data)
+
+    if form.validate_on_submit():
+        if trained:  # The user might be re-doing the traing, no need to rewrite DB
+            flash("You answered all the questions correctly!")
+        else:
+            app.logger.info(f"{str(current_user)} passed the bar training.")
+            bar.trained_volunteers.append(volunteer)
+            db.session.commit()
+            flash("Your completion of bar training has been saved.")
+        return redirect(url_for(".bar_training"))
+
+    # The template takes a list of pages which it will build sequentially, start
+    # building this list now.
+    pages = []
+    page_num = 0
+
+    for json_page in training_json["pages"]:
+        page = {}
+        page_num += 1
+        page["number"] = page_num
+        page["content"] = load_training_markdown(json_page["content"])
+
+        if page["content"] is None:
+            app.logger.error(
+                f"Bar training failed -- unable to load Markdown: '{json_page['content']}'"
+            )
+            abort(404)
+
+        page["questions"] = json_page["questions"]
+        pages.append(page)
+
+    return render_template(
+        "volunteer/training/bar-training.html",
+        trained=trained,
+        form=form,
+        pages=pages,
+        last_page=len(pages),
+        volunteer=volunteer,
+    )

--- a/config/development-example.cfg
+++ b/config/development-example.cfg
@@ -52,7 +52,6 @@ RADIO = False
 ISSUE_TICKETS = False
 VOLUNTEER_SITE = True
 VOLUNTEERS_SIGNUP = True
-BAR_TRAINING_FORM = True
 # Blueprint toggles are feature flags
 ARRIVALS_SITE = False
 
@@ -83,3 +82,5 @@ EVENT_END = "2020-07-26 23:00:00"
 # Presented to volunteers when signing up
 ARRIVAL_DAYS = 2
 DEPARTURE_DAYS = 2
+
+BAR_TRAINING_JSON = "models/fixtures/training/bar.json"

--- a/models/fixtures/training/bar-training-age-restrictions.md
+++ b/models/fixtures/training/bar-training-age-restrictions.md
@@ -1,0 +1,28 @@
+## Age restrictions
+Although there are some exceptions to the following, they don’t apply at EMF so we won’t be covering them.
+
+It is illegal:
+
+- to sell alcohol to anyone under the age of 18
+- to sell tobacco to anyone under the age of 18 (we have to mention this, even though we don’t sell tobacco)
+- for an adult to buy or attempt to buy alcohol on behalf of someone under 18
+- for someone under 18 to buy alcohol, attempt to buy alcohol or to be sold alcohol
+- for someone under 18 to drink alcohol in licensed premises
+
+Since it is very difficult to tell if someone is over 18 (are they 17 and 51 weeks?) we have an **Age Verification Policy​** that everyone working on the bar must follow. It is informally referred to as “Challenge 25”. 
+
+### Age verification policy
+It is our policy that every person attempting to buy alcohol who appears to be under the age of 25 and who has not already provided proof of age to the person serving them will be required to prove that they are aged 18 or over.
+
+The following documents will be accepted as proof:
+
+- Passport
+- Full, or provisional, UK or EU photocard driving license
+- Proof of age card bearing the PASS hologram
+- National identity card issued by an EU member state, such as Norway, Iceland, Liechtenstein or Switzerland
+- Biometric immigration document
+
+In the event that proof of age is requested and is not provided, the sale of alcohol will not go ahead and the person serving the alcohol will make an entry in the refusals log. The decision to refuse service is solely that of the person serving and this decision will not be overturned by any other member of staff.
+
+### Penalties
+Licensing authorities take sales to people who are underage very seriously. ​**Police officers** may send people who are obviously underage into licensed premises to attempt to purchase alcohol; if they are successful in doing so the police can issue an on-the-spot fine of ​£90​. In theory we could be fined up to £20,000 if this happens multiple times. This will affect our ability to get a licence for EMF in the future, so please be careful!

--- a/models/fixtures/training/bar-training-alcohol.md
+++ b/models/fixtures/training/bar-training-alcohol.md
@@ -1,0 +1,16 @@
+## Alcohol
+Alcohol, also known by its chemical name ethanol, is a psychoactive substance that is the active ingredient in drinks such as beer, wine, and distilled spirits. Thanks, [​Wikipedia​](https://en.wikipedia.org/wiki/Alcohol_(drug))!
+
+The consumption of alcohol has a clear impact on public health as it is a causal factor in more than 60 medical conditions, including: mouth, throat, stomach, liver and breast cancers; high blood pressure, cirrhosis of the liver; and depression and must therefore be consumed responsibly. Alcohol consumption is influenced by availability, so the availability of alcohol is restricted by a licensing system.
+
+In the UK, the alcoholic content of a drink is generally shown as "alcohol by volume", abbreviated as ABV. This is defined as the number of millilitres (mL) of pure ethanol present in 100 mL of drink at 20°C. (Thanks again, [​Wikipedia](https://en.wikipedia.org/wiki/Alcohol_by_volume)​! The page on this is worth a read; it’s not a simple subject.) For our purposes, the amount of alcohol in a drink is the amount of drink (eg. 25ml) multiplied by the ABV (eg. 40%, or 0.4).
+
+The law defines an "alcoholic drink" as any drink with more than **​0.5% ABV**​; sales of these drinks are restricted and can only be made in accordance with a licence. (Aside: "alcohol-free" drinks contain less than 0.05% ABV; this figure isn’t relevant to licensing.)
+
+A ​**unit**​ of alcohol in the UK is 10 millilitres. The official advice is that a typical healthy adult can metabolise (break down) **​one unit of alcohol per hour​**, and that to keep health risks from alcohol low it is safest not to regularly drink more than ​**14 units per week​**.
+  
+Examples of alcohol content of common drinks:
+
+- A pint of 4% ABV beer: 2.3 units
+- A 25ml measure of 40% ABV spirit: 1 unit
+- A 175ml glass of 12% ABV wine: 2.1 units

--- a/models/fixtures/training/bar-training-drunkenness.md
+++ b/models/fixtures/training/bar-training-drunkenness.md
@@ -1,0 +1,4 @@
+## Drunkenness
+It’s against the law to serve alcohol to anyone who is drunk; doing so can lead to fines of up to **​£1,000**​. Unfortunately, the law doesn’t define drunkenness and there is no consistent system of enforcement.
+
+For EMF, we will treat someone as drunk if we believe drinking has made them ​**a danger to themselves or others​**, for example if they are staggering or showing an inability to walk. If you believe someone is drunk, then you must not serve them or anybody else who you believe is trying to obtain alcohol for them.

--- a/models/fixtures/training/bar-training-intro.md
+++ b/models/fixtures/training/bar-training-intro.md
@@ -1,0 +1,10 @@
+## Bar training
+Thank you for your interest in volunteering behind the bar at EMF Camp!
+
+As a member of bar staff, EMF Camp will provide you with the following course of online training in order to ensure that you have the knowledge required to serve alcohol safely and in compliance with UK licensing laws. 
+
+On this page you will be presented with the information you are required to know, and you will then be asked some simple multiple choice questions to confirm your understanding of the material. Once you have completed the training then you will be eligible to sign up for bar shifts in the volunteer schedule.
+
+Please ensure you have enough time to complete the training before attempting it - it should take no longer than 15 minutes. Read through each section carefully and then answer any questions - not all of the training sections have questions attached to them. Once you have completed all of the questions, you can submit your answers for validation and any incorrect answers will be clearly highlighted for you to review and correct.
+
+If you are struggling with the training, or require additional assistance to complete it, do not hesitate to contact us via email at [volunteers@emfcamp.org](mailto:volunteers@emfcamp.org). 

--- a/models/fixtures/training/bar-training-licensing.md
+++ b/models/fixtures/training/bar-training-licensing.md
@@ -1,0 +1,26 @@
+## Licensing in England and Wales
+In England and Wales there are four ​licensing objectives:​
+
+1. The prevention of crime and disorder
+2. Public safety
+3. The prevention of public nuisance
+4. The protection of children from harm
+
+(Scotland has five, and six are proposed for Northern Ireland, but that doesn’t matter right now...)
+
+Licensing regulates these four activities:
+
+1. the retail sale of alcohol
+2. the supply of alcohol in clubs
+3. the provision of late night refreshment
+4. the provision of regulated entertainment
+
+We’re only covering the first of these in this training course.
+
+Licensing is split into two parts: the premises where alcohol is sold, and the people who authorise the sales.
+
+The **​Premises Licence**​ describes the physical location where licensable activities will take place, and contains the **​operating schedule**​ which lists all of the **licensable activities​** that may take place and the ​times​ at which these are allowed. The operating schedule also contains conditions which must be complied with that are agreed between the licensing authority and the premises licence holder and have the force of law.
+
+A **​Personal Licence**​ enables its holder to authorise the sale of alcohol on licensed premises; every sale of alcohol must be authorised by a personal licence holder. This doesn’t have to be done in person: generally, at each premises there will be a list of people to whom a personal licence holder has delegated this authority. By completing this training, you are joining this list of people at EMF.
+
+If a premises licence includes the sale of alcohol as one of the licensable activities, it must specify a single personal licence holder as the ​**Designated Premises Supervisor**​. This is the person who is in ​**day-to-day control**​ of the premises: the person who sets the rules and policies and ensures they are followed. They don’t have to be present all of the time: they are allowed to go on holiday, for example! They are the first point of contact for the licensing authorities at the premises.

--- a/models/fixtures/training/bar-training-safety.md
+++ b/models/fixtures/training/bar-training-safety.md
@@ -1,0 +1,23 @@
+## Safety
+### Health and safety
+
+- You should wear suitable footwear behind the bar: the floor may be wet, and there is a possibility that things might be dropped on it.
+- Although we’re not using much glass, there will be some glass bottles and it is possible that these might become broken. Don’t attempt to clear up broken glass by hand: use the dustpan and brush and make sure the broken glass goes in the bottle bin.
+- Report accidents or near-misses, bad practices and potential hazards to the bar organisers.
+- You are responsible for your own safety and that of everyone else. If you are unsure about something, seek advice.
+
+### Food safety
+The area behind the bar is a food preparation area. While you are in this area there are some things you must do and some things you must not do.
+
+#### Things you must do
+
+- Wash your hands when entering the bar area.
+- Wash your hands after wiping down the bar.
+- Cuts and grazes, etc. must be covered using waterproof plasters.
+
+#### Things you must not do
+
+- You must not smoke or take snuff.
+- **You must not consume food while behind the bar.**​ (This is the rule that we have to remind people of most often.)
+- You must not put your fingers inside the glass or on the rim of the glass while pouring into it and handing it to the customer.
+- You must not use a glass to scoop up ice from the ice bucket. Always use the scoop or tongs provided.

--- a/models/fixtures/training/bar-training-weights-and-measures.md
+++ b/models/fixtures/training/bar-training-weights-and-measures.md
@@ -1,0 +1,6 @@
+## Weights and measures
+Beer is served in multiples of half a pint. The pint and half pint glasses we use are CE marked and legal to serve into directly.
+
+Wine is served in measures of 125ml, 175ml and 250ml. The glasses aren’t marked for this, so we have CE marked 125ml and 175ml thimble measures behind the bar: fill the measure to the brim and tip it into the glass.
+
+We have chosen to serve spirits in multiples of 25ml. We have CE marked thimble measures and optics. (It isn’t legal to mix 25ml and 35ml measures on the same site.)

--- a/models/fixtures/training/bar.json
+++ b/models/fixtures/training/bar.json
@@ -1,10 +1,17 @@
 {
-  "training": [
+  "role": "Bar",
+  "pass_auto": true,
+  "pass_mark": 100,
+  "url": "https://usercontent.irccloud-cdn.com/file/3LYiO0Er/Training%20outline.pdf",
+  "pages": [
     {
-      "role": "Bar",
-      "pass_auto": true,
-      "pass_mark": 100,
-      "url": "https://usercontent.irccloud-cdn.com/file/3LYiO0Er/Training%20outline.pdf",
+      "page": 1,
+      "content": "models/fixtures/training/bar-training-intro.md",
+      "questions": []
+    },
+    {
+      "page": 2,
+      "content": "models/fixtures/training/bar-training-alcohol.md",
       "questions": [
         {
           "question": "At what percentage of abv is a drink legally classed as alcohol?",
@@ -56,7 +63,13 @@
               "correct": false
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "page": 3,
+      "content": "models/fixtures/training/bar-training-licensing.md",
+      "questions": [
         {
           "question": "Which of these is <strong>not</strong> a licensing objective?",
           "answers": [
@@ -124,7 +137,13 @@
               "correct": false
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "page": 4,
+      "content": "models/fixtures/training/bar-training-age-restrictions.md",
+      "questions": [
         {
           "question": "A proof of age document is reliable if it has",
           "answers": [
@@ -188,7 +207,13 @@
               "correct": false
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "page": 5,
+      "content": "models/fixtures/training/bar-training-drunkenness.md",
+      "questions": [
         {
           "question": "Which of these is considered a common sign of drunkenness?",
           "answers": [
@@ -207,6 +232,16 @@
           ]
         }
       ]
+    },
+    {
+      "page": 6,
+      "content": "models/fixtures/training/bar-training-safety.md",
+      "questions": []
+    },
+    {
+      "page": 7,
+      "content": "models/fixtures/training/bar-training-weights-and-measures.md",
+      "questions": []
     }
   ]
 }

--- a/templates/volunteer/training/bar-training.html
+++ b/templates/volunteer/training/bar-training.html
@@ -7,67 +7,88 @@
 {% block body %}
 {% include "volunteer/_nav.html" %}
 
-<div id="training" class="{% if trained %}hidden{% endif %}" style="height: 780px">
-    <p></p>
-    <p></p>
-    Please wait while we load the training...
-</div>
+{% if not volunteer.over_18 %}
 
-<div id="waiting" style="display: none">
-    <p></p>
-    <p></p>
-    Please wait while we check your answers. If you don't see any progress,
-    please <a href="{{ url_for('.bar_training') }}">try again</a>.
-</div>
-
-<div id="complete" class="{% if not trained %}hidden{% endif %}">
-<h2>Training complete</h2>
+<h2>Bar training</h2>
 <p>
-    You have completed your training for the bar. You can now <a href="{{ url_for('volunteer.schedule') }}">sign up</a> for bar shifts!
+    Thank you for your interest in working behind the bar. Unfortunately, this role is only available to those
+    over the age of 18. If your age setting is incorrect, please update it on the 
+    <a href="{{ url_for('volunteer.account') }}">volunteer account page</a>.
 </p>
-</div>
 
+{% else %}
 
-{% endblock body %}
+{% if trained %}
 
-{% block foot %}
-<script src="https://embed.typeform.com/embed.js"></script>
-<script type="text/javascript">
-$(() => {
-  var attempts = 0;
-  function check_bar_trained() {
-    fetch({{ url_for('volunteer.bar_training_check')|tojson }})
-    .then(response => response.json())
-    .then(function(result) {
-      if (result) {
-        $('#training').show();
-        $('#waiting').hide();
-      } else {
-        attempts++;
-        if (attempts < 10) setTimeout(check_bar_trained, 2000);
-      }
-    });
-  }
+<h2>You have completed this training!</h2>
+<p>
+    <strong>Congratulations - you have completed your training for working in the bar.</strong>
+    You can now <a href="{{ url_for('volunteer.schedule') }}">sign up</a> for bar shifts.
+</p>
+<p>
+    You are welcome to review the training material again to boost your knowledge, or even
+    complete the questions again - however you are not required to.
+</p>
+<hr />
 
-  function show_training() {
-    typeformEmbed.makeWidget(
-      $('#training')[0],
-      {{ url|tojson }},
-      {
-        hideHeaders: true,
-        hideFooter: true,
-        onSubmit: () => {
-          $('#training').hide();
-          $('#waiting').show();
-          check_bar_trained();
-        }
-      }
-    )
-    $('#training').show();
-    $('#waiting').hide();
-  }
+{% endif %}
 
-  show_training();
-});
-</script>
+<form method="post">
+    {% if form.errors %}
+        <div class="alert alert-warning">Some of your answers are incorrect or incomplete, please review them below.</div>
+    {% endif %}
+
+    {% for page in pages %}
+        <div id="page-{{ page['number'] }}" class="paged-content">
+            {% if page['number'] != 1 %}<hr />{% endif %}
+
+            {{ page.content|safe }}
+
+            {% if page.questions %}
+                <h3>Questions</h3>
+                {% for q in form.questions %}
+                    {% if page['number'] == q.page %}
+
+                        {% if q.answers.errors %}
+                            <p>
+                                <mark>
+                                    {{q.question_id.data + 1}}. {{ q.question|safe }}
+                                    <strong class="pull-right" style="color: red">{{ ', '.join(q.answers.errors) }}</strong>
+                                </mark>
+                            </p>
+                        {% else %}
+                            <p>{{q.question_id.data + 1}}. {{ q.question|safe }}</p>
+                        {% endif %}
+
+                        {{ q.answers(class_="no-list-style") }}
+                        {{ q.hidden_tag_without('csrf_token') }}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+
+            {% if page['number'] == last_page %}
+                {{ form.hidden_tag() }}
+                {{ form.submit(class_="btn btn-primary") }}
+            {% endif %}
+
+        </div>
+    {% endfor %}
+</form>
+
+<script>$('html, body').animate({ scrollTop: 0 }, 'fast');</script>
+<style type="text/css">
+label {
+    font-weight: normal;
+}
+
+.no-list-style li{ 
+    list-style-type: none;
+}
+</style>
+{% endif %}
+
 {% endblock %}
+
+{% block footer %}
+{% endblock %}
+


### PR DESCRIPTION
Issue ref #867.

I've been working on this a bit over the past few days (with help from @idnorton), and I won't have time to look at it again for a little while, so I thought it might be good to leave here for review. 

I've implemented an in-house mechanism for completing the bar training. It is fully working, tested and functional, although it is a bit rough around the edges at the moment. It:

- Imports questions and answers from JSON
- Imports training data from Markdown files
- Renders the data in order - educational material, then sections on that material, then the next educational material, etc.
- Highlights incorrect answers or unfilled answers
- Saves successful completion to the database
- Allows users to re-do the training for reference if they wish
- Prevents under 18s from accessing the training

Features that could be added:

- At the moment, all the content is displayed on one page. I don't actually think it looks *too* bad, but could be improved by paginating it in JavaScript.
- JavaScript validation could be added - although again the experience without it isn't terrible.
- UI could probably be generally improved even without pagination - front end isn't my thing.
- Implement a way to reference static material from the markdown files to enable some images to be included (or just host the images on a domain that won't change and include them as hardcoded HTML)

Welcome any feedback/comments/requested changes.
