### PR TITLE
Add a £1k logo on web sponsorship tier

### DIFF
--- a/templates/sponsors/sponsor.html
+++ b/templates/sponsors/sponsor.html
@@ -49,7 +49,17 @@ we hope support from sponsors will make the following things possible:</p>
 <p>The following sponsorship levels are presented as guidance, however we are happy to produce
     a custom sponsorship package for each sponsor that wishes to be involved with EMF.</p>
 <div class="row row-equal" id="sponsorship-row">
-    <div class="col-sm-6 col-md-3">
+    <div class="col-sm-4 col-md-2">
+        <div class="panel panel-default">
+            <div class="panel-heading"><h4>Copper: £1000</h4></div>
+            <div class="panel-body">
+                <ul>
+                    <li>Logo on website</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4 col-md-2">
         <div class="panel panel-default">
             <div class="panel-heading"><h4>Bronze: £2000</h4></div>
             <div class="panel-body">
@@ -61,7 +71,7 @@ we hope support from sponsors will make the following things possible:</p>
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-md-3">
+    <div class="col-sm-4 col-md-2">
         <div class="panel panel-default">
             <div class="panel-heading"><h4>Silver: £4000</h4></div>
             <div class="panel-body">
@@ -76,7 +86,7 @@ we hope support from sponsors will make the following things possible:</p>
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-md-3">
+    <div class="col-sm-6 col-md-2">
         <div class="panel panel-default">
             <div class="panel-heading"><h4>Gold: £6000</h4></div>
             <div class="panel-body">
@@ -92,7 +102,7 @@ we hope support from sponsors will make the following things possible:</p>
             </div>
         </div>
     </div>
-    <div class="col-sm-6 col-md-3">
+    <div class="col-sm-6 col-md-2">
         <div class="panel panel-default">
             <div class="panel-heading"><h4>Custom: £8000+</h4></div>
             <div class="panel-body">


### PR DESCRIPTION
This looks pretty bad on mobile but then it didn't look great previously

@Jonty & sponsorship team to confirm perks @ £1k

Current:
<img width="1024" alt="Screenshot 2024-03-25 at 23 36 07" src="https://github.com/emfcamp/Website/assets/486265/4e000fff-2146-4957-b299-acf098b1432f">
<img width="815" alt="Screenshot 2024-03-25 at 23 36 27" src="https://github.com/emfcamp/Website/assets/486265/45775b0e-16cb-4826-90a1-5c479d061a4d">

Previous, narrow view:
<img width="821" alt="Screenshot 2024-03-25 at 23 36 39" src="https://github.com/emfcamp/Website/assets/486265/52b1f6fd-833a-41c4-b95b-8f148a1ced60">
