### PR TITLE
Enable responsive rendering for volunteer schedule table

### DIFF
--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -3,7 +3,7 @@
 
 {% macro days_shifts(day, active_day) %}
 <div role="tabpanel" class="tab-pane {%- if active_day == day %} active {%- endif %}" id="{{ day }}">
-    <table id="tab-{{ day }}" class="table table-bordered shifts-table">
+    <table id="tab-{{ day }}" class="table table-bordered table-responsive shifts-table">
         <thead><tr>
             <th>Starts</th>
             <th>Ends</th>


### PR DESCRIPTION
I haven't been able to test this locally, so perhaps it's a bad idea.  I'm available to try it out if we do merge & deploy it.

NB: The existing `table-bordered` CSS style might be obsolete.

Resolves #1235