### PR TITLE
make <title> the same as the published title (if different to title)

### DIFF
--- a/templates/cfp_review/proposal.html
+++ b/templates/cfp_review/proposal.html
@@ -1,6 +1,6 @@
 {% from "_formhelpers.html" import render_field, render_dl_field, render_radio_field %}
 {% extends "cfp_review/base.html" %}
-{% block title %}{{proposal.title}}{% endblock %}
+{% block title %}{{proposal.published_title or proposal.title}}{% endblock %}
 {% block body %}
 
 {% set active='details' %}


### PR DESCRIPTION
Currently, if a `published_title` is not equal to `title`, then the page displays `published_title` as the talk title but the tab title shows `title` which just greatly confused me (See eg https://www.emfcamp.org/cfp-review/proposals/341)