### PR TITLE
Give sensecheck testcases allowed_periods.

### DIFF
--- a/tests/test_cfp_sense_check.py
+++ b/tests/test_cfp_sense_check.py
@@ -22,12 +22,16 @@ VENUE_TALK = Venue(name='Talk Venue', allowed_types=['talk'])
 VENUE_WORKSHOP = Venue(name='Workshop Venue', allowed_types=['workshop'])
 
 
+def _dedent_periods(periods: str) -> str:
+    return textwrap.dedent(periods).strip() + "\n"
+
+
 def _talk_with_time_period(periods) -> TalkProposal:
     return TalkProposal(
         scheduled_time=parse('2024-05-30 12:00:00 BST'),
         scheduled_venue=VENUE_TALK,
         scheduled_duration=25,
-        allowed_times=textwrap.dedent(periods).strip() + "\n",
+        allowed_times=_dedent_periods(periods),
     )
 
 
@@ -37,6 +41,9 @@ def _talk_with_time_period(periods) -> TalkProposal:
         scheduled_time=parse('2024-05-30 12:00:00 BST'),
         scheduled_venue=VENUE_TALK,
         scheduled_duration=25,
+        allowed_times=_dedent_periods('''
+            2024-05-30 12:00:00 > 2024-05-30 12:25:00
+        '''),
     ), set(), id="correctly-scheduled"),
     # Not scheduled but accepted
     pytest.param(TalkProposal(), {'not_scheduled', 'no_duration'}, id="accepted-but-not-scheduled"),
@@ -44,11 +51,17 @@ def _talk_with_time_period(periods) -> TalkProposal:
     pytest.param(TalkProposal(
         scheduled_time=parse('2024-05-30 12:00:00 BST'),
         scheduled_duration=25,
+        allowed_times=_dedent_periods('''
+            2024-05-30 12:00:00 > 2024-05-30 12:25:00
+        '''),
     ), {'scheduled_without_venue'}, id="scheduled-without-venue"),
     # No proposed venue, but has proposed time
     pytest.param(TalkProposal(
         potential_time=parse('2024-05-30 12:00:00 BST'),
         scheduled_duration=25,
+        allowed_times=_dedent_periods('''
+            2024-05-30 12:00:00 > 2024-05-30 12:25:00
+        '''),
     ), {'proposed_without_venue'}, id="proposed-without-venue"),
     # Before event
     pytest.param(TalkProposal(
@@ -57,7 +70,10 @@ def _talk_with_time_period(periods) -> TalkProposal:
         scheduled_time=parse('2024-05-30 10:00:00 BST'),  # 2 hours before 12 noon
         scheduled_venue=VENUE_TALK,
         scheduled_duration=180,
-    ), {'proposed_start', 'scheduled_start'}, id="before-event"),
+        allowed_times=_dedent_periods('''
+            2024-05-29 12:00:00 > 2024-06-03 12:00:00
+        '''),
+    ), {'proposed_start', 'scheduled_start', 'period_0_too_long'}, id="before-event"),
     # After event
     pytest.param(TalkProposal(
         potential_time=parse('2024-06-03 01:00:00 BST'),  # 1 hour before 2am (i.e. in bounds, but end is not)
@@ -65,7 +81,10 @@ def _talk_with_time_period(periods) -> TalkProposal:
         scheduled_time=parse('2024-06-03 04:00:00 BST'),  # 2 hours after 2am
         scheduled_venue=VENUE_TALK,
         scheduled_duration=180,
-    ), {'scheduled_start', 'scheduled_end', 'proposed_end', 'proposed_end_quiet', 'scheduled_start_quiet', 'scheduled_end_quiet'}, id="after-event"),
+        allowed_times=_dedent_periods('''
+            2024-05-29 12:00:00 > 2024-06-03 12:00:00
+        '''),
+    ), {'scheduled_start', 'scheduled_end', 'proposed_end', 'proposed_end_quiet', 'scheduled_start_quiet', 'scheduled_end_quiet', 'period_0_too_long'}, id="after-event"),
     # During event, but between 2am and 9am
     pytest.param(TalkProposal(
         potential_time=parse('2024-06-01 03:00:00 BST'),  # 1 hour after 2am
@@ -73,7 +92,10 @@ def _talk_with_time_period(periods) -> TalkProposal:
         scheduled_time=parse('2024-06-01 04:00:00 BST'),  # 2 hours after 2am
         scheduled_venue=VENUE_TALK,
         scheduled_duration=25,
-    ), {'proposed_start_quiet', 'proposed_end_quiet', 'scheduled_start_quiet', 'scheduled_end_quiet'}, id="in-quiet-period"),
+        allowed_times=_dedent_periods('''
+            2024-05-29 12:00:00 > 2024-06-03 12:00:00
+        '''),
+    ), {'proposed_start_quiet', 'proposed_end_quiet', 'scheduled_start_quiet', 'scheduled_end_quiet', 'period_0_too_long'}, id="in-quiet-period"),
     # Scheduled in wrong type of venue
     pytest.param(TalkProposal(
         potential_time=parse('2024-05-30 12:00:00 BST'),
@@ -81,10 +103,14 @@ def _talk_with_time_period(periods) -> TalkProposal:
         scheduled_time=parse('2024-05-30 12:00:00 BST'),
         scheduled_venue=VENUE_WORKSHOP,
         scheduled_duration=25,
+        allowed_times=_dedent_periods('''
+            2024-05-30 12:00:00 > 2024-05-30 12:25:00
+        '''),
     ), {'proposed_venue_illegal', 'scheduled_venue_illegal'}, id="illegal-venue"),
     # Time period ends before it starts
     pytest.param(_talk_with_time_period('''
         2024-05-30 11:00:00 > 2024-05-30 10:00:00
+        2024-05-30 12:00:00 > 2024-05-30 12:25:00
     '''), {'period_0_starts_after_end'}, id="period-ends-before-it-starts"),
     # Time period spans multiple days (and therefore overlaps the quiet period)
     pytest.param(_talk_with_time_period('''
@@ -93,17 +119,21 @@ def _talk_with_time_period(periods) -> TalkProposal:
     # Time period starts in 2am-9am quiet period
     pytest.param(_talk_with_time_period('''
         2024-05-30 03:00:00 > 2024-05-30 12:00:00
+        2024-05-30 12:00:00 > 2024-05-30 12:25:00
     '''), {'period_0_starts_in_quiet'}, id="period-starts-in-quiet"),
     # Time period ends in 2am-9am quiet period
     pytest.param(_talk_with_time_period('''
         2024-05-30 01:00:00 > 2024-05-30 03:00:00
+        2024-05-30 12:00:00 > 2024-05-30 12:25:00
     '''), {'period_0_ends_in_quiet'}, id="period-ends-in-quiet"),
     # Time period spans before and after quiet period
     pytest.param(_talk_with_time_period('''
         2024-05-30 01:00:00 > 2024-05-30 10:00:00
+        2024-05-30 12:00:00 > 2024-05-30 12:25:00
     '''), {'period_0_same_day_subsumes_quiet'}, id="period-same-day-subsumes-quiet"),
     pytest.param(_talk_with_time_period('''
         2024-05-29 22:00:00 > 2024-05-30 10:00:00
+        2024-05-30 12:00:00 > 2024-05-30 12:25:00
     '''), {'period_0_different_day_subsumes_quiet'}, id="period-different-day-subsumes-quiet"),
 ])
 def test_cfp_sense_check(override_event_time, inp, expected):


### PR DESCRIPTION
We now check to make sure that scheduled proposals are happening inside their allowed periods, so we need to ensure that our testcases have them, or accept the error.

Maybe the big function-o-doom should be split up so it's possible to test bits of it without testing the whole thing end-to-end. Ho hum.