### PR TITLE
Remove start_url which causes 404 url to be saved

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,6 @@
   "name": "Electromagnetic Field",
   "short_name": "EMF",
   "lang": "en-GB",
-  "start_url": ".",
   "display": "standalone",
   "background_color": "#171123",
   "orientation": "portrait-primary",


### PR DESCRIPTION
Per #1217, this relative url seems to cause iOS to save the static directory to the home screen - which does not work.

This _could_ be set to the root directory. But [by removing this key](https://stackoverflow.com/questions/39495573/set-start-url-in-web-app-manifest-based-on-the-url-that-was-added-to-homescreen), it will save whatever page the user was on - in my use case this would let me save the schedule to my home screen.