### PR TITLE
Add pre-commit hook to prevent commits to master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,9 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
+
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ['--branch', 'master']


### PR DESCRIPTION
Following on from an oops moment, add pre-commit hook to prevent accidental commits to master.

This is bypassed using `git commit -n` if required.