### PR TITLE
Various CfP changes

### DIFF
--- a/templates/cfp/new.html
+++ b/templates/cfp/new.html
@@ -85,7 +85,7 @@
       {# NB this excludes installations, which have a separate section #}
       {% if cfp_type in ('talk', 'performance', 'workshop', 'youthworkshop') %}
         {% call render_field(form.equipment_required, horizontal=9,
-                            placeholder="Additional equipment required") %}
+                             placeholder="Additional equipment required") %}
           {% if cfp_type in ('talk', 'performance') %}
             We'll provide a sound system and projector or screen.
           {% elif cfp_type in ('workshop', 'youthworkshop') %}
@@ -128,7 +128,12 @@
           {% endcall %}
       {% endif %}
 
-        {{ render_field(form.additional_info, horizontal=9, placeholder="Anything else you'd like to tell us") }}
+        {% call render_field(form.additional_info, horizontal=9, placeholder="Anything else you'd like to tell us") %}
+          {% if cfp_type == 'performance' %}
+            If you could give us a SoundCloud link or YouTube video of you performing,
+            it'll help with our selection process.
+          {% endif %}
+        {% endcall %}
 
         <div class="col-md-9 col-sm-offset-3">
           {% if cfp_type == 'youthworkshop' %}

--- a/templates/emails/cfp-slot-moved.txt
+++ b/templates/emails/cfp-slot-moved.txt
@@ -6,7 +6,7 @@ Unfortunately we have had to move your EMF {{ proposal.human_type }} '{{ proposa
 
 You now have a {{ proposal.scheduled_duration }} minute slot in {{ proposal.scheduled_venue.name }} on {{ proposal.scheduled_time.strftime('%A at %-I:%M %p') }}. If this is not suitable, please let us know as soon as possible.
 
-If you'd like to share this with people, the public link to your {{ proposal.human_type }} is: https://www.emfcamp.org/schedule/2022/{{ proposal.id }}
+If you'd like to share this with people, the public link to your {{ proposal.human_type }} is: https://www.emfcamp.org/schedule/{{ event_year }}/{{ proposal.id }}
 
 Things to note:
 

--- a/templates/emails/cfp-slot-scheduled.txt
+++ b/templates/emails/cfp-slot-scheduled.txt
@@ -6,7 +6,7 @@ Your EMF {{ proposal.human_type }} '{{ proposal.title }}' has been scheduled!
 
 You have a {{ proposal.scheduled_duration }} minute slot in {{ proposal.scheduled_venue.name }} on {{ proposal.scheduled_time.strftime('%A at %-I:%M %p') }}. If this is not suitable, please let us know as soon as possible.
 
-If you'd like to share this with people, the public link to your {{ proposal.human_type }} is: https://www.emfcamp.org/schedule/2022/{{ proposal.id }}
+If you'd like to share this with people, the public link to your {{ proposal.human_type }} is: https://www.emfcamp.org/schedule/{{ event_year }}/{{ proposal.id }}
 
 Things to note:
 

--- a/templates/emails/cfp-slot-scheduled.txt
+++ b/templates/emails/cfp-slot-scheduled.txt
@@ -21,7 +21,7 @@ Things to note:
 * You can also update your {{ proposal.human_type }} title and description at any time using the link above, so make sure it sounds great!
 
 {% if proposal.type == 'talk' %}
-* While you are allowed on-stage Q&A within your slot, we would prefer it if you asked the audience to meet you somewhere afterwards to discuss it.
+* We would strongly prefer that you do not take on-stage Q&A after your talk unless it is, for instance, a panel that requires audience participation - these are hard for us to manage, and frequently unproductive. Please consider taking questions outside the tent, or in the bar instead.
 {% endif %}
 
 * All this information and more is available on our speakers website page: https://wiki.emfcamp.org/wiki/Speaking


### PR DESCRIPTION
* For performances, ask (again) for a SoundCloud/YouTube link underneath the "additional info" box (#1125)
  * Is there a better place that this should be provided? In the description?
* Make the cfp-slot-moved and cfp-slot-scheduled emails use the `{{ event_year }}` rather than hardcoding 2022 (#1175)
* Strengthen the wording in the cfp-slot-scheduled email around not having a Q&A at the end of your talk (#1256 / #827)