### PR TITLE
Add form to change a proposal's owner

### DIFF
--- a/apps/cfp_review/forms.py
+++ b/apps/cfp_review/forms.py
@@ -14,7 +14,7 @@ from wtforms import (
 from wtforms.validators import DataRequired, Optional, NumberRange, ValidationError
 
 from models.cfp import Venue, ORDERED_STATES
-from ..common.forms import Form, HiddenIntegerField
+from ..common.forms import Form, HiddenIntegerField, EmailField
 
 from dateutil.parser import parse as parse_date
 
@@ -314,3 +314,11 @@ class SendMessageForm(Form):
 class AddNoteForm(Form):
     notes = TextAreaField("Notes")
     send = SubmitField("Update notes")
+
+
+class ChangeProposalOwner(Form):
+    user_email = EmailField(
+        "Which email address to associate this proposal with", [DataRequired()]
+    )
+    user_name = StringField("User name (if creating new user)")
+    submit = SubmitField("Change proposal owner")

--- a/templates/cfp_review/change_proposal_owner.html
+++ b/templates/cfp_review/change_proposal_owner.html
@@ -1,0 +1,21 @@
+{% from "_formhelpers.html" import render_field %}
+{% extends "cfp_review/base.html" %}
+{% block body %}
+
+{% include "cfp_review/_propsal_tabs.html" %}
+
+<h4>Change owner of {{proposal.type}} '{{ proposal.title }}'</h4>
+
+<p>Currently owned by: <a href="{{ url_for('admin.user', user_id=proposal.user_id) }}">{{ proposal.user.name }} ({{ proposal.user.email }})</a></p>
+
+<form method="post" action="{{ url_for('.proposal_change_owner', proposal_id=proposal.id) }}">
+    {{ form.hidden_tag() }}
+    {{ render_field(form.user_email, tabindex=1) }}
+    {{ render_field(form.user_name, tabindex=2) }}
+    <div class="pull-right">
+        {{ form.submit(class_='btn btn-success debounce', tabindex=3) }}
+        <a class="btn btn-default" href="{{ url_for('.update_proposal', proposal_id=proposal.id) }}">Cancel</a>
+    </div>
+</form>
+
+{% endblock %}

--- a/templates/cfp_review/update_proposal.html
+++ b/templates/cfp_review/update_proposal.html
@@ -99,6 +99,10 @@
                     class="btn btn-warning">
                 Convert proposal
             </a>
+            <a href="{{ url_for('.proposal_change_owner', proposal_id=proposal.id) }}"
+                    class="btn btn-warning">
+                Change proposal owner
+            </a>
 
             {% if next_id %}
                 <a href="{{ url_for('.update_proposal', proposal_id=next_id, **full_qs) }}"


### PR DESCRIPTION
We often end up creating submissions for invited users. At some point
it's useful to change the ownership of these back to the correct people
so we can communicate with them via the site/keep them updated on the
status of their talk slot/send them speaker tickets

(or in some rare cases they just used the wrong email address etc).

This adds a new form which makes that change.