### PR TITLE
Create system to invite speakers to the CfP

### DIFF
--- a/apps/cfp/views.py
+++ b/apps/cfp/views.py
@@ -417,7 +417,7 @@ def edit_proposal(proposal_id):
     del form.email
 
     if form.validate_on_submit():
-        if proposal.state not in ["new", "edit"]:
+        if proposal.state not in ["new", "edit", "manual-review"]:
             flash("This submission can no longer be edited.")
             return redirect(url_for(".proposals"))
 
@@ -462,7 +462,7 @@ def edit_proposal(proposal_id):
 
         return redirect(url_for(".edit_proposal", proposal_id=proposal_id))
 
-    if request.method != "POST" and proposal.state in ["new", "edit"]:
+    if request.method != "POST" and proposal.state in ["new", "edit", "manual-review"]:
         if proposal.type in ("talk", "performance"):
             form.length.data = proposal.length
 

--- a/apps/cfp_review/forms.py
+++ b/apps/cfp_review/forms.py
@@ -13,9 +13,10 @@ from wtforms import (
 )
 from wtforms.validators import DataRequired, Optional, NumberRange, ValidationError
 
-from models.cfp import Venue, ORDERED_STATES
+from models.cfp import HUMAN_CFP_TYPES, Venue, ORDERED_STATES
 from models.cfp_tag import Tag
 from ..common.forms import Form, HiddenIntegerField, EmailField
+from ..admin.users import NewUserForm
 
 from dateutil.parser import parse as parse_date
 
@@ -410,3 +411,12 @@ class ReversionForm(Form):
     proposal_id = HiddenIntegerField("Proposal ID")
     txn_id = HiddenIntegerField("Transaction ID")
     revert = SubmitField("Revert to this version")
+
+
+class CFPInviteForm(NewUserForm):
+    proposal_type = SelectField(
+        "Proposal Type",
+        choices=[tuple(i) for i in HUMAN_CFP_TYPES.items() if i[0] != "lightning"],
+    )
+    title = StringField("Title", default="[How should this appear in the schedule?]")
+    description = StringField("Description", default="[A more detailed description]")

--- a/templates/cfp_review/_nav.html
+++ b/templates/cfp_review/_nav.html
@@ -63,6 +63,8 @@
                 <li role="separator" class="divider"></li>
                 {{ menuitem('Anonymisation', '.anonymisation', proposal_counts['checked']) }}
                 {{ menuitem('Review', '.review_list') }}
+                <li role="separator" class="divider"></li>
+                {{ menuitem('Invite Speaker', '.invite_speaker') }}
             </ul>
         </li>
     {% endif %}

--- a/templates/cfp_review/invite-speaker.html
+++ b/templates/cfp_review/invite-speaker.html
@@ -1,0 +1,13 @@
+{% from "_formhelpers.html" import render_dl_field %}
+{% extends "cfp_review/base.html" %}
+{% block body %}
+  <form method="POST" class="form">
+    {{ form.hidden_tag() }}
+    {{ render_dl_field(form.name) }}
+    {{ render_dl_field(form.email) }}
+    {{ render_dl_field(form.proposal_type) }}
+    {{ render_dl_field(form.title) }}
+    {{ render_dl_field(form.description) }}
+    {{ form.add(class_="btn btn-primary debounce") }}
+  </form>
+{% endblock %}

--- a/templates/emails/invited-speaker.txt
+++ b/templates/emails/invited-speaker.txt
@@ -1,0 +1,18 @@
+{% extends "emails/base.txt" %}
+{% block body %}
+Hi {{ user.name }},
+
+This is to let you know that you now have an account on our website for Electromagnetic Field {{ event_year }}!
+
+You can log into this account by visiting:
+
+  {{ external_url('users.login', code=code, next=url_for('cfp.edit_proposal', proposal_id=proposal.id)) }}
+
+Once you've logged in please fill in the details for your {{proposal.human_type}}.
+
+If you think you've been added in error or you have any problems, please let us know by replying to this email.
+
+Love,
+
+All the EMF team
+{% endblock %}


### PR DESCRIPTION
create a user & empty proposal of a specific type for them, put it in manual review & email them a link to fill it out.

see https://github.com/emfcamp/Website/issues/1327 & https://github.com/emfcamp/Website/issues/813


Flow is 

1. Fill out form:
    * name + email (both required)
    * title (otherwise defaults to `[How should this appear in the schedule?]`
    * description (default: `[A more detailed description]`)
2. Creates a new user & proposals, adds them to the db
3. Sends the user a login link with `next` set to `/cfp/proposal/<new id>/edit` which is the account edit page

To make this work any proposal in 'manual review' can now be edited at any time (but this should be fine as we'll be paying more attention to these)