### PR TITLE
Allow (manually) populating video URLs mid-event

### DIFF
--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -391,6 +391,9 @@ def update_proposal(proposal_id):
     form.available_times.data = prop.available_times
     form.content_note.data = prop.content_note
     form.family_friendly.data = prop.family_friendly
+    form.thumbnail_url.data = prop.thumbnail_url
+    form.c3voc_url.data = prop.c3voc_url
+    form.youtube_url.data = prop.youtube_url
 
     form.user_scheduled.data = prop.user_scheduled
     form.hide_from_schedule.data = prop.hide_from_schedule

--- a/apps/cfp_review/forms.py
+++ b/apps/cfp_review/forms.py
@@ -75,6 +75,10 @@ class UpdateProposalForm(Form):
     potential_time = StringField("Potential Time")
     potential_venue = StringField("Potential Venue")
 
+    thumbnail_url = StringField("Video Thumbnail URL")
+    c3voc_url = StringField("C3VOC Video URL")
+    youtube_url = StringField("YouTube URL")
+
     update = SubmitField("Update")
     reject = SubmitField("Reject without telling user")
     checked = SubmitField("Mark as checked")
@@ -107,6 +111,10 @@ class UpdateProposalForm(Form):
         proposal.user_scheduled = self.user_scheduled.data
 
         proposal.hide_from_schedule = self.hide_from_schedule.data
+
+        proposal.thumbnail_url = self.thumbnail_url.data
+        proposal.c3voc_url = self.c3voc_url.data
+        proposal.youtube_url = self.youtube_url.data
 
         # Just talks? Weird to have here
 

--- a/apps/schedule/data.py
+++ b/apps/schedule/data.py
@@ -45,6 +45,15 @@ def _get_proposal_dict(proposal: Proposal, favourites_ids):
         res["equipment"] = proposal.display_participant_equipment
         res["age_range"] = proposal.display_age_range
         res["attendees"] = proposal.attendees
+    video_res = {}
+    if proposal.c3voc_url:
+        video_res["ccc"] = proposal.c3voc_url
+    if proposal.youtube_url:
+        video_res["youtube"] = proposal.youtube_url
+    if proposal.thumbnail_url:
+        video_res["preview_image"] = proposal.thumbnail_url
+    if video_res:
+        res["video"] = video_res
     return res
 
 

--- a/apps/schedule/schedule_xml.py
+++ b/apps/schedule/schedule_xml.py
@@ -64,12 +64,12 @@ def make_root():
 
 
 def add_day(root, index, start, end):
-    # Don't include start because it's not needed
     return etree.SubElement(
         root,
         "day",
         index=str(index),
         date=start.strftime("%Y-%m-%d"),
+        start=start.isoformat(),
         end=end.isoformat(),
     )
 

--- a/apps/schedule/schedule_xml.py
+++ b/apps/schedule/schedule_xml.py
@@ -124,6 +124,7 @@ def add_persons(event_node, event):
 
 
 def add_recording(event_node, event):
+    video = event.get("video", {})
 
     recording_node = etree.SubElement(event_node, "recording")
 
@@ -131,6 +132,10 @@ def add_recording(event_node, event):
     _add_sub_with_text(
         recording_node, "optout", "false" if event.get("may_record") else "true"
     )
+    if "ccc" in video:
+        _add_sub_with_text(recording_node, "url", video["ccc"])
+    elif "youtube" in video:
+        _add_sub_with_text(recording_node, "url", video["youtube"])
 
 
 def export_frab(schedule):

--- a/apps/schedule/schedule_xml.py
+++ b/apps/schedule/schedule_xml.py
@@ -91,6 +91,7 @@ def add_event(room, event):
     _add_sub_with_text(event_node, "title", event["title"])
     _add_sub_with_text(event_node, "type", event.get("type", "talk"))
     _add_sub_with_text(event_node, "date", event["start_date"].isoformat())
+    _add_sub_with_text(event_node, "url", url)
 
     # Start time
     _add_sub_with_text(event_node, "start", event["start_date"].strftime("%H:%M"))

--- a/templates/cfp_review/update_proposal.html
+++ b/templates/cfp_review/update_proposal.html
@@ -137,6 +137,11 @@
                                     {{ render_dl_field(form.published_cost) }}
                                     {{ render_dl_field(form.published_participant_equipment) }}
                                 {% endif %}
+				{% if proposal.type in ['talk', 'lightning'] %}
+				    {{ render_dl_field(form.thumbnail_url) }}
+				    {{ render_dl_field(form.c3voc_url) }}
+				    {{ render_dl_field(form.youtube_url) }}
+				{% endif %}
                             </dl>
                         </div>
                     </div>

--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -30,19 +30,6 @@
 
 <div class="well">
 
-{% if proposal.youtube_url %}
-<div class="youtube-link">
-  {% if proposal.thumbnail_url %}
-  <a class="row" href="{{ proposal.youtube_url }}">
-  <img class="img-responsive xs-col-6" src="{{ proposal.thumbnail_url }}">
-  </a>
-  {% else %}
-  <a class="no-thumbnail" href="{{ proposal.youtube_url }}">
-  </a>
-  {% endif %}
-</div>
-{% endif %}
-
 <p class="multiline">{{ (proposal.published_description or proposal.description) | urlize }}</p>
 
 {% if proposal.type == 'workshop' or proposal.type == 'youthworkshop' %}
@@ -79,6 +66,22 @@
   </p>
 {% endif %}
 <p>&nbsp;</p>
+
+{% if proposal.youtube_url or proposal.c3voc_url %}
+<h4>Video</h4>
+<div class="well">
+  {% if proposal.c3voc_url %}
+    <iframe src="{{proposal.c3voc_url}}/oembed" width="100%" height="500px"
+        frameborder="0" allowfullscreen></iframe>
+  {% elif proposal.youtube_url %}
+    <iframe src="{{proposal.youtube_url|replace('youtube.com/watch?v=', 'youtube.com/embed/')}}"
+        width="100%" height="500px" frameborder="0" 
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <p>View this video <a href="{{ proposal.youtube_url }}">on YouTube</a>.</p>
+  {% endif %}
+</div>
+<p>&nbsp;</p>
+{% endif %}
 
 <h4>Return to:</h4>
 <ul class='nav nav-pills'>

--- a/tests/frabs_schema.xml
+++ b/tests/frabs_schema.xml
@@ -3,17 +3,35 @@
   <xs:element name="schedule">
     <xs:complexType>
       <xs:sequence>
-        <xs:element type="xs:string" name="version" minOccurs="1"/>
+        <xs:element minOccurs="0" name="generator">
+          <xs:complexType>
+            <xs:sequence />
+            <xs:attribute type="xs:string" name="name"/>
+            <xs:attribute type="xs:string" name="version"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element type="xs:string" name="version"/>
         <xs:element name="conference">
           <xs:complexType>
-            <xs:all>
-              <xs:element type="xs:string"  name="title"/>
-              <xs:element type="xs:string"  name="acronym"/>
-              <xs:element type="xs:date"    name="start" minOccurs="0"/>
-              <xs:element type="xs:date"    name="end" minOccurs="0"/>
-              <xs:element type="xs:integer" name="days" minOccurs="0"/>
-              <xs:element type="duration"   name="timeslot_duration" minOccurs="0"/>
-            </xs:all>
+            <xs:sequence>
+              <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element type="xs:string"  name="title" maxOccurs="1"/>
+                <xs:element type="acronym"  name="acronym" maxOccurs="1"/>
+
+                <xs:element type="dateOrDateTimeTZ" name="start" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="dateOrDateTimeTZ" name="end" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="xs:integer"       name="days" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="duration"         name="timeslot_duration" minOccurs="0"/>
+                <xs:element type="httpURI"          name="base_url" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="httpURI"          name="logo" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="httpURI"          name="url" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="xs:string"        name="time_zone_name" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="color"            name="color" minOccurs="0"/>
+
+                <xs:element type="track" name="track" minOccurs="0" maxOccurs="unbounded"/>
+              </xs:choice>
+
+            </xs:sequence>
           </xs:complexType>
         </xs:element>
         <xs:element type="day" name="day" maxOccurs="unbounded"/>
@@ -34,49 +52,68 @@
       <xs:selector xpath="day/room/event/slug" />
       <xs:field xpath="." />
     </xs:unique>
+
+    <xs:unique name="day_index_unique">
+      <xs:selector xpath="day" />
+      <xs:field xpath="@index" />
+    </xs:unique>
   </xs:element>
 
   <xs:complexType name="day">
     <xs:sequence>
       <xs:element type="room" name="room" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute type="xs:date" name="date" use="optional"/>
-    <xs:attribute type="xs:dateTime" name="start" use="optional"/>
-    <xs:attribute type="xs:dateTime" name="end" use="optional"/>
-    <xs:attribute type="xs:positiveInteger" name="index" use="optional"/>
+    <xs:attribute type="xs:date" name="date"/>
+    <xs:attribute type="dateTimeTZ" name="start" use="required"/>
+    <xs:attribute type="dateTimeTZ" name="end" use="required"/>
+    <xs:attribute type="xs:positiveInteger" name="index" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="room">
     <xs:sequence>
       <xs:element type="event" name="event" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
-    <xs:attribute type="xs:string" name="name" use="optional"/>
+    <xs:attribute type="xs:string" name="name" use="required"/>
+    <xs:attribute name="guid" type="uuid"/>
   </xs:complexType>
 
   <xs:complexType name="event">
     <xs:all>
       <xs:element type="xs:string" name="room"/>
       <xs:element type="xs:string" name="title"/>
+      <xs:element type="xs:string" name="subtitle"/>
       <xs:element type="xs:string" name="type"/>
-      <xs:element type="xs:dateTime" name="date"/>
+      <xs:element type="dateTimeTZ" name="date"/>
       <xs:element type="start" name="start"/>
       <xs:element type="duration" name="duration"/>
-
-      <xs:element type="xs:string" name="logo" minOccurs="0"/>
+      <xs:element type="xs:string" name="abstract"/>
+      <xs:element type="voc-slug" name="slug"/>
+      <xs:element type="xs:string" name="track"/>
+      <!-- logo is the path or URL to an image, we use httpURI as type here as apps prefer full URLs now -->
+      <xs:element type="httpURI" name="logo" minOccurs="0"/>
       <xs:element type="persons" name="persons" minOccurs="0"/>
       <xs:element type="xs:string" name="language" minOccurs="0"/>
-      <xs:element type="xs:string" name="abstract" minOccurs="1"/>
       <xs:element type="xs:string" name="description" minOccurs="0"/>
-      <xs:element type="xs:string" name="slug" minOccurs="1"/>
       <xs:element type="recording" name="recording" minOccurs="0"/>
-      <xs:element type="xs:string" name="subtitle" minOccurs="1"/>
-      <xs:element type="xs:string" name="track" minOccurs="1"/>
       <xs:element type="links" name="links" minOccurs="0"/>
       <xs:element type="attachments" name="attachments" minOccurs="0"/>
+      <xs:element type="httpURI" name="video_download_url" minOccurs="0"/>
+      <xs:element type="httpURI" name="url" minOccurs="0"/>
+      <xs:element type="httpURI" name="feedback_url" minOccurs="0"/>
     </xs:all>
     <xs:attribute name="id" type="xs:positiveInteger" use="required"/>
-    <xs:attribute name="guid" type="xs:string" use="optional"/>
+    <xs:attribute name="guid" type="uuid" use="required"/>
   </xs:complexType>
+
+  <xs:simpleType name="dateTimeTZ">
+    <xs:restriction base="xs:dateTime">
+      <xs:pattern value=".+(Z|\+[0-9]{1,2}:[0-9]{2}|-[0-9]{1,2}:[0-9]{2})"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="dateOrDateTimeTZ">
+    <xs:union memberTypes="dateTimeTZ xs:date"/>
+  </xs:simpleType>
 
   <xs:simpleType name="duration">
     <xs:restriction base="xs:string">
@@ -90,10 +127,55 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="uuid">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="acronym">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9_-]{4,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="voc-slug">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9_]{4,}-[0-9]{1,6}-[a-z0-9\-_]{4,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="slug">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z0-9-]{2,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="httpURI">
+    <xs:restriction base="xs:anyURI">
+      <xs:pattern value="https?://.*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="string-nonempty">
+    <xs:restriction base="xs:string">
+      <xs:pattern value=".+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="hexColor">
+    <xs:restriction base="xs:string">
+      <!-- Pattern for hexadecimal color code: # followed by exactly 6 hexadecimal digits, prefered in lower case -->
+      <xs:pattern value="#[0-9a-f]{6}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:complexType name="recording">
     <xs:all>
       <xs:element type="xs:string"  name="license"/>
       <xs:element type="xs:boolean" name="optout"/>
+      <xs:element type="httpURI" name="url" minOccurs="0"/>
+      <xs:element type="httpURI" name="link" minOccurs="0"/>
     </xs:all>
   </xs:complexType>
 
@@ -103,7 +185,8 @@
         <xs:complexType>
           <xs:simpleContent>
             <xs:extension base="xs:string">
-              <xs:attribute type="xs:positiveInteger" name="id" use="optional"/>
+              <xs:attribute type="xs:positiveInteger" name="id" />
+              <xs:attribute type="uuid" name="guid"/>
             </xs:extension>
           </xs:simpleContent>
         </xs:complexType>
@@ -117,7 +200,7 @@
         <xs:complexType>
           <xs:simpleContent>
             <xs:extension base="xs:string">
-              <xs:attribute type="xs:string" name="href" use="optional"/>
+              <xs:attribute type="xs:string" name="href"/>
             </xs:extension>
           </xs:simpleContent>
         </xs:complexType>
@@ -131,11 +214,32 @@
         <xs:complexType>
           <xs:simpleContent>
             <xs:extension base="xs:string">
-              <xs:attribute type="xs:string" name="href" use="optional"/>
+              <xs:attribute type="xs:string" name="href"/>
             </xs:extension>
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
+  <xs:complexType name="track">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name"  use="required"/>
+        <xs:attribute type="hexColor"  name="color" use="optional"/>
+        <xs:attribute type="slug"      name="slug"  use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="color">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="hexColor" name="primary" use="required"/>
+        <xs:attribute type="hexColor" name="background" use="optional"/>
+        <xs:anyAttribute processContents="lax"/> <!-- Allows for additional, unspecified attributes -->
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
 </xs:schema>

--- a/tests/test_frab_export.py
+++ b/tests/test_frab_export.py
@@ -95,6 +95,9 @@ def test_export_frab(frab_schema, request_context):
             "user_id": 123,
             "end_date": _local_datetime(2016, 8, 5, 11, 00),
             "start_date": _local_datetime(2016, 8, 5, 10, 30),
+            "video": {
+                "ccc": "http://example.com/media.ccc.de",
+            },
         },
         {
             "id": 2,
@@ -106,6 +109,9 @@ def test_export_frab(frab_schema, request_context):
             "user_id": 123,
             "end_date": _local_datetime(2016, 8, 5, 11, 00),
             "start_date": _local_datetime(2016, 8, 5, 10, 30),
+            "video": {
+                "youtube": "http://example.com/youtube.com",
+            },
         },
         {
             "id": 3,
@@ -118,6 +124,10 @@ def test_export_frab(frab_schema, request_context):
             "user_id": 123,
             "end_date": _local_datetime(2016, 8, 6, 11, 00),
             "start_date": _local_datetime(2016, 8, 6, 10, 30),
+            "video": {
+                "ccc": "http://example.com/media.ccc.de",
+                "youtube": "http://example.com/youtube.com",
+            },
         },
     ]
 


### PR DESCRIPTION
At the moment this is only accessible to CfP admins; maybe we should add a separate role/form for people who are allowed to attach uploaded videos to (accepted) proposals?

This also makes the talk URL visible in the frab XML (which will hopefully mean that media.ccc.de will link back to the talk's page) and updates a few bits to bring things into sync with c3voc's latest copy of the schema.