### PR TITLE
Volunteer roles

### DIFF
--- a/apps/base/about.py
+++ b/apps/base/about.py
@@ -69,6 +69,11 @@ def volunteering():
     return render_template("about/volunteering.html")
 
 
+@base.route("/about/volunteer-roles")
+def volunteer_roles():
+    return render_template("about/volunteer-roles.html")
+
+
 @base.route("/about/what_to_bring")
 def what_to_bring():
     return render_template("about/what-to-bring.html")

--- a/templates/_nav.html
+++ b/templates/_nav.html
@@ -35,6 +35,10 @@
                 <li role="presentation">
                     <a role="menuitem" href="{{ url_for('volunteer.main') }}">Volunteer</a>
                 </li>
+            {% else %}
+                <li role="presentation">
+                    <a role="menuitem" href="{{ url_for('base.volunteering') }}">Volunteer</a>
+                </li>
             {% endif %}
             {% if feature_enabled('CFP') and not feature_enabled('CFP_CLOSED') %}
                 <li role="presentation">

--- a/templates/_nav.html
+++ b/templates/_nav.html
@@ -17,9 +17,6 @@
             <li role="presentation">
                 <a role="menuitem" href="{{ url_for('base.about') }}">About</a>
             </li>
-            <li role="presentation">
-                <a role="menuitem" href="{{ url_for('base.emp') }}">EMP</a>
-            </li>
             {% if SITE_STATE == 'sales' and SALES_STATE in ['available', 'unavailable'] %}
                 <li role="presentation">
                     <a role="menuitem" href="{{ url_for('tickets.main') }}">Tickets</a>

--- a/templates/about/volunteer-roles.html
+++ b/templates/about/volunteer-roles.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+{% block title %}Volunteering{% endblock %}
+{% block secondary_nav %}
+  {% include "about/_nav.html" %}
+{% endblock %}
+{% set main_class = 'about' %}
+{% block body %}
+<h2 id="volunteer-roles">Pre-event Volunteer Roles</h2>
+<div class="intro-text">
+  <p>We're looking for people to fill the roles listed below, please keep in mind that all of them require a time commitment ahead of the event.</p>
+  <p>Some of these are entirely new roles for 2022, while others are making sure we have dedicated people focused on specific roles, rather than people taking on multiple roles.</p>
+  <p>If any of these roles are of interest to you please send an email to <a href="mailto:volunteers@emfcamp.org">volunteers@emfcamp.org</a> and introduce yourself.</p>
+</div>
+
+<h3>First Aid Team Lead</h3>
+<p>The first aid team ensure that medical help is available to everyone on site, from buildup all the way to tear down.</p>
+<p>We're looking for someone to lead this team, ensuring all relevant policies are in place, and preparing the volunteer rota for first aid during the event, and booking any suppliers required such as paramedics.</p>
+<p>The team lead is also responsible for working with the core orga team to ensure the event management plan properly covers any medical provisions required.</p>
+
+<h3>Content Team Lead + Second</h3>
+<p>Ahead of the event the content team are responsible for making sure there's something to do once you arrive at EMF, organising the talks, workshops, and installations around the site. They manage the CfP process, contact any invited speakers, and making sure any special requirements are dealt with.</p>
+<p>Once on site, they make sure speakers are on the right stage at the right time, and manage the stage teams and heralds.</p>
+<p>We're looking for both a team lead, and for someone to act as their second. In the run up to the event you should be able to commit to about 20 hours a month, particularly around the CfP opening and closing.</p>
+
+<h3>Music Team Lead + Second</h3>
+<p>Working with the content team the music team arrange artists to play on one of the main stages in the evening, and DJs for the Cybar dance floor.</p>
+<p>You'll need to commit about 20 hours a month ahead of the event to find, contact, and book artists.</p>
+
+<h3>Workshops Co-ordinator</h3>
+<p>Working with the content team the workshops coordinator will organise which wrokshops are running at which locations, that all required equipment has been bought or hired, and that it's available in the right place.</p>
+
+<h3>Volunteer Catering Manager</h3>
+<p>The catering manager will work with the chefs to make sure all the required equipment has been hired or bought ahead of time, organise food deliveries, and manage the kitchen team rota during the event.</p>
+
+<h3>Design Team</h3>
+<p>In addition to the flags and beermats that may be familiar from the last EMF, for 2022 the new Design team will coordinate with other volunteers across EMF to help ensure the festival looks as cohesive and beautiful as possible, from the website to the wristbands to backgrounds for the stages.</p>
+<p>We’re absolutely delighted to welcome logistics-minded volunteers who can wrangle suppliers and hands-on folks who can help build physical items.</p>
+
+<h4>Graphic Designer</h4>
+<p>We have a really exciting marine theme this year, including a corrupted/overgrown logo variant and deep sea luminescence colour palette.  We also have a CG artist who has offered to ‘grow’ assets for us.</p>
+<p>We have a comprehensive plan for what needs to be created, but to stop Morag trying to design everything themselves we’re looking for people with skills in vector artwork and manipulation, desktop publishing and a tiny bit of web magic.</p>
+<p>We would like help to create:</p>
+<ul>
+  <li>Assets such as logo colour variations, background graphics</li>
+  <li>A matching style guide</li>
+  <li>A cosmetic update for the website to fit this year’s theme</li>
+  <li>Swag including stickers, tshirts, lanyards, wristbands</li>
+  <li>Printed materials such as the attendee booklet and postcards</li>
+  <li>Stage flats to act as a background for speakers</li>
+  <li>Video cards/graphic inserts for talk streams/recordings</li>
+  <li>Signage</li>
+  <li>Other Cool Things!</li>
+</ul>
+<p>This is quite a broad remit, and we’d welcome your help for whatever parts of it match your skills and interests.  There’s so much to do and about 6 months to do it in, but you’d be welcomed with a shower of concept sketches and the most comprehensive planning and support we can manage.  We’re doing our best to set everyone up to succeed, and to have a great time volunteering.</p> 
+
+<h3>Cybar Team</h3>
+<p>The team who built Null Sector in 2018 are doing something else this year, and looking for people to make it even better. All these roles will be working with the team to build a consistent look and feel for the area.</p>
+
+<h4>Graphic Designer</h4>
+<p>Someone to take charge of the visual aspects of the area and make sure the set is authentic by providing consistent signage, posters, logos, videos etc.</p>
+
+<h4>Sound Designer</h4>
+<p>A sound designer to work on soundscapes and spot sound effects.</p>
+
+<h4>Copy/story Writer</h4>
+<p>A storyteller working with the wider team on the story of the area.</p>
+
+<h4>Bar Manager (Cybar)</h4>
+<p>A manager to liase between the bar and Cybar teams to make sure the bar is staffed, stocked, and can run throughout the event.</p>
+
+<h3>Tent Team</h3>
+<p>A new team this year, the Tent Team will be helping people who are new to the event, and particularly those who aren't used to camping.</p>
+
+<h4>Tent Team Organiser</h4>
+<p>Organise and recruit team members for on-site work helping others erect tents and get comforatble.</p>
+
+<h4>Camping Gear Librarian</h4>
+<p>Organise asking for loanable camping gear donations, manage check-in and out of items, and return at end of event. This aims to reduce single-use camping gear purchases and improve the experience for people who don't camp regularly (including several diversity groups).</p>
+{% endblock %}
+

--- a/templates/about/volunteering.html
+++ b/templates/about/volunteering.html
@@ -7,35 +7,41 @@
 {% block body %}
 <h2 id="volunteering-at-emf">Volunteering at EMF</h2>
 <div class="intro-text">
-<p>EMF is a non-profit event, entirely organised by volunteers. Nobody is paid to work on EMF, and everyone who attends (with very few exceptions<a href="#footnote">*</a>) pays for their own ticket. This includes the core organisers.</p>
-<p>We’d like everyone to consider volunteering to help the event run smoothly, even if it is only for an hour or two.</p>
+  <p>EMF is a non-profit event, entirely organised by volunteers. Nobody is paid to work on EMF, and everyone who attends (with very few exceptions<a href="#footnote">*</a>) pays for their own ticket. This includes the core organisers.</p>
+  <p>We’d like everyone to consider volunteering to help the event run smoothly, even if it is only for an hour or two.</p>
 </div>
+
 <h3 id="getting-involved">Getting Involved</h3>
 <p>The EMF organisation is split into teams which organise different aspects of the event. Each team has a lead and a deputy who are responsible for keeping track of work and coordinating with other teams.</p>
 <p>To get involved:</p>
 <ul>
-<li>Look at the <a href="https://wiki.emfcamp.org/wiki/Teams">teams page</a> on the wiki to find a team you're interested in.</li>
-<li>Join the <a href="https://lists.emfcamp.org/listinfo/general">general mailing list</a>, which is the main, low-traffic email list we use for announcing volunteer work.</li>
-<li>Get in touch and say you'd like to volunteer, either on <a href="https://wiki.emfcamp.org/wiki/IRC">IRC</a>, or by emailing <a href="mailto:contact@emfcamp.org">contact@emfcamp.org</a>.</li>
+  <li>Look at the <a href="https://wiki.emfcamp.org/wiki/Teams">teams page</a> on the wiki to find a team you're interested in.</li>
+  <li>Join the <a href="https://lists.emfcamp.org/listinfo/general">general mailing list</a>, which is the main, low-traffic email list we use for announcing volunteer work.</li>
+  <li>Get in touch and say you'd like to volunteer, either on <a href="https://wiki.emfcamp.org/wiki/IRC">IRC</a>, or by emailing <a href="mailto:contact@emfcamp.org">contact@emfcamp.org</a>.</li>
 </ul>
 <p>Please remember that everyone is a volunteer so you may not get an immediate response. Some teams are a lot more popular than others so may not need your assistance, but many others will be grateful for your help.</p>
+
 <h3 id="how-to-volunteer">How volunteering works</h3>
 <p>We understand that everyone who helps with EMF has other commitments and we plan ahead to cope with this.</p>
 <p>We have two golden rules for you:</p>
 <ul>
-<li>Don’t over-commit yourself</li>
-<li>Tell us if you can’t get something done</li>
+  <li>Don’t over-commit yourself</li>
+  <li>Tell us if you can’t get something done</li>
 </ul>
 <p>Nobody will criticise you if you can't do something, and telling us quickly means we can handle the situation.</p>
+
 <h3 id="volunteering-before-the-event">Volunteering before the event</h3>
 <p>Running an event like EMF requires a huge amount of planning to make sure the event runs smoothly. This starts a year or more in advance.</p>
+
 <h3 id="helping-out-during-the-event">Helping out during the event</h3>
 <p>During the event, there are plenty of roles which need to be filled, from construction to cooking for volunteers.</p>
 <p>Closer to the event, you’ll be able to log in to the volunteer system which allows you to sign up for shifts. Volunteers who complete a shift will receive a delicious free meal from our volunteer kitchen.</p>
+
 <h3 id="helping-with-setup-teardown">Helping with setup &amp; teardown</h3>
 <p>We’re grateful for help setting up the event, and especially tearing it down.</p>
 <p>If you want to help with either setup or teardown you will need a ticket to EMF and <u>permission from us to turn up early or stay after the event ends</u>. We do not allow under-18's on site during setup or teardown without explicit permission.</p>
 <p>During setup and teardown, EMF is a construction site and we are liable for your safety. If you don’t follow instructions we will be forced to remove you from site, for everyone's safety.</p>
 <p>If you’re on site for setup/teardown you have to help with everything - not just what you’re interested in. There’s plenty of lifting and shifting that requiring a degree of physical fitness and mobility. If you’re not actively helping, we will ask you to leave.</p>
-<small id="footnote">* We provide free tickets for qualified First Aid staff who must work a minimum of three eight-hour shifts during the event.</small></p>
+
+<p><small id="footnote">* We provide free tickets for qualified First Aid staff who must work a minimum of three eight-hour shifts during the event.</small></p>
 {% endblock %}

--- a/templates/about/volunteering.html
+++ b/templates/about/volunteering.html
@@ -11,16 +11,6 @@
   <p>We’d like everyone to consider volunteering to help the event run smoothly, even if it is only for an hour or two.</p>
 </div>
 
-<h3 id="getting-involved">Getting Involved</h3>
-<p>The EMF organisation is split into teams which organise different aspects of the event. Each team has a lead and a deputy who are responsible for keeping track of work and coordinating with other teams.</p>
-<p>To get involved:</p>
-<ul>
-  <li>Look at the <a href="https://wiki.emfcamp.org/wiki/Teams">teams page</a> on the wiki to find a team you're interested in.</li>
-  <li>Join the <a href="https://lists.emfcamp.org/listinfo/general">general mailing list</a>, which is the main, low-traffic email list we use for announcing volunteer work.</li>
-  <li>Get in touch and say you'd like to volunteer, either on <a href="https://wiki.emfcamp.org/wiki/IRC">IRC</a>, or by emailing <a href="mailto:contact@emfcamp.org">contact@emfcamp.org</a>.</li>
-</ul>
-<p>Please remember that everyone is a volunteer so you may not get an immediate response. Some teams are a lot more popular than others so may not need your assistance, but many others will be grateful for your help.</p>
-
 <h3 id="how-to-volunteer">How volunteering works</h3>
 <p>We understand that everyone who helps with EMF has other commitments and we plan ahead to cope with this.</p>
 <p>We have two golden rules for you:</p>
@@ -32,6 +22,10 @@
 
 <h3 id="volunteering-before-the-event">Volunteering before the event</h3>
 <p>Running an event like EMF requires a huge amount of planning to make sure the event runs smoothly. This starts a year or more in advance.</p>
+<p>We're looking for a small number of people to take responsibility for planning aspects of the event, and to help with design. If this is something that interests you take a look at the list of roles we're looking to fill.</p>
+<div class="list-group">
+  <a href="/about/volunteer-roles" class="list-group-item">Open Roles</a>
+</div>
 
 <h3 id="helping-out-during-the-event">Helping out during the event</h3>
 <p>During the event, there are plenty of roles which need to be filled, from construction to cooking for volunteers.</p>

--- a/templates/about/volunteering.html
+++ b/templates/about/volunteering.html
@@ -9,6 +9,7 @@
 <div class="intro-text">
   <p>EMF is a non-profit event, entirely organised by volunteers. Nobody is paid to work on EMF, and everyone who attends (with very few exceptions<a href="#footnote">*</a>) pays for their own ticket. This includes the core organisers.</p>
   <p>We’d like everyone to consider volunteering to help the event run smoothly, even if it is only for an hour or two.</p>
+  <p><small id="footnote">* We provide free tickets for qualified First Aid staff who must work a minimum of three eight-hour shifts during the event.</small></p>
 </div>
 
 <h3 id="how-to-volunteer">How volunteering works</h3>
@@ -24,7 +25,7 @@
 <p>Running an event like EMF requires a huge amount of planning to make sure the event runs smoothly. This starts a year or more in advance.</p>
 <p>We're looking for a small number of people to take responsibility for planning aspects of the event, and to help with design. If this is something that interests you take a look at the list of roles we're looking to fill.</p>
 <div class="list-group">
-  <a href="/about/volunteer-roles" class="list-group-item">Open Roles</a>
+  <a href="{{ url_for('base.volunteer_roles') }}" class="list-group-item">Open Roles</a>
 </div>
 
 <h3 id="helping-out-during-the-event">Helping out during the event</h3>
@@ -36,6 +37,4 @@
 <p>If you want to help with either setup or teardown you will need a ticket to EMF and <u>permission from us to turn up early or stay after the event ends</u>. We do not allow under-18's on site during setup or teardown without explicit permission.</p>
 <p>During setup and teardown, EMF is a construction site and we are liable for your safety. If you don’t follow instructions we will be forced to remove you from site, for everyone's safety.</p>
 <p>If you’re on site for setup/teardown you have to help with everything - not just what you’re interested in. There’s plenty of lifting and shifting that requiring a degree of physical fitness and mobility. If you’re not actively helping, we will ask you to leave.</p>
-
-<p><small id="footnote">* We provide free tickets for qualified First Aid staff who must work a minimum of three eight-hour shifts during the event.</small></p>
 {% endblock %}


### PR DESCRIPTION
Updates the volunteering page to mention we're looking for people now, adds a page to describe the roles that we're recruiting for, and has the volunteer header link go to the /about/volunteering if the full volunteer management system isn't active.