### PR TITLE
Make the volunteer schedule more usable on mobile

### DIFF
--- a/css/volunteer_schedule.scss
+++ b/css/volunteer_schedule.scss
@@ -1,9 +1,15 @@
-.modal {
-  color: black;
-}
+@use "./_variables.scss" as *;
 
 #role-select {
   height: 260px;
+}
+
+.nav-select {
+  display: none;
+
+  select {
+    color: black;
+  }
 }
 
 table.shifts-table tr,
@@ -11,4 +17,99 @@ table.shifts-table th,
 table.shifts-table td {
   // !important because I'm a terrible (and very lazy) person
   border-color: #630047 !important;
+}
+
+table.shifts-table tbody td.hidden {
+  display: none;
+}
+
+table.shifts-table tbody td.mobile-only {
+  display: none;
+}
+
+// Overrides for mobile.
+@media (max-width: 768px) {
+  .nav-tabs {
+    display: none;
+  }
+
+  .nav-select {
+    display: block;
+  }
+
+  .tab-content {
+    border: none;
+  }
+
+  #filters label.checkbox {
+    margin-left: 20px;
+  }
+
+  table.shifts-table {
+    border: none !important; // Override table-bordered
+
+    tbody {
+      tr {
+        td:before {
+          width: 30%;
+          left: 0px;
+          padding-left: 15px;
+          padding-top: 0;
+          font-weight: bold;
+        }
+
+        td {
+          padding-left: 30%;
+          padding-top: 5px;
+          padding-bottom: 0;
+          border: none;
+        }
+
+        td.mobile-only {
+          display: block;
+        }
+
+        td.button:before {
+          width: 0;
+        }
+
+        td.button {
+          padding-left: 15px;
+          padding-bottom: 15px;
+        }
+
+        // This is used to provide a heading for each start time.
+        td.start_time {
+          font-size: 1.2em;
+          padding-left: 0px;
+          padding-bottom: 5px;
+          background-color: $main-background;
+          color: $main-background-header;
+          font-family: $header-font-stack;
+
+        }
+
+        // Hide discrete end time column in favour of showing "from X to Y"
+        td.end_time {
+          display: none;
+        }
+
+        td.time:before {
+          content: "Time";
+        }
+
+        td.venue:before {
+          content: "Location";
+        }
+
+        td.role:before {
+          content: "Role";
+        }
+
+        td.staffing:before {
+          content: "Signed up";
+        }
+      }
+    }
+  }
 }

--- a/js/volunteer-schedule.js
+++ b/js/volunteer-schedule.js
@@ -1,3 +1,5 @@
+const { verified } = require("@primer/octicons");
+
 function saveFilters() {
     localStorage.setItem("volunteer-filters:v2", JSON.stringify(getFilters()))
 }
@@ -74,8 +76,9 @@ function shouldDisplayNode(node_data, filters) {
 
 function spanStartTimeCell(firstNodeOfHour, rowCount) {
     if (firstNodeOfHour !== null) {
-        firstNodeOfHour.children[0].setAttribute("rowspan", rowCount);
-        $(firstNodeOfHour.children[0]).show();
+        let start_time_cell = firstNodeOfHour.querySelector(".start_time");
+        start_time_cell.setAttribute("rowspan", rowCount);
+        start_time_cell.classList.remove("hidden")
     }
 }
 
@@ -89,6 +92,14 @@ function rowClass(node_data) {
     }
 
     return 'warning';
+}
+
+function colourise_row(node, node_data, colourful_mode) {
+    ["danger", "warning", "info"].forEach(className => node.classList.remove(className))
+
+    if (!colourful_mode) { return }
+
+    node.classList.add(rowClass(node_data))
 }
 
 function updateRowDisplay() {
@@ -116,23 +127,17 @@ function updateRowDisplay() {
                 rowCount = 0
                 currentHour = node.getAttribute("data-shift-start")
             } else {
-                // Otherwise we hide the start time cell. q
-                $(node.children[0]).hide()
+                // Otherwise we hide the start time cell.
+                node.querySelector(".start_time").classList.add("hidden")
             }
 
-            node.classList.remove("danger")
-            node.classList.remove("warning")
-            node.classList.remove("info")
-
-            if (filters.colourful_mode) {
-                node.classList.add(rowClass(node_data))
-            }
+            colourise_row(node, node_data, filters.colourful_mode);
 
             rowCount += 1;
 
-            $(node).show();
+            node.classList.remove("hidden");
         } else {
-            $(node).hide();
+            node.classList.add("hidden");
         }
 
         if (idx == rows.length - 1) { spanStartTimeCell(firstNodeOfHour, rowCount); }
@@ -177,6 +182,9 @@ function init_volunteer_schedule() {
         document.querySelectorAll('input[data-role-id]').forEach((checkbox) => checkbox.checked = checkbox.getAttribute('data-trained') == 'True')
         saveFilters()
         updateRowDisplay()
+    });
+    document.getElementById('select-day').addEventListener("change", (ev) => {
+        document.location.replace(ev.target.value)
     });
 };
 

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -39,9 +39,20 @@
         {{ tabnav('sun', 'Sunday', active_day) }}
         {{ tabnav('mon', 'Monday', active_day) }}
     </ul>
+    <div class="nav-select form-group form-inline">
+        <label for="select-day">Day:</label>
+        <select id="select-day">
+            <option value="{{ url_for('.schedule', day='wed') }}" {% if active_day == "wed" %}selected{% endif %}>Wednesday</option> 
+            <option value="{{ url_for('.schedule', day='thu') }}" {% if active_day == "thu" %}selected{% endif %}>Thursday</option> 
+            <option value="{{ url_for('.schedule', day='fri') }}" {% if active_day == "fri" %}selected{% endif %}>Friday</option> 
+            <option value="{{ url_for('.schedule', day='sat') }}" {% if active_day == "sat" %}selected{% endif %}>Saturday</option> 
+            <option value="{{ url_for('.schedule', day='sun') }}" {% if active_day == "sun" %}selected{% endif %}>Sunday</option> 
+            <option value="{{ url_for('.schedule', day='mon') }}" {% if active_day == "mon" %}selected{% endif %}>Monday</option> 
+        </select>
+    </div>
     <div class="tab-content table-responsive">
         <div role="tabpanel" class="tab-pane active" id="{{ active_day }}">
-            <table id="tab-{{ active_day }}" class="table table-bordered shifts-table">
+            <table id="tab-{{ active_day }}" class="table table-bordered responsive-table shifts-table">
                 <thead><tr>
                     <th>Starts</th>
                     <th>Ends</th>
@@ -55,18 +66,19 @@
                         {% for shift in all_shifts[hour] %}
                             <tr id="shift-{{ shift.id }}" data-role-id="{{ shift.role.id }}" data-shift-start="{{ hour }}" data-shift-end="{{ shift.end }}" data-staffed="{{ shift.current_count >= shift.min_needed }}" data-full="{{ shift.current_count >= shift.max_needed }}" data-signed-up="{{ shift.is_user_shift }}" data-min-staff="{{ shift.min_needed }}" data-max-staff="{{ shift.max_needed }}" data-current-staff="{{ shift.current_count }}">
                                 {% if loop.first %}
-                                    <td rowspan="{{ all_shifts[hour] | length }}">{{ hour }}</td>
+                                    <td class="start_time" rowspan="{{ all_shifts[hour] | length }}">{{ hour }}</td>
                                 {% else %}
-                                    <td style="display: none">{{ hour }}</td>
+                                    <td class="start_time hidden">{{ hour }}</td>
                                 {% endif %}
-                                <td>{{ shift.end_time if shift.end else '--' }}</td>
-                                <td>{{ shift.venue.name }}</td>
-                                <td>{{ shift.role.name }}</td>
-                                <td>{{ shift.current_count }}/{{ shift.max_needed }}</td>
+                                <td class="end_time">{{ shift.end_time if shift.end else '--' }}</td>
+                                <td class="time mobile-only">{{ hour }}{% if shift.end %} to {{ shift.end_time }}{% endif %}</td>
+                                <td class="venue">{{ shift.venue.name }}</td>
+                                <td class="role">{{ shift.role.name }}</td>
+                                <td class="staffing">{{ shift.current_count }}/{{ shift.max_needed }}</td>
                                 {% if current_user.has_permission("volunteer:admin") %}
-                                    <td><a href="{{ url_for('.shift', shift_id=shift.id) }}" class="btn btn-block btn-primary">Details</a></td>
+                                    <td class="button"><a href="{{ url_for('.shift', shift_id=shift.id) }}" class="btn btn-block btn-primary">Details</a></td>
                                 {% else %}
-                                    <td>
+                                    <td class="button">
                                             {%- if shift.is_user_shift -%}
                                                 <form method="post" action="{{ url_for('.shift_cancel', shift_id=shift.id) }}">
                                                     <button class="btn btn-block btn-danger">Cancel</button>


### PR DESCRIPTION
* Use `responsive-table` to turn each row into a block element that can be easily read on a mobile device.
* Switch the day tabs for a select box on mobile so they don't take up half the screen.