### PR TITLE
Use CSS grid on the /account page to fit the panels

### DIFF
--- a/css/_panel_grid.scss
+++ b/css/_panel_grid.scss
@@ -1,0 +1,18 @@
+/* A grid of panels. */
+
+.panel-grid {
+  --panel-grid-min-size: 350px;
+  --panel-grid-max-size: 1fr;
+  --panel-grid-gap: 10px;
+
+  display: grid;
+  gap: var(--panel-grid-gap);
+  grid-template-columns: repeat(auto-fill, minmax(var(--panel-grid-min-size), var(--panel-grid-max-size)));
+  grid-template-rows: masonry;
+  margin-bottom: 20px;
+}
+
+.panel-grid > .panel {
+  block-size: fit-content;
+  margin-bottom: 0;
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -10,6 +10,7 @@
 @use "./_tables.scss";
 @use "./_buttons.scss";
 @use "./_video.scss";
+@use "./_panel_grid.scss";
 
 @use "./_about.scss";
 @use "./_attendee_content.scss";

--- a/templates/account/main.html
+++ b/templates/account/main.html
@@ -8,100 +8,90 @@
   You're logged in as <strong>{{current_user.name}}</strong> (<strong>{{ current_user.email }}</strong>).
     <a href="{{url_for('.details')}}">Edit your account details</a>.
 </p>
-<div class="row">
-  <div class="col-md-6">
-    <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Villages</h3>
-        </div>
-        <div class="panel-body">
-          {% if current_user.village %}
-            <p>You're a member of the <strong>{{current_user.village.name}}</strong> village.</p>
-            {% if current_user.village_membership.admin %}
-              <a class="btn btn-primary" href="{{url_for('villages.edit', year=event_year, village_id=current_user.village.id)}}">
-                Edit village details</a>
-            {% endif %}
-          {% else %}
-            <p>Village registration is open! If you're planning on camping with a group of people,
-            you can let us know about it by registering your village.
-            This will help us try to make sure you have the space and facilities you need.
-            <a href="{{url_for('base.page', page_name='villages')}}">Learn more about villages</a>.
-            </p>
-            <div class="btn-group">
-              <a class="btn btn-primary" href="{{ url_for("villages.register") }}">Register a village</a>
-              <a class="btn btn-default" href="{{url_for("villages.main", year=event_year)}}">View villages</a>
-            </div>
+<div class="panel-grid">
+  <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Villages</h3>
+      </div>
+      <div class="panel-body">
+        {% if current_user.village %}
+          <p>You're a member of the <strong>{{current_user.village.name}}</strong> village.</p>
+          {% if current_user.village_membership.admin %}
+            <a class="btn btn-primary" href="{{url_for('villages.edit', year=event_year, village_id=current_user.village.id)}}">
+              Edit village details</a>
           {% endif %}
-        </div>
-    </div>
+        {% else %}
+          <p>Village registration is open! If you're planning on camping with a group of people,
+          you can let us know about it by registering your village.
+          This will help us try to make sure you have the space and facilities you need.
+          <a href="{{url_for('base.page', page_name='villages')}}">Learn more about villages</a>.
+          </p>
+          <div class="btn-group">
+            <a class="btn btn-primary" href="{{ url_for("villages.register") }}">Register a village</a>
+            <a class="btn btn-default" href="{{url_for("villages.main", year=event_year)}}">View villages</a>
+          </div>
+        {% endif %}
+      </div>
   </div>
 
   {% if feature_enabled('CFP') and not feature_enabled('CFP_CLOSED') %}
-    <div class="col-md-6">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Call for Participation</h3>
-        </div>
-        <div class="panel-body">
-          <p>Our Call for Participation is open!<br>
-          We're looking for talks, workshops, or performances at EMF {{event_year}}.
-          </p>
-          <a class="btn btn-primary" href="{{url_for('cfp.main')}}">Submit a proposal</a>
-        </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Call for Participation</h3>
+      </div>
+      <div class="panel-body">
+        <p>Our Call for Participation is open!<br>
+        We're looking for talks, workshops, or performances at EMF {{event_year}}.
+        </p>
+        <a class="btn btn-primary" href="{{url_for('cfp.main')}}">Submit a proposal</a>
       </div>
     </div>
   {% endif %}
 
   {% if feature_enabled('ATTENDEE_CONTENT') %}
-    <div class="col-md-6">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Your Content</h3>
-        </div>
-        <div class="panel-body">
-          <p>
-            You can help other people find you or your village's talks, workshops, installations, and gatherings by
-            adding them to the schedule.</p>
-          <p>
-            If you're part of a village you'll be able to schedule content occurring there,
-            and anyone can arrange gatherings in the main bar or lounge.
-          </p>
-          <a class="btn btn-primary" href="{{url_for('schedule.attendee_content')}}">Manage your content</a>
-        </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Your Content</h3>
+      </div>
+      <div class="panel-body">
+        <p>
+          You can help other people find you or your village's talks, workshops, installations, and gatherings by
+          adding them to the schedule.</p>
+        <p>
+          If you're part of a village you'll be able to schedule content occurring there,
+          and anyone can arrange gatherings in the main bar or lounge.
+        </p>
+        <a class="btn btn-primary" href="{{url_for('schedule.attendee_content')}}">Manage your content</a>
       </div>
     </div>
   {% endif %}
 
   {% if owned_tickets|length > 1 %}
-    <div class="col-md-6">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Transfer Tickets</h3>
-        </div>
-        <div class="panel-body">
-          <p>
-          You have more than one ticket assigned to you. We recommend you transfer tickets to
-          whoever will be using them, so they can receive updates from us and sign up for workshops.
-          </p>
-          <a class="btn btn-primary" href="{{url_for(".purchases")}}">Transfer tickets</a>
-        </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Transfer Tickets</h3>
+      </div>
+      <div class="panel-body">
+        <p>
+        You have more than one ticket assigned to you. We recommend you transfer tickets to
+        whoever will be using them, so they can receive updates from us and sign up for workshops.
+        </p>
+        <a class="btn btn-primary" href="{{url_for(".purchases")}}">Transfer tickets</a>
       </div>
     </div>
   {% endif %}
 
   {% if SITE_STATE in ('sales', 'event') %}
-    <div class="col-md-6">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">T-shirts and badges</h3>
-        </div>
-        <div class="panel-body">
-          <p>We still have a limited number of EMF 2024 T-shirts and Tildagon electronic badges available
-          for sale &mdash; order now and collect them at the event.</p>
-          <div class="btn-group">
-            <a class="btn btn-primary" href="{{url_for("tickets.main", flow="tees")}}">Buy t-shirts</a>
-            <a class="btn btn-primary" href="{{url_for("tickets.main", flow="badge")}}">Buy badges</a>
-          </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">T-shirts and badges</h3>
+      </div>
+      <div class="panel-body">
+        <p>We still have a limited number of EMF 2024 T-shirts and Tildagon electronic badges available
+        for sale &mdash; order now and collect them at the event.</p>
+        <div class="btn-group">
+          <a class="btn btn-primary" href="{{url_for("tickets.main", flow="tees")}}">Buy t-shirts</a>
+          <a class="btn btn-primary" href="{{url_for("tickets.main", flow="badge")}}">Buy badges</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Note that on Firefox Nightly/Dev and Safari Tech Preview, this uses the masonry extension to CSS Grid to pack the rows a bit tighter - this doesn't really make a difference yet since noone supports this "live", but it's a nice indication of what we could do. It degrades gracefully to something that looks at least a little more sensible than our current panel mess.

Before: ![image](https://github.com/emfcamp/Website/assets/246745/225aecb7-42dc-4d39-8e9f-2663b8dae9fd)

After (Chrome, no masonry support, desktop): 
![image](https://github.com/emfcamp/Website/assets/246745/2be8cf19-07d4-4f09-8e0f-900a694214bd)

After (Firefox Nightly, *masonry supported*, desktop):
![image](https://github.com/emfcamp/Website/assets/246745/4c99e96d-569e-4c4d-b35a-335142f817a0)

After (Chrome, sized for iPhone SE): ![totoro_2342_account(iPhone SE)](https://github.com/emfcamp/Website/assets/246745/9a40fec4-a3a8-4b3f-b2a9-93eeef173e4b)
