### PR TITLE
WIP: Add structured ISO-11649 creditor references for SEPA QR codes

### DIFF
--- a/apps/payments/invoice.py
+++ b/apps/payments/invoice.py
@@ -39,7 +39,7 @@ def make_epc_qrfile(payment, **kwargs):
         name="EMF Festivals Ltd",
         iban=payment.recommended_destination.iban,
         amount=payment.amount,
-        reference=payment.bankref,
+        reference=payment.customer_reference,
         encoding=1,
     )
     qr.save(qrfile, **kwargs)

--- a/models/payment.py
+++ b/models/payment.py
@@ -323,7 +323,10 @@ class BankPayment(Payment):
         if self.currency == "EUR":
             order_id = f"{event_year()}{self.id:08d}"
             order_check_digits = mod_97_10.calc_check_digits(order_id)
-            return f"RF{order_check_digits}{order_id}"
+            assert len(order_check_digits) == 2
+            customer_reference =  f"RF{order_check_digits}{order_id}"
+            assert iso11649.validate(customer_reference)
+            return customer_reference
         else:
             return self.bankref
 

--- a/models/payment.py
+++ b/models/payment.py
@@ -322,8 +322,7 @@ class BankPayment(Payment):
         # Derive an ISO-11649 payment reference for EUR-currency payments
         if self.currency == "EUR":
             order_id = f"{event_year()}{self.id:08d}"
-            order_check_digits = mod_97_10.calc_check_digits(order_id)
-            assert len(order_check_digits) == 2
+            order_check_digits = mod_97_10.calc_check_digits(f"{order_id}RF")
             customer_reference =  f"RF{order_check_digits}{order_id}"
             assert iso11649.validate(customer_reference)
             return customer_reference

--- a/poetry.lock
+++ b/poetry.lock
@@ -2940,6 +2940,23 @@ files = [
 six = ">=1.4.0"
 
 [[package]]
+name = "python-stdnum"
+version = "1.19"
+description = "Python module to handle standardized numbers and codes"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "python-stdnum-1.19.tar.gz", hash = "sha256:133ec82f56390ea74c190569e98f2fb14b869808b1d54785708f22d0fead8b3f"},
+    {file = "python_stdnum-1.19-py2.py3-none-any.whl", hash = "sha256:1b5b401ad3f45b798b0317313b781a433f5d7a5ff2c9feb8054664f76f78644e"},
+]
+
+[package.extras]
+soap = ["zeep"]
+soap-alt = ["suds"]
+soap-fallback = ["PySimpleSOAP"]
+
+[[package]]
 name = "pytz"
 version = "2023.3.post1"
 description = "World timezone definitions, modern and historical"
@@ -4465,4 +4482,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "194bd410d1f201885f74ab3a866628d33a8d40dfc077ad9297011d46d4d4f199"
+content-hash = "7c5dbd9bd4a5921aafb0cb5f8181c193ba31d43541cd16b439834029a41d785f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pywisetransfer = "^0.3.0"
 freezegun = "^1.1.0"
 logging_tree = "^1.9"
 flask-mailman = "^0.3.0"
+python-stdnum = "^1.19"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -33,7 +33,7 @@ def test_format_inline_epc_qr(app):
         "GB47LOND11213141516171",
         "EUR10",
         "",
-        "RF53202400000001",
+        "RF84202400000001",
     ]
 
     decoded = decode(qr_image)

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -1,13 +1,24 @@
 from pyzbar.pyzbar import decode
 
 from apps.payments.invoice import format_inline_epc_qr
+from main import db
 from models.payment import BankPayment
+from models.user import User
 
 from tests._utils import render_svg
 
 
 def test_format_inline_epc_qr(app):
+    user = User("test_invoice_user@test.invalid", "test_invoice_user")
+    db.session.add(user)
+    db.session.commit()
+
     payment = BankPayment(currency="EUR", amount=10)
+    payment.user_id = user.id
+
+    # Persist the payment object so that a sequence ID is generated for it
+    db.session.add(payment)
+    db.session.commit()
 
     qr_inline = format_inline_epc_qr(payment)
     qr_image = render_svg(qr_inline)
@@ -22,7 +33,7 @@ def test_format_inline_epc_qr(app):
         "GB47LOND11213141516171",
         "EUR10",
         "",
-        payment.bankref,
+        "RF53202400000001",
     ]
 
     decoded = decode(qr_image)


### PR DESCRIPTION
The lack of structured ISO-11649 creditor references seems to be at least one potential/likely reason why many SEPA-QR enabled banking applications failed to parse our QR codes during testing in #891.

There are a few more todos here:

- [ ] Determine whether to use `Payment.id` (sequence) or `BankPayment.bankref` to derive the creditor reference.
- [ ] Ensure that this works correctly end-to-end including reconcilation of transactions after receiving Wise balance credit webhooks.
- [ ] Either here or in a follow-up PR: adding the amount, recipient name, creditor reference and IBAN in plaintext on the edges of the SEPA QR for additional human verification and reassurance purposes (see [this online SEPA QR generator](https://epc-qr.eu/?form) for a nice example).

Resolves #878.