### PR TITLE
Fix schedule constraints for attendee content

### DIFF
--- a/apps/schedule/attendee_content.py
+++ b/apps/schedule/attendee_content.py
@@ -97,6 +97,7 @@ def populate(proposal, form):
         "{}T{}".format(form.day.data, form.scheduled_time.data.strftime("%H:%M"))
     )
     proposal.length = proposal.scheduled_duration = form.scheduled_duration.data
+    proposal.allowed_times = "{} > {}"
     proposal.attendees = form.attendees.data
     proposal.cost = proposal.published_cost = form.cost.data
     proposal.age_range = proposal.published_age_range = form.age_range.data

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -402,7 +402,6 @@ class Proposal(BaseModel):
     scheduled_venue = db.relationship(
         "Venue",
         backref="proposals",
-        cascade="all",
         primaryjoin="Venue.id == Proposal.scheduled_venue_id",
     )
     potential_venue = db.relationship(

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -614,7 +614,7 @@ class Proposal(BaseModel):
     def get_allowed_venues(self) -> list["Venue"]:
         # FIXME: this should reference a foreign key instead
         if self.user_scheduled:
-            venue_names = [self.venue.name]
+            venue_names = [self.scheduled_venue.name]
         elif self.allowed_venues:
             venue_names = [v.strip() for v in self.allowed_venues.split(",")]
         else:
@@ -682,9 +682,6 @@ class Proposal(BaseModel):
         )
 
     def get_allowed_time_periods_with_default(self):
-        if self.user_scheduled:
-            return cfp_period(self.start_date, self.end_date)
-
         allowed_time_periods = self.get_allowed_time_periods()
         if not allowed_time_periods:
             allowed_time_periods = [


### PR DESCRIPTION
* scheduled_venue, not venue for the venue constraint
* Add hard constraints on time when creating content, rather than
  trying to derive them and add further complexity to the misc
  `allowed_time_periods` methods in the scheduler.