### PR TITLE
Village content

### DIFF
--- a/apps/schedule/attendee_content.py
+++ b/apps/schedule/attendee_content.py
@@ -47,9 +47,7 @@ class ContentForm(Form):
         venues = []
 
         if user.village:
-            private_venues = Venue.query.filter_by(
-                village_id=user.village.id
-            ).all()
+            private_venues = Venue.query.filter_by(village_id=user.village.id).all()
             venues.extend(private_venues)
 
         public_venues = Venue.query.filter_by(
@@ -112,13 +110,16 @@ def populate(proposal, form):
 @feature_flag("ATTENDEE_CONTENT")
 def attendee_content():
     # Yes, this is probably awful Python.
-    venues = [venue.id for venue in Venue.query.filter_by(village_id=current_user.village.id).all()]
+    venues = [
+        venue.id
+        for venue in Venue.query.filter_by(village_id=current_user.village.id).all()
+    ]
     content = Proposal.query.filter(
         or_(
-            and_(Proposal.user_id == current_user.id, Proposal.user_scheduled == True),
-            Proposal.scheduled_venue_id.in_(venues)
+            and_(Proposal.user_id == current_user.id, Proposal.user_scheduled is True),
+            Proposal.scheduled_venue_id.in_(venues),
         ),
-        Proposal.state.in_(["accepted", "finished"])
+        Proposal.state.in_(["accepted", "finished"]),
     ).all()
 
     form = ContentForm()
@@ -159,7 +160,10 @@ def attendee_content():
 @feature_flag("ATTENDEE_CONTENT")
 def attendee_content_edit(id):
     proposal = Proposal.query.filter_by(id=id).first()
-    if not proposal or (proposal.user_id != current_user.id and proposal.scheduled_venue.village_id != current_user.village.id):
+    if not proposal or (
+        proposal.user_id != current_user.id
+        and proposal.scheduled_venue.village_id != current_user.village.id
+    ):
         return redirect(url_for("schedule.attendee_content"))
 
     form = ContentForm(obj=proposal)

--- a/css/_base.scss
+++ b/css/_base.scss
@@ -199,6 +199,7 @@ div.micro img {
 .help-block {
   font-size: 0.9em;
   margin-bottom: 0px;
+  color: #ccc;
 }
 
 .form-horizontal .form-group .help-block {

--- a/templates/schedule/attendee_content/_form.html
+++ b/templates/schedule/attendee_content/_form.html
@@ -71,6 +71,16 @@
             {% endif %}
         </div>
     </div>
+    {% if proposal and not proposal.user_scheduled and proposal.allowed_times %}    
+        <div class="form-group">
+            <p>The person who submitted this content is available at the following times:</p>
+            <ul>
+                {% for time in proposal.allowed_times.split("\n") %}
+                    <li>{{ time }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
     <div class="form-group {%- if form.venue.errors %} has-error {%- endif %}">
         <label for="venue">Venue</label>
         <select class="form-control" id="venue" name="venue">
@@ -156,7 +166,6 @@
         {% endif %}
     </div>
     <div class="form-actions">
-    {{ form.obj }}
         <button type="submit" class="btn btn-primary">{%- if proposal %}Update{%- else %}Add{%- endif %} Content</button>
     </div>
 </form>

--- a/templates/schedule/attendee_content/index.html
+++ b/templates/schedule/attendee_content/index.html
@@ -12,6 +12,9 @@
                 <th>Location</th>
                 <th>Start</th>
                 <th>End</th>
+                {% if current_user.village %}
+                    <th>EMF<br />Scheduled</th>
+                {% endif %}
                 <th></th>
                 <th></th>
             </tr>
@@ -24,8 +27,15 @@
                 <td>{{ p.scheduled_venue.name }}</td>
                 <td>{{ p.start_date.strftime("%a %H:%M") }}</td>
                 <td>{{ p.end_date.strftime("%a %H:%M") }}</td>
+                {% if current_user.village %}
+                    <td>{{ not p.user_scheduled }}</td>
+                {% endif %}
                 <td><a href="{{ url_for("schedule.attendee_content_edit", id=p.id) }}">Edit</a></td>
-                <td><a href="{{ url_for("schedule.attendee_content_delete", id=p.id) }}">Delete</a></td>
+                <td>
+                    {% if p.user_scheduled %}
+                        <a href="{{ url_for("schedule.attendee_content_delete", id=p.id) }}">Delete</a>
+                    {% endif %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
Village members can now manage all content scheduled in venues attached to their village, rather than only content submitted by themselves. Anything scheduled by us will be highlighted as such in their schedule will be highlighted as such, and can't be entirely deleted. Speaker availability is shown when editing CFP content, but isn't currently enforced.