### PR TITLE
Add deliveries page to About

### DIFF
--- a/templates/about/deliveries.md
+++ b/templates/about/deliveries.md
@@ -1,0 +1,42 @@
+title: Deliveries
+---
+# Deliveries
+
+If you want to get items delivered to the event while you're here, the Logistics team offer a *best-effort* delivery receiving service for anything coming by post or delivery service (e.g. Amazon packages).
+
+*Note: This is for personal and village deliveries only. If you need something delivered for an EMF team or if it's larger than a pallet, please contact the Logistics team for instructions*
+
+To make sure your item gets to you, you need to do three things:
+
+* Address it correctly
+* Let us know it's coming
+* Pick it up when it has arrived
+
+## Addressing
+
+Please address the item in this format:
+
+**Your Name Here**
+**Your Village Name Here (if applicable)**
+Electromagnetic Field 2024
+Eastnor Castle Deer Park
+Access from A438
+Eastnor, LEDBURY HR8 1RQ
+
+It's important you get all of this in; if the service you're using doesn't
+have that many address lines, combine some (the name/village name line and the
+Deer Park/A438 lines could be combined).
+
+## Let Us Know
+
+Once you've ordered your item, please fill out our [attendee delivery form](https://grist.orga.emfcamp.org/forms/8K5iWGnmsyHS71NDesWDQy/7), and provide as many details about the package as you can. While tracking numbers are optional, please include them if you know them, as it helps us get through the pile of packages quicker.
+
+If you don't let us know about a package, we may still receive it, but expect a bigger delay at pickup or the possibility that we won't be able to find it.
+
+## Pick it up
+
+Packages are held for collection at the Logistics tent; visit us just inside the HQ area (at the southeast end of the site) between 10am - 5pm during the event to pick them up once your courier tells you they're delivered.
+
+It takes us a little bit to get through all of the packages when they arrive (during the main event, we often have a delivery van just full of items for us) so please give us an hour or so after you are notified of delivery to come collect it.
+
+If you don't collect them before the end of the event, or they arrive after the event is over, they will be discarded!

--- a/templates/about/deliveries.md
+++ b/templates/about/deliveries.md
@@ -23,9 +23,7 @@ Eastnor Castle Deer Park
 Access from A438
 Eastnor, LEDBURY HR8 1RQ
 
-It's important you get all of this in; if the service you're using doesn't
-have that many address lines, combine some (the name/village name line and the
-Deer Park/A438 lines could be combined).
+It's important you get all of this in; if the service you're using doesn't have that many address lines, combine some (the name/village name line and the Deer Park/A438 lines could be combined).
 
 ## Let Us Know
 

--- a/templates/about/deliveries.md
+++ b/templates/about/deliveries.md
@@ -4,7 +4,7 @@ title: Deliveries
 
 If you want to get items delivered to the event while you're here, the Logistics team offer a *best-effort* delivery receiving service for anything coming by post or delivery service (e.g. Amazon packages).
 
-*Note: This is for personal and village deliveries only. If you need something delivered for an EMF team or if it's larger than a pallet, please contact the Logistics team for instructions*
+*Note: This is for personal and village deliveries only. If you need something delivered for an EMF team or if it's larger than a pallet, please contact the Logistics team at logistics@emfcamp.org or DECT 1030 for instructions*
 
 To make sure your item gets to you, you need to do three things:
 
@@ -37,4 +37,4 @@ Packages are held for collection at the Logistics tent; visit us just inside the
 
 It takes us a little bit to get through all of the packages when they arrive (during the main event, we often have a delivery van just full of items for us) so please give us an hour or so after you are notified of delivery to come collect it.
 
-If you don't collect them before the end of the event, or they arrive after the event is over, they will be discarded!
+Note that we will not notify you when something has arrived. If you don't collect your deliveries before the end of the event, or they arrive after the event is over, they will be discarded!

--- a/templates/about/template.html
+++ b/templates/about/template.html
@@ -24,6 +24,7 @@
     {#{{page("Food & Drink", "food")}}#}
     {{page("Power", "power")}}
     {{page("Internet", "internet")}}
+    {{page("Deliveries", "deliveries")}}
     {#{{page("Bring & Donate", "bring_and_donate")}}#}
     {{page("Volunteering", "volunteering")}}
     {{view("Branding", "base.branding")}}


### PR DESCRIPTION
This adds a public-facing deliveries page for smaller-than-pallet deliveries to the About set of pages.