### PR TITLE
poetry: update gunicorn to v21.2.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1359,17 +1359,17 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "gunicorn"
-version = "20.1.0"
+version = "21.2.0"
 description = "WSGI HTTP Server for UNIX"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
-    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+    {file = "gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
+    {file = "gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
 ]
 
 [package.dependencies]
-setuptools = ">=3.0"
+packaging = "*"
 
 [package.extras]
 eventlet = ["eventlet (>=0.24.1)"]
@@ -4350,4 +4350,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "17d70e68295efbe6be37601d425500dbb2e75d4f8d16ae87088811c4f451fe0c"
+content-hash = "a4283673c95da1af7e9e3f482e862a1b6fd1706ba34b0a355af11dbc036dbf45"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ flask-wtf = "~=1.0"
 wtforms = "~=2.3"
 flask-login = "~=0.6"
 flask-debugtoolbar = "*"
-gunicorn = "~=20.1"
+gunicorn = "~=21.2"
 pybarcode = {git = "https://github.com/emfcamp/python-barcode"}
 pillow = "~=10.2"
 icalendar = "==3.11.7"


### PR DESCRIPTION
Based on the `gunicorn` [security support policy](https://github.com/benoitc/gunicorn/security), I think we should update to the most-recent version [v21.2.0](https://github.com/benoitc/gunicorn/commit/ab9c8301cb9ae573ba597154ddeea16f0326fc15) - it has been the latest version since its release on 2023-07-19, and seems relatively stable based on searching [issues that mention it](https://github.com/benoitc/gunicorn/issues?q=is%3Aissue+is%3Aopen+21.2.0).

There is one bugreport https://github.com/benoitc/gunicorn/issues/3038 - a possible regression since the v21.0.0 release series that isn't yet resolved.

Additionally there have been a few reports ([ref](https://github.com/benoitc/gunicorn/issues/3046), [ref](https://github.com/benoitc/gunicorn/issues/3120)) of problems with `eventlet` (aka `geventlet`) - we don't use that worker-type though; [we use `gthread`](https://github.com/emfcamp/Website/blob/1bf11f19de6bdcad7bb26e8a287c076d9dcc7565/docker/prod_entrypoint.sh#L19).

NB: The bugreport mentioned above _does_ appear to be related to a `gthread` regression.