### PR TITLE
payments: update the test IBAN used in the codebase

### DIFF
--- a/apps/base/tasks_banking.py
+++ b/apps/base/tasks_banking.py
@@ -40,8 +40,8 @@ def create_bank_accounts():
         active=True,
         institution="London Bank",
         address="13 Bartlett Place, London, WC1B 4NM",
-        iban="GB47LOND11213141516171",
-        swift="GB47LOND",
+        iban="GB33BUKB20201555555555",
+        swift="GB33BUKB",
     )
     for acct in [gbp, eur]:
         try:

--- a/tests/test_invoice.py
+++ b/tests/test_invoice.py
@@ -19,7 +19,7 @@ def test_format_inline_epc_qr(app):
         "SCT",
         "",
         "EMF Festivals Ltd",
-        "GB47LOND11213141516171",
+        "GB33BUKB20201555555555",
         "EUR10",
         "",
         payment.bankref,


### PR DESCRIPTION
The existing test fixture didn't pass IBAN check-digit validity:

```pyi
>> from stdnum import iban
>>> iban.is_valid('GB47LOND11213141516171')
False
>>> iban.is_valid('GB33BUKB20201555555555')
True
```

The updated test value was sourced from [this list of test IBANs](https://www.iban.com/testibans).