### PR TITLE
Volunteering fixes

### DIFF
--- a/templates/volunteer/_nav.html
+++ b/templates/volunteer/_nav.html
@@ -8,7 +8,7 @@
     <a href="{{url}}">{{text}}</a>
 </li>
 {% endmacro %}
-{% if current_user.is_authenticated %}
+{% if current_user.is_authenticated and current_user.has_permission('volunteer:user') %}
     <ul class="nav nav-pills">
         {{ menuitem('Account', '.account') }}
         {{ menuitem('Roles', '.choose_role') }}

--- a/templates/volunteer/training/bar-training.html
+++ b/templates/volunteer/training/bar-training.html
@@ -21,10 +21,17 @@
 {% if trained %}
 
 <h2>You have completed this training!</h2>
-<p>
-    <strong>Congratulations - you have completed your training for working in the bar.</strong>
-    You can now <a href="{{ url_for('volunteer.schedule') }}">sign up</a> for bar shifts.
-</p>
+{% if feature_enabled("VOLUNTEERS_SCHEDULE") %}
+    <p>
+        <strong>Congratulations - you have completed your training for working in the bar.</strong>
+        You can now <a href="{{ url_for('volunteer.schedule') }}">sign up</a> for bar shifts.
+    </p>
+{% else %}
+    <p>
+        <strong>Congratulations - you have completed your training for working in the bar.</strong>
+        You will be able to sign up for bar shifts once the volunteer schedule is live.
+    </p>
+{% endif %}
 <p>
     You are welcome to review the training material again to boost your knowledge, or even
     complete the questions again - however you are not required to.


### PR DESCRIPTION
* Hide volunteer nav for people who haven't yet registered as volunteers.
* Don't try to redirect people who've completed bar training to the schedule before it's live.