### PR TITLE
Fixed broken link: /volunteering/ -> /about/volunteering (on Travel page)

### DIFF
--- a/templates/about/travel.md
+++ b/templates/about/travel.md
@@ -4,7 +4,7 @@ title: Travelling to Electromagnetic Field
 
 EMF will be held at the Eastnor Castle Deer Park, just east of Ledbury, Herefordshire.
 
-You can arrive after 10am on Thursday 30 May and you can stay until midday on Monday 3 June{# 2024 #}. You won't be allowed on site outside those times unless you've [volunteered](/volunteering) to help with setup or teardown.
+You can arrive after 10am on Thursday 30 May and you can stay until midday on Monday 3 June{# 2024 #}. You won't be allowed on site outside those times unless you've [volunteered](/about/volunteering) to help with setup or teardown.
 
 ## By Train
 EMF is close to Ledbury station which is around [three hours](https://traintimes.org.uk/london+paddington/ledbury/) from London Paddington (on [GWR](https://www.gwr.com)) and [one hour](https://traintimes.org.uk/birmingham+new+street/ledbury) from Birmingham New Street (on [West Midlands Railway](https://www.westmidlandsrailway.co.uk/)).


### PR DESCRIPTION
I fixed a broken link found on the [travel page](https://www.emfcamp.org/about/travel) that incorrectly linked [Volunteering](https://www.emfcamp.org/about/volunteering)

**Before:**
`You won't be allowed on site outside those times unless you've [volunteered](https://www.emfcamp.org/volunteering) to help with setup or teardown.`

**After:**
`You won't be allowed on site outside those times unless you've [volunteered](https://www.emfcamp.org/about/volunteering) to help with setup or teardown.`