### PR TITLE
Build for arm64 as well as amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ to monitor the containers.
 
 To start all containers (and rebuild any which may have changed):
 
+> [!TIP]
+> **Apple Silicon Users**
+> You'll probably want to build your own version of the base images as well, as
+> the ones we build are amd64 only, and so painfully slow on ARM devices. This
+> is unlikely to be resolved until GitHub Actions has ARM runners.
+>
+> ```sh
+> docker build -t ghcr.io/emfcamp/website-base -f ./docker/Dockerfile.base .
+> docker build -t ghcr.io/emfcamp/website-base-dev -f ./docker/Dockerfile.base-dev .
+> ```
+
 ```
 docker compose build --parallel
 docker compose up


### PR DESCRIPTION
I'm not sure whether this actually works or not, but theoretically it should result in making arm64 images available for people running on recent Apple machines rather than having to translate from amd64 which sucks up battery life at an impressive rate.

Annoyingly this isn't a complete solution as PostGIS doesn't have ARM builds on Docker Hub, but it does get us most of the way there I believe.