### PR TITLE
Differentiate live-in vehicle tickets from parking tickets

### DIFF
--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -28,9 +28,8 @@ def render_receipt(user, png=False, pdf=False):
 
     admissions = purchases.filter(ProductGroup.type == "admissions").all()
 
-    vehicle_tickets = purchases.filter(
-        ProductGroup.type.in_(["parking", "campervan"])
-    ).all()
+    parking_tickets = purchases.filter(ProductGroup.type == "parking").all()
+    campervan_tickets = purchases.filter(ProductGroup.type == "campervan").all()
 
     tees = purchases.filter(ProductGroup.type == "tees").all()
     hires = purchases.filter(ProductGroup.type == "hire").all()
@@ -49,7 +48,8 @@ def render_receipt(user, png=False, pdf=False):
         format_inline_qr=format_inline_qr,
         format_inline_barcode=format_inline_barcode,
         admissions=admissions,
-        vehicle_tickets=vehicle_tickets,
+        parking_tickets=parking_tickets,
+        campervan_tickets=campervan_tickets,
         transferred_tickets=transferred_tickets,
         tees=tees,
         hires=hires,

--- a/templates/receipt-campervan.html
+++ b/templates/receipt-campervan.html
@@ -1,9 +1,10 @@
 {% from '_receipthelpers.html' import render_header, render_barcode with context %}
 
-  {% for ticket in parking_tickets %}
+  {% for ticket in campervan_tickets %}
     {{ render_header(ticket.owner) }}
-    <h3>Parking ticket {{ loop.index }}</h3>
+    <h3>Live-in vehicle ticket {{ loop.index }}</h3>
     <div class="vehicle-tickets">
+{# TODO: This wording needs amending! https://github.com/emfcamp/Website/issues/1193 #}
         <p>Please put this on your dashboard before arriving at EMF.
            Volunteers at the <b>main access gate</b> will check it on your arrival.
            They will show you where to park and unload your stuff.</p>

--- a/templates/receipt.html
+++ b/templates/receipt.html
@@ -94,14 +94,22 @@
 
     </div>
 
-    {% if vehicle_tickets %}
+    {% if parking_tickets %}
       <div class="nextpage"></div>
     {% endif %}
 
   {% endif %}
 
-  {% if vehicle_tickets %}
+  {% if parking_tickets %}
     {% include 'receipt-parking.html' %}
+
+    {% if campervan_tickets %}
+      <div class="nextpage"></div>
+    {% endif %}
+  {% endif %}
+
+  {% if campervan_tickets %}
+    {% include 'receipt-campervan.html' %}
   {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
These now use a separate template, but at present the text is identical. The only difference is that one says "Live-in vehicle ticket" and the other says "Parking ticket".

Fixes #1193.

- Screenshot of webpage: https://github.com/emfcamp/Website/assets/246745/b3a31b22-0ef5-45eb-837f-83b7523b3f79
- [As printed to PDF](https://github.com/emfcamp/Website/files/14042308/Electromagnetic.Field.pdf)
