### PR TITLE
Drop the entrance infodesk roles

### DIFF
--- a/apps/volunteer/shifts/info_volunteer.py
+++ b/apps/volunteer/shifts/info_volunteer.py
@@ -16,14 +16,6 @@ info_vol_shifts = {
                 "min": 1,
                 "max": 3,
             },
-        ],
-        "Entrance Tent": [
-            {
-                "first": edt(d, "10:00:00"),
-                "final": edt(d, "18:00:00"),
-                "min": 1,
-                "max": 1,
-            } for d in ["thurs", "fri"]
         ]
     },
     "Volunteer Manager": {


### PR DESCRIPTION
It's not certain that we'll have anywhere for them to go. Should somewhere become apparent we'll bump volunteer requirements for the main infodesk up.