### PR TITLE
Update volunteer list search filter

### DIFF
--- a/apps/volunteer/admin/volunteer.py
+++ b/apps/volunteer/admin/volunteer.py
@@ -24,7 +24,7 @@ class VolunteerUserModelView(VolunteerModelView):
         "allow_comms_during_event",
         "banned",
     )
-    column_filters = ["trained_roles", "allow_comms_during_event"]
+    column_filters = ["interested_roles", "allow_comms_during_event"]
     column_list = (
         "nickname",
         "volunteer_email",


### PR DESCRIPTION
Use interested roles not trained roles. We only have one role that
requires training so we're not getting to see who's actually volunteered
to do a particular role only those trained.

Casual drive by whilst we were triaging remaining volunteer issues last
night.