### PR TITLE
Fix incorrect lottery date month

### DIFF
--- a/templates/schedule/event_tickets.html
+++ b/templates/schedule/event_tickets.html
@@ -62,7 +62,7 @@
 
         <p>
           {# FIXME hard coded date alert event_start should find this but I CBA with date calculations rn #}
-          The lottery will be run on Wednesday 29th June 2024
+          The lottery will be run on Wednesday 29th May 2024.
         </p>
 
         <hr>


### PR DESCRIPTION
Switch lottery date month from June to May on event_tickets page.