### PR TITLE
Make clashfinder input stable

### DIFF
--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -1239,7 +1239,7 @@ def clashfinder():
         user_counts[user].append(proposal)
 
     for proposals in user_counts.values():
-        popularity.update(combinations(proposals, 2))
+        popularity.update(combinations(sorted(proposals), 2))
 
     clashes = []
     offset = 0


### PR DESCRIPTION
Without this you can end up with talk clashes being reported both ways round depending on how the talks were favourited by users.