### PR TITLE
Fix data: EMF 2016 did not last for two years

### DIFF
--- a/exports/2016/event.json
+++ b/exports/2016/event.json
@@ -1,6 +1,6 @@
 {
 	"start_date": "2016-08-05",
-	"end_date": "2018-08-07",
+	"end_date": "2016-08-07",
 	"location": {
 		"name": "Loseley Park",
 		"locality": "Guildford",


### PR DESCRIPTION
This should fix [this page](https://www.emfcamp.org/schedule/2016).