### PR TITLE
Clarify tickets-reminder email

### DIFF
--- a/templates/emails/tickets-reminder.txt
+++ b/templates/emails/tickets-reminder.txt
@@ -7,46 +7,12 @@ reserved for Electromagnetic Field {{ event_year }}.
 
 The tickets will expire in a few days if not paid for.
 
-If you don't want the tickets you can ignore this email. {% if payment.provider == 'banktransfer' -%} Otherwise,
+If you don't want the tickets you can ignore this email. Otherwise,
 if you wish to pay for the tickets, you can go to the EMF website:
 
   {{ external_url('users.purchases') }}
 
 and complete the payment process.
-
-{%- endif -%}
-{%- if payment.provider == "banktransfer" -%}
-
-{% if payment.currency == 'GBP' %}
-
-You can pay by CHAPS/Faster Payments, or by cash at your bank.
-
-We will use the reference to identify the payment as yours, so please
-ensure it's included in full.
-
-Bank:           Barclays
-Payee:          EMF Festivals Ltd
-Sort code:      {{ account.sort_code | sort_code }}
-Account number: {{ account.acct_id }}
-Amount:         {{ payment.amount | price('GBP') }}
-Reference:      {{ payment.bankref | bankref }}
-
-(Don't worry if the payee name doesn't quite fit)
-
-{% else %}
-
-You can pay into our {{ account.currency }} bank account:
-
-Payee:     EMF Festivals Ltd
-SWIFT:     {{ account.swift }}
-IBAN:      {{ account.iban | iban }}
-Amount:    {{ payment.amount | price(payment.currency) }}
-Reference: {{ payment.bankref | bankref }}
-
-(Don't worry if the payee name doesn't quite fit)
-
-{% endif %}
-{%- endif -%}
 
 Your tickets are:
 


### PR DESCRIPTION
This was referencing our old banking details. Now we just want to direct
users to the purchases page to check out.

I've removed the logic around payment type as this flow should work even
if they checked out with stripe and hit problems (i.e. they should go
to the purchases page and checkout again).

closes #1022 