### PR TITLE
CFP guidance: fixup for the timeline header toggle button

### DIFF
--- a/templates/cfp/guidance.html
+++ b/templates/cfp/guidance.html
@@ -89,10 +89,10 @@
 </dl>
 
 <hr>
-<a class="collapse-toggle" role="button" data-toggle="collapse" href="#timeline" aria-expanded="true" aria-controls="#timeline" id="timeline">
+<a class="collapse-toggle" role="button" data-toggle="collapse" href="#timeline" aria-expanded="true" aria-controls="#timeline">
   <h3>Timeline {{octicon('chevron-down-24')}}</h3>
 </a>
-<div class="collapse in">
+<div class="collapse in" id="timeline">
   <p>The call for participation is split into multiple selection rounds lasting several weeks.</p>
 
   <p>


### PR DESCRIPTION
This button was hiding itself.

**Before**
[timeline-toggle-before.webm](https://github.com/emfcamp/Website/assets/55152140/53abbaf7-4e9f-4161-a2ff-5678b6b2b961)

**After**
[timeline-toggle-after.webm](https://github.com/emfcamp/Website/assets/55152140/c792658b-9f7a-4514-944f-4e65565fa046)