### PR TITLE
Fix broken h2 tag

### DIFF
--- a/templates/schedule/attendee_content/index.html
+++ b/templates/schedule/attendee_content/index.html
@@ -10,7 +10,7 @@
     <strong>You should not add content that you have submitted to the CfP here.</strong>
 </p>
     {% if content|length > 0 %}
-    <h2>Your Content</h2
+    <h2>Your Content</h2>
     <table class="table">
         <thead>
             <tr>


### PR DESCRIPTION
Currently the table renders as a blob of text (at least in firefox)