### PR TITLE
Add a map link to the event description in the ICS view

### DIFF
--- a/apps/schedule/feeds.py
+++ b/apps/schedule/feeds.py
@@ -26,8 +26,18 @@ def _format_event_description(event):
         description += "\n\nAttending this workshop will cost: " + event["cost"]
         description += "\nSuitable age range: " + event["age_range"]
         description += "\nAttendees should bring: " + event["equipment"]
+
+    footer_block = []
     if event["link"]:
-        description += "\n\nLink: " + event["link"]
+        footer_block.append(f'Link: {event["link"]}')
+    if event["venue"]:
+        venue_str = event["venue"]
+        if event["map_link"]:
+            venue_str = f'{venue_str} ({event["map_link"]})'
+        footer_block.append(f'Venue: {venue_str}')
+    if footer_block:
+        description += '\n\n' + '\n'.join(footer_block)
+
     return description
 
 

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -799,7 +799,7 @@ class Proposal(BaseModel):
     def map_link(self) -> Optional[str]:
         latlon = self.latlon
         if latlon:
-            return "https://map.emfcamp.org/#18.5/%s/%s" % (latlon[0], latlon[1])
+            return "https://map.emfcamp.org/#18.5/%s/%s/m=%s,%s" % (latlon[0], latlon[1], latlon[0], latlon[1])
         return None
 
     @property


### PR DESCRIPTION
This is convenient for some very basic calendar apps that don't show descriptions, and for people who forget where venues are and want a link to the map (because we can't easily do that in the location field).