### PR TITLE
Allow trailing slash in cfp-review and arrivals

### DIFF
--- a/apps/arrivals.py
+++ b/apps/arrivals.py
@@ -28,7 +28,7 @@ arrivals_required = require_permission(
 )  # Decorator to require arrivals permission
 
 
-@arrivals.route("")
+@arrivals.route("/")
 @arrivals_required
 def main():
     badge = bool(session.get("badge"))

--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -65,7 +65,7 @@ from . import (
 from ..common.email import from_email
 
 
-@cfp_review.route("")
+@cfp_review.route("/")
 def main():
     if current_user.is_anonymous:
         return redirect(url_for("users.login", next=url_for(".main")))


### PR DESCRIPTION
So people don't get a 404 if they leave the slash in the url.