### PR TITLE
Add link to wiki for lift sharing

### DIFF
--- a/templates/about/getting-there.html
+++ b/templates/about/getting-there.html
@@ -20,7 +20,7 @@
 
 <p>Once you're near the site, you'll see yellow temporary road signs for EMF - follow these and ignore your sat nav if it tells you differently.</p>
 
-<p>We encourage attendees to carpool where possible. There's a [lift sharing page](https://wiki.emfcamp.org/wiki/Location/Lift_sharing) on the wiki to find other people on the same route.</p>
+<p>We encourage attendees to carpool where possible. There's a <a href="https://wiki.emfcamp.org/wiki/Location/Lift_sharing">lift sharing page</a> on the wiki to find other people on the same route.</p>
 
 <h4>Electric Vehicles</h4>
 <p>Owing to the increased price of providing electricity at EMF, and the increasing number of electric

--- a/templates/about/getting-there.html
+++ b/templates/about/getting-there.html
@@ -20,6 +20,8 @@
 
 <p>Once you're near the site, you'll see yellow temporary road signs for EMF - follow these and ignore your sat nav if it tells you differently.</p>
 
+<p>We encourage attendees to carpool where possible. There's a [lift sharing page](https://wiki.emfcamp.org/wiki/Location/Lift_sharing) on the wiki to find other people on the same route.</p>
+
 <h4>Electric Vehicles</h4>
 <p>Owing to the increased price of providing electricity at EMF, and the increasing number of electric
     vehicles, we do not plan to provide generally-available electric vehicle charging at EMF 2022.


### PR DESCRIPTION
Adding a link to https://wiki.emfcamp.org/wiki/Location/Lift_sharing to the public page given that https://wiki.emfcamp.org/wiki/Location isn't linked to from the wiki itself.