### PR TITLE
Cfp tweaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         additional_dependencies:
           - flake8-print
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: git@github.com:pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: no-commit-to-branch

--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -764,10 +764,20 @@ def close_round():
             if "min_votes" in session:
                 del session["min_votes"]
 
+    # Find proposals where the submitter has already had an accepted proposal
+    # or another proposal in this list
+    duplicates = {}
+    for (prop, _) in proposals:
+        if prop.user.proposals.count() > 1:
+            # Only add each proposal once
+            if prop.user not in duplicates:
+                duplicates[prop.user] = prop.user.proposals
+
     return render_template(
         "cfp_review/close-round.html",
         form=form,
         proposals=proposals,
+        duplicates=duplicates,
         preview=preview,
         min_votes=session.get("min_votes"),
     )

--- a/logger.py
+++ b/logger.py
@@ -2,6 +2,7 @@ from enum import Enum
 import logging
 import os
 
+
 class AnsiColors(Enum):
     RESET = 0
     BOLD = 1
@@ -19,16 +20,22 @@ class AnsiColors(Enum):
 
     @classmethod
     def sgr(cls, *codes):
-        return AnsiColors.CSI.value + ";".join([str(AnsiColors[c].value) for c in codes]) + "m"
+        return (
+            AnsiColors.CSI.value
+            + ";".join([str(AnsiColors[c].value) for c in codes])
+            + "m"
+        )
+
 
 # modified from http://plumberjack.blogspot.co.uk/2010/12/colorizing-logging-output-in-terminals.html
 
+
 class ColorizingStreamHandler(logging.StreamHandler):
     DEFAULT_COLORS = {
-        'DEBUG': 'BLUE',
-        'WARNING': 'YELLOW',
-        'ERROR': 'RED',
-        'CRITICAL': ['RED', 'BOLD'],
+        "DEBUG": "BLUE",
+        "WARNING": "YELLOW",
+        "ERROR": "RED",
+        "CRITICAL": ["RED", "BOLD"],
     }
 
     def __init__(self, stream=None, colors=None):
@@ -43,7 +50,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
                 v = [v]
             self.colors[k] = AnsiColors.sgr(*v)
 
-        self.should_colorize = self.is_tty or os.getenv('COLORIZE_LOGS') == 'always'
+        self.should_colorize = self.is_tty or os.getenv("COLORIZE_LOGS") == "always"
 
     @property
     def is_tty(self):
@@ -62,8 +69,8 @@ class ColorizingStreamHandler(logging.StreamHandler):
         color = self.colors.get(record.levelname)
         if color:
             lines = message.splitlines()
-            lines_colorized = [color + line + AnsiColors.sgr('RESET') for line in lines]
-            message = '\n'.join(lines_colorized)
+            lines_colorized = [color + line + AnsiColors.sgr("RESET") for line in lines]
+            message = "\n".join(lines_colorized)
         return message
 
     def format(self, record):

--- a/templates/cfp_review/close-round.html
+++ b/templates/cfp_review/close-round.html
@@ -13,6 +13,43 @@
         Proposals to be set as 'reviewed' are like <span class="bg-info">this.</span>
     </p>
 {% endif %}
+
+{% if duplicates %}
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h4 class="panel-title">
+            <a role="button" data-toggle="collapse" data-target="#duplicatesPanel"
+                aria-controls="duplicatesPanel" aria-expanded="true">
+                These users have other proposals
+            </a>
+        </h4>
+    </div>
+    <div class="panel-body collapse" id="duplicatesPanel">
+        <table class="table">
+            <tr>
+                <th>User</th>
+                <th>Type</th>
+                <th>State</th>
+                <th>Title</th>
+            </tr>
+            {% for (user, proposals) in duplicates.items() %}
+                <tr>
+                    <td rowspan="{{ proposals.count() }}">{{ user.name }}</td>
+                {% for prop in proposals %}
+                    {% if not loop.first %}
+                    <tr>
+                    {% endif %}
+                    <td>{{ prop.type }}</td>
+                    <td>{{ prop.state }}</td>
+                    <td><a href="{{ url_for('.update_proposal', proposal_id=prop.id) }}">{{prop.title}}</a></td>
+                </tr>
+                {% endfor %}
+            {% endfor %}
+        </table>
+    </div>
+</div>
+{% endif %}
+
 <br>
 <table class="table">
     <tr>

--- a/templates/cfp_review/rank.html
+++ b/templates/cfp_review/rank.html
@@ -72,6 +72,7 @@
 
 <table class="table">
     <tr>
+        <th></th>
         <th>Rank</th>
         <th>Type</th>
         <th>Submitter</th>
@@ -79,6 +80,7 @@
     </tr>
 {% for (prop, score) in proposals %}
     <tr {% if preview and score >= min_score %} class="info" {% endif %}>
+        <td><small>{{ loop.index }}.</small></td>
         <td>{{ score }}</td>
         <td>{{prop.human_type | capitalize}}</td>
         <td>{{prop.user.name}}</td>


### PR DESCRIPTION
close #1039 and #862 

The 'duplicate' view has been added before marking proposals as 'reviewed' (i.e the first screen of the close-round process when we set the number of votes required) and is a toggle-able panel. Currently any duplicate proposals will need to be clicked through to and resolved manually but we can automate further if need-be (e.g. a form that rejects or moves to 'manual review' for later resolution). cc @Jonty 

<img width="1327" alt="Screenshot 2022-03-22 at 23 35 01" src="https://user-images.githubusercontent.com/486265/159593388-31fea464-0399-4246-bc08-c8d9dc508006.png">

