### PR TITLE
add a holding page for the cfp

### DIFF
--- a/apps/cfp/views.py
+++ b/apps/cfp/views.py
@@ -165,8 +165,10 @@ def get_cfp_type_form(cfp_type):
 
 
 @cfp.route("/cfp")
-@feature_flag("CFP")
 def main():
+    if not feature_enabled("CFP"):
+        return render_template("cfp/holding-page.html")
+
     ignore_closed = "closed" in request.args
 
     if feature_enabled("CFP_CLOSED") and not ignore_closed:

--- a/templates/cfp/holding-page.html
+++ b/templates/cfp/holding-page.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block body %}
+
+<div class="well">
+  <p>
+    The Call for Participation (CfP) is currently closed. It will normally open
+    around the same time tickets go on sale and close about a month before the
+    event.
+  </p>
+  <p>
+    We have several types of submission: talks, workshops, installations,
+    performances and youth content. Further information can be found in our
+    <a href="{{ url_for('.guidance') }}" target="_blank">guidance</a>.
+  </p>
+  <p>
+    Successful submissions will have a ticket reserved for them to buy.
+  </p>
+  <p>
+    If you have further questions please check the
+    <a href="{{ url_for('.guidance') }}" target="_blank">guidance</a> or
+    <a href="mailto:{{ config['CONTENT_EMAIL'][1] }}">email us</a>.
+  </p>
+</div>
+{% endblock %}


### PR DESCRIPTION
the /cfp url is pretty well known and returning a 404 in the event run-up isn't great. This at least gives a little more information & direction

closes #1341 