### PR TITLE
Misc schedule tweaks

### DIFF
--- a/js/schedule/Calendar.jsx
+++ b/js/schedule/Calendar.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import octicons from '@primer/octicons';
 import nl2br from 'react-nl2br';
+import Linkify from "linkify-react";
 
 function Icon({ name, className, size, label }) {
   let svg = octicons[name].toSVG({ 'aria-label': label, width: size, height: size });
@@ -106,7 +107,7 @@ function Event({ event, toggleFavourite, authenticated }) {
         <AdditionalInformation label="Cost" value={ event.cost } />
         <AdditionalInformation label="Required equipment" value={ event.equipment } />
 
-        <p>{ nl2br(event.description) }</p>
+        <p><Linkify options={{target:'blank'}}>{ nl2br(event.description) }</Linkify></p>
         <p>
           <a href={ event.link } target="_blank" class="btn btn-default"><Icon name="link" size="16" /> Details</a>&nbsp;
           <FavouriteButton event={ event } toggleFavourite={ toggleFavourite } authenticated={ authenticated } />&nbsp;

--- a/js/schedule/Calendar.jsx
+++ b/js/schedule/Calendar.jsx
@@ -106,9 +106,12 @@ function Event({ event, toggleFavourite, authenticated }) {
         <AdditionalInformation label="Cost" value={ event.cost } />
         <AdditionalInformation label="Required equipment" value={ event.equipment } />
 
-        <p>{ nl2br(event.description) }</p><p><a href={ event.link } target="_blank"><Icon name="link" size="16" label="Link to this content" />Details</a></p>
-        <FavouriteButton event={ event } toggleFavourite={ toggleFavourite } authenticated={ authenticated } />
-        <TicketButton event={event} authenticated={authenticated} />
+        <p>{ nl2br(event.description) }</p>
+        <p>
+          <a href={ event.link } target="_blank" class="btn btn-default"><Icon name="link" size="16" /> Details</a>&nbsp;
+          <FavouriteButton event={ event } toggleFavourite={ toggleFavourite } authenticated={ authenticated } />&nbsp;
+          <TicketButton event={event} authenticated={authenticated} />
+        </p>
       </div>
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "datatables.net-bs": "^2.0.7",
         "jquery": "^3.7.1",
         "jquery-highlight": "^3.5.0",
+        "linkify-react": "^4.1.3",
+        "linkifyjs": "^4.1.3",
         "luxon": "^1.28.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
@@ -5640,6 +5642,20 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/linkify-react": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkify-react/-/linkify-react-4.1.3.tgz",
+      "integrity": "sha512-rhI3zM/fxn5BfRPHfi4r9N7zgac4vOIxub1wHIWXLA5ENTMs+BGaIaFO1D1PhmxgwhIKmJz3H7uCP0Dg5JwSlA==",
+      "peerDependencies": {
+        "linkifyjs": "^4.0.0",
+        "react": ">= 15.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.3.tgz",
+      "integrity": "sha512-auMesunaJ8yfkHvK4gfg1K0SaKX/6Wn9g2Aac/NwX+l5VdmFZzo/hdPGxEOETj+ryRa4/fiOPjeeKURSAJx1sg=="
     },
     "node_modules/load-json-file": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "datatables.net-bs": "^2.0.7",
     "jquery": "^3.7.1",
     "jquery-highlight": "^3.5.0",
+    "linkifyjs": "^4.1.3",
+    "linkify-react": "^4.1.3",
     "luxon": "^1.28.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -79,6 +79,9 @@
     {{ favourite_icons() }}
     &nbsp;Favourite
   </button>
+  {% if feature_enabled('SCHEDULE') and proposal.map_link %}
+  <a href="{{ proposal.map_link }}" target="_blank" class="btn btn-primary favourite-button">📍&nbsp;Map</a>
+  {% endif %}
   <div class="pull-right">
     {% if SIGNUP_STATE == "issue-lottery-tickets" and proposal.requires_ticket %}
       {% if proposal.has_lottery_capacity() %}


### PR DESCRIPTION
* Convert links in proposal descriptions into clickable links in schedule expand view (Fixes #1607)
* Converts the "Details" link into a button, as it can now look like it is a link in the description
* Add a map button to the proposal page as people miss the clickable venue link