### PR TITLE
Re-add proposals to be reviewed if not accepted

### DIFF
--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -821,6 +821,7 @@ def rank():
                         send_email_for_proposal(prop, reason="accepted")
 
                 else:
+                    prop.set_state("anonymised")
                     if form.confirm_type.data == "accepted_unaccepted":
                         send_email_for_proposal(prop, reason="still-considered")
 

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -32,7 +32,7 @@ CFP_STATES = {
     "cancelled": ["accepted", "rejected", "edit"],
     "anonymised": ["accepted", "rejected", "reviewed", "edit"],
     "anon-blocked": ["accepted", "rejected", "reviewed", "edit"],
-    "reviewed": ["accepted", "rejected", "edit"],
+    "reviewed": ["accepted", "rejected", "edit", "anonymised"],
     "manual-review": ["accepted", "rejected", "edit"],
     "accepted": ["accepted", "rejected", "finished"],
     "finished": ["rejected", "finished"],


### PR DESCRIPTION
Change the CfP system so that proposals that aren't accepted (but also not rejected, i.e. in non-final round closes) are moved back to the anonymised state so that they can be reviewed by more people.

closes #1040