### PR TITLE
Add a help page to the cfp-review stuff

### DIFF
--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -75,11 +75,13 @@ def main():
 
     abort(404)
 
+
 @cfp_review.route("help")
 def help():
     if current_user.is_anonymous:
         return redirect(url_for("users.login", next=url_for(".main")))
     return render_template("cfp_review/help.html")
+
 
 def bool_qs(val):
     # Explicit true/false values are better than the implicit notset=&set=anything that bool does

--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -75,6 +75,11 @@ def main():
 
     abort(404)
 
+@cfp_review.route("help")
+def help():
+    if current_user.is_anonymous:
+        return redirect(url_for("users.login", next=url_for(".main")))
+    return render_template("cfp_review/help.html")
 
 def bool_qs(val):
     # Explicit true/false values are better than the implicit notset=&set=anything that bool does

--- a/templates/cfp_review/_nav.html
+++ b/templates/cfp_review/_nav.html
@@ -76,6 +76,7 @@
                 {{ menuitem("Clashfinder", ".clashfinder") }}
             </ul>
         </li>
+        {{ menuitem("Help", ".help") }}
     {% endif %}
     {# Hide these menus from admin as they're in the misc dropdown #}
     {% if current_user.has_permission('cfp_anonymiser') and not current_user.has_permission('cfp_admin') %}

--- a/templates/cfp_review/help.html
+++ b/templates/cfp_review/help.html
@@ -5,7 +5,7 @@
 <p>This covers technical notes on how the CfP system works. If you're after guidance on how the CfP process works as a submitter you want <a href="{{ url_for('cfp.guidance') }}">the guidance page.</a>
 <p>It mostly covers the process for submitted talks. Installations, workshops, youth workshops etc. etc. are organised by the relevant teams and are reviewed by them.
 
-<h2>The process (for talks)</h2>
+<h2 id="how-to-review">The process (for talks)</h2>
 <ol>
   <li>Submitted
   <li>Content check
@@ -26,12 +26,12 @@
   <ul>
   <li>Vote (the three green buttons). The options are:
     <ol>
-      <li>"Bad" something you don't think we should host that you wouldn't go to.
-      <li>"OK" something interesting but not amazing that you might go to.
-      <li>"Excellent" something amazing that you would definitely go to
+      <li><button class="btn btn-success btn-sm">Bad</button> something you don't think we should host that you wouldn't go to.
+      <li><button class="btn btn-success btn-sm">OK</button> something interesting but not amazing that you might go to.
+      <li><button class="btn btn-success btn-sm">Excellent</button> something amazing that you would definitely go to
     </ol>
-  <li>"I can identify the submitter (do not vote)" (the red button) If you think you can identify the submitter please write who you think it is in the message box and click this button. This proposal will no longer be shown to you.
-  <li>"I need more information" (the blue button) - if something in the proposal is unclear you can request clarification by filling in the message box and clicking the button.
+  <li><button class="btn btn-danger btn-sm">I can identify the submitter (do not vote)</button> If you think you can identify the submitter please write who you think it is in the message box and click this button. This proposal will no longer be shown to you.
+  <li><button class="btn btn-info btn-sm">I need more information</button> - if something in the proposal is unclear you can request clarification by filling in the message box and clicking the button.
 </ul>
 <p>While you're reviewing you'll be auto-advanced through this list so it's recommended to start from the top but not essential.
 
@@ -41,7 +41,25 @@
 <h3>Feedback/Questions</h3>
 <p>One final note: if you have any problems, comments and/or suggestions please <a href="mailto:{{ config['CONTENT_EMAIL'][1] }}">email</a>
 
-<h2>How to anonymise</h2>
-<p>The key
+<hr>
+
+<h2 id="how-to-anonymise">How to anonymise</h2>
+
+<p>There are two key things we want to know from this stage:
+
+<ol>
+  <li>Is there any identifying information?
+  <li>Does the description (once identifying information is removed) seem to give enough information to know what the talk will be about?
+</ol>
+
+<p>The most common identifying information are:
+
+<ul>
+  <li>short bios "My name is Jane and I'm...."
+  <li>social media links (e.g. Twitter, LinkedIn)
+  <li>youTube links to previous versions of the talk
+</ul>
+
+<p>If you can, feel free to delete these bits but if it'll require re-writing (and especially if it means the description stops giving enough information to answer question 2, above) click the <button class="btn btn-danger btn-sm">I cannot anonymise this proposal</button> and we'll help the submitter improve it.
 
 {% endblock %}

--- a/templates/cfp_review/help.html
+++ b/templates/cfp_review/help.html
@@ -1,0 +1,47 @@
+{% extends "cfp_review/base.html" %}
+{% block body %}
+<h1>CfP Process Help</h1>
+
+<p>This covers technical notes on how the CfP system works. If you're after guidance on how the CfP process works as a submitter you want <a href="{{ url_for('cfp.guidance') }}">the guidance page.</a>
+<p>It mostly covers the process for submitted talks. Installations, workshops, youth workshops etc. etc. are organised by the relevant teams and are reviewed by them.
+
+<h2>The process (for talks)</h2>
+<ol>
+  <li>Submitted
+  <li>Content check
+  <li>Anonimisation &amp; reviewability check
+  <li>Reviewed
+  <li>Accepted/rejected/added to next round
+  <li>Accepted talks scheduled
+</ol>
+
+<h2>How to review</h2>
+<p>The aim of this review process is to select the most interesting talks and workshops in as an un-biased a way as we can. To that end all proposals are anonymised and we do blind selection of the best proposals based on how you vote.
+<p>Proposals that are ready for you to review can be seen in the <a href="{{ url_for('.review_list') }}">review page</a>.
+<p>It is split into two lists, 'requires review' and 'previously reviewed'.
+<p>The order of proposals in the 'requires review' list is randomised to (hopefully) reduce first/last biasing. The order shouldn't change unless you delete your cookie.
+<p>At the bottom is a button 'show some different proposals' which will re-randomise the proposals in your 'requires review' list.
+<p>You'll see proposals in blocks of 30. You don't have to review everything but please aim to review at least 1 block of 30.
+<p>For each un-reviewed proposal you have several options:
+  <ul>
+  <li>Vote (the three green buttons). The options are:
+    <ol>
+      <li>"Bad" something you don't think we should host that you wouldn't go to.
+      <li>"OK" something interesting but not amazing that you might go to.
+      <li>"Excellent" something amazing that you would definitely go to
+    </ol>
+  <li>"I can identify the submitter (do not vote)" (the red button) If you think you can identify the submitter please write who you think it is in the message box and click this button. This proposal will no longer be shown to you.
+  <li>"I need more information" (the blue button) - if something in the proposal is unclear you can request clarification by filling in the message box and clicking the button.
+</ul>
+<p>While you're reviewing you'll be auto-advanced through this list so it's recommended to start from the top but not essential.
+
+<h3>Changing your mind</h3>
+<p>If you want to change your mind you can select previous proposal from "previously reviewed" and click "I'd like to change my response".
+
+<h3>Feedback/Questions</h3>
+<p>One final note: if you have any problems, comments and/or suggestions please <a href="mailto:{{ config['CONTENT_EMAIL'][1] }}">email</a>
+
+<h2>How to anonymise</h2>
+<p>The key
+
+{% endblock %}


### PR DESCRIPTION
Mostly for reviewers but can be expanded with e.g. info on
anonymisation, and admin features later.