### PR TITLE
Volunteering updates

### DIFF
--- a/templates/about/volunteer-roles.md
+++ b/templates/about/volunteer-roles.md
@@ -1,31 +1,38 @@
-title: Volunteering
+title: Volunteer Roles
 show_nav: false
 ---
-# Pre-event Volunteer Roles
-We're looking for people to fill the roles listed below, please keep in mind that all of them require a time commitment ahead of the event.
+# Volunteer Roles
 
-Some of the roles are new this year whilst others are portions of previous positions in order to lighten the load on other volunteers.
+It takes a wide variety of skills to make EMF happen, it's not all network cabling and designing badges. Ahead of the event, a lot of what needs doing is sending emails and project management. If you've got some spare time and would like to help please do [get in touch](mailto:volunteer@emfcamp.org).
 
-If any of these roles are of interest to you please send an email to [volunteers@emfcamp.org](mailto:volunteers@emfcamp.org) and introduce yourself. If you can't find a role that interests you but would still like to help, get in touch - we'll do our best to find something that you'll enjoy!
+In general we're looking for people ahead of the event who are comfortable with some of the following skills:
 
-**The following teams currently need pre-event volunteers:**
+* Project management
+* Supplier management & ordering
+* Stage design & production
+* Logistics
+* Community outreach
+* Graphic design
+* Web development
 
-* **Badge** - Electronics and software design for our unique camp badge
-* **Site** - Getting the site built
+We're also looking for people to fill the following specific roles:
 
-## Badge Team
-Responsible for designing, programming, and manufacturing the unique electronic camp badge produced for each EMF event. During the event the badge team also hosts workshops on how to use the badge, and assists people with issues.
+## Conduct Team
 
-### Firmware developer
-Firmware developers build the base software that runs on the badge, generally working in C++/Python and targetting microcontrollers. You do not need to be a professional to help with this role. If you've got any experience with USB protocols such as U2F, CTAP2, CCID, or love cmake, we'd love to hear from you - but this is not required.
+We're looking for people to join the conduct team, which is responsible for enforcing our [code of conduct](https://emfcamp.org/code-of-conduct). We need people who can respond quickly to issues during the event, with a small amount of work involved in handling issues before and after the event.
 
-### Web developer
-The badge team web developers work on the online app-store and development support tools so attendees can easily write code for the badge and experiment with other's code. We're looking for people with experience in web frontend technologies, python, and an eye for design & UX.
+As this is a sensitive role, we're looking for people who are trusted among EMF attendees or similar communities.
 
-## Site Team
-The site team is in charge of getting the power run, water running and tents up.
+## Print Designer
 
-### Chippy/Carpenter
-We need someone to make sure that various pieces of woodwork get done, in previous years this has included the frames for sinks, simple post boxes and pieces of the EMF sign. We idelly need someone who can supply their own tools and is able to be on site early.
+The design team are looking for someone with experience using InDesign or similar to help with layout and design of the printed materials that are given to attendees, including the information booklet and badge manual.
 
-**Do not show up early unless cleared by a team lead**
+## NullSector Production Manager
+
+In the months ahead of the event NullSector need someone to help with administration, supplier management, placing orders, and scheduling. Some knowledge of set construction, staging, and shipping containers would be very helpful.
+
+## Shop Manager
+
+The shop was hugely popular last year, and we're looking for some people to manage it this year. You'll be keeping track of stock, training volunteers on how to work the till, and generally making sure everything runs smoothly.
+
+A driving license and transport would be a huge help in this role to enable going out to restock things, but it isn't essential that everyone involved can drive. We can provide help and support in getting a till system set up.

--- a/templates/about/volunteering.md
+++ b/templates/about/volunteering.md
@@ -6,35 +6,25 @@ EMF is a non-profit event, entirely organised by volunteers. Nobody is paid to w
 
 We’d like everyone to consider volunteering to help the event run smoothly, even if it is only for an hour or two.
 
-<small id="footnote">* We provide free tickets for qualified First Aid staff who must work a minimum of three eight-hour shifts during the event.</small>
-
-## How volunteering works
-We understand that everyone who helps with EMF has other commitments and we plan ahead to cope with this.
-
-We have two golden rules:
-
-* Don’t over-commit yourself
-* Tell us if you can’t get something done
-
-Nobody will criticise you if you can't do something, and telling us quickly means we can handle the situation.
-
-## Volunteering before the event
-Running an event like EMF requires a huge amount of planning to make sure the event runs smoothly. This starts a year or more in advance.
-
-**We're looking for people to help organise the event**. If this is something that interests you [take a look at the list of roles we're looking to fill](/about/volunteer-roles).
-
-We also have a mailing list where we periodically post about volunteer roles, to
-subscribe fill out the form below:
+To be notified when we're looking for help you can subscribe to the volunteering list below:
 
 {{ contact_form("volunteer") }}
 
-## Helping out during the event
+<small id="footnote">* We provide free tickets for qualified First Aid staff who must work a minimum of three eight-hour shifts during the event.</small>
+
+## Before the event
+
+Running an event like EMF requires a huge amount of planning to make sure the event runs smoothly. This starts a year or more in advance.
+
+**We're looking for people to help organise the event**. If this is something that interests you [take a look at the sort of things we're looking for help with](/about/volunteer-roles).
+
+## During the event
 
 During the event, there are plenty of roles which need to be filled, from construction to cooking for volunteers.
 
 Closer to the event, you’ll be able to log in to the volunteer system which allows you to sign up for shifts. Volunteers who complete a shift will receive a delicious free meal from our volunteer kitchen.
 
-## Helping with setup & teardown
+## Setup & teardown
 
 We’re grateful for help setting up the event, and especially tearing it down.
 If you want to help with either setup or teardown you will need a ticket to EMF and **permission from us to turn up early or stay after the event ends**. We do not allow under-18's on site during setup or teardown without explicit permission.
@@ -42,3 +32,7 @@ If you want to help with either setup or teardown you will need a ticket to EMF 
 During setup and teardown, EMF is a construction site and we are liable for your safety. If you don’t follow instructions we will be forced to remove you from site, for everyone's safety.
 
 If you’re on site for setup/teardown you have to help with everything - not just what you’re interested in. There’s plenty of lifting and shifting that requiring a degree of physical fitness and mobility. If you’re not actively helping, we will ask you to leave.
+
+To be notified when we start looking for help with setup & teardown please join the mailing list.
+
+{{ contact_form("volunteer") }}


### PR DESCRIPTION
Update volunteering content:

* Complete rewrite of the volunteering roles page
* Make the top level volunteering page a bit more approachable
  * Possibly controversial is dropping the golden rules - this feels like a thing to communicate during onboarding, rather than the opening salvo on these pages effectively being "you're going to burn out, tell us when you do"