### PR TITLE
Don't break if lightning talks exist but not set

### DIFF
--- a/models/cfp.py
+++ b/models/cfp.py
@@ -841,6 +841,8 @@ class LightningTalkProposal(Proposal):
 
         slots = {}
         for sess in sessions:
+            if not sess.allowed_times:
+                continue
             short_day = (
                 parse_date(sess.allowed_times.split(">")[0]).strftime("%a").lower()
             )


### PR DESCRIPTION
If parent talks exist for lightning talks but don't have 'allowed_times'
set it can 500 this fixes that by ignoring the problem