### PR TITLE
Add orga-links doc

### DIFF
--- a/apps/base/__init__.py
+++ b/apps/base/__init__.py
@@ -188,11 +188,13 @@ def subscribe():
 def emp():
     return render_template("emp.html")
 
-
 @base.route("/deliveries")
 def deliveries():
     return redirect("/static/deliveries.pdf")
 
+@base.route("/orga-links")
+def orga_links():
+    return redirect("https://docs.google.com/document/d/1AAkzW2J1keCYZj1vDaEWcmVNLIbUTHoqh1zCaZUgNHk/edit?usp=sharing")
 
 from . import redirects  # noqa
 from . import about  # noqa


### PR DESCRIPTION
While link is now public, permissions are still set private.

Shorthand is for use on site, much easier to say "visit emfcamp.org/orga-links" than giving a Google Docs share URL
