### PR TITLE
Schedule fixes

### DIFF
--- a/js/schedule/Calendar.jsx
+++ b/js/schedule/Calendar.jsx
@@ -66,6 +66,14 @@ function FavouriteButton({ event, toggleFavourite, authenticated }) {
   );
 }
 
+function TicketButton({ event, authenticated }) {
+  if (!authenticated || !event.requires_ticket) { return null; }
+
+  return (
+    <a href={event.link} className="btn btn-primary">Request Tickets</a>
+  )
+}
+
 function AdditionalInformation({ label, value }) {
   if (value === null || value === undefined || value == "Unspecified" || value == "") { return null; }
 
@@ -100,6 +108,7 @@ function Event({ event, toggleFavourite, authenticated }) {
 
         <p>{ nl2br(event.description) }</p><p><a href={ event.link } target="_blank"><Icon name="link" size="16" label="Link to this content" />Details</a></p>
         <FavouriteButton event={ event } toggleFavourite={ toggleFavourite } authenticated={ authenticated } />
+        <TicketButton event={event} authenticated={authenticated} />
       </div>
     );
   }

--- a/js/schedule/Filters.jsx
+++ b/js/schedule/Filters.jsx
@@ -60,12 +60,13 @@ function Filters({ schedule, onlyFavourites, setOnlyFavourites, onlyFamilyFriend
           labels={ schedule.eventTypes.map(t => t.name) }
           onChange={ setSelectedEventTypes } />
 
-        <h3>Age Ranges</h3>
+        { /* Hidden because they're a mess. */}
+        {/* <h3>Age Ranges</h3>
         <CheckboxGroup
           options={ schedule.ageRanges }
           selectedOptions={ selectedAgeRanges }
           labels={ schedule.ageRanges }
-          onChange={ setSelectedAgeRanges } />
+          onChange={ setSelectedAgeRanges } /> */}
 
         <DebugOptions debug={ debug } currentTime={ currentTime } setCurrentTime={ setCurrentTime } />
       </div>

--- a/js/schedule/ScheduleData.jsx
+++ b/js/schedule/ScheduleData.jsx
@@ -54,9 +54,21 @@ class ScheduleData {
       this.scheduleByHour[isoHour].push(e);
     });
 
+    this.venuePriority = (venue) => {
+      if (venue.name.startsWith("Stage")) { return 999 }
+      if (venue.name.startsWith("Workshop")) { return 900 }
+      return 1;
+    };
+
     this.venues = this.venues.sort((a,b) => {
       if (a.official && !b.official) { return -1; }
       if (!a.official && b.official) { return 1; }
+
+      // Horrible code, used for prioritising stages and workshops.
+      let priority_a = this.venuePriority(a);
+      let priority_b = this.venuePriority(b);
+      if (priority_a > priority_b) { return -1; }
+      if (priority_b > priority_a) { return 1; }
 
       return a.name.localeCompare(b.name);
     });
@@ -89,7 +101,13 @@ class ScheduleData {
   }
 
   addVenue(name, official) {
-    if (this.venuesSeen.has(name)) { return null; }
+    if (this.venuesSeen.has(name)) {
+      // More nasty hacks to handle venues with mixed content not being marked
+      // as one of our's if the first event in that venue is attendee content.
+      if (official) {
+        this.venues.find(v => v["name"] == name)["official"] = official;
+      }
+    }
 
     this.venuesSeen.add(name);
     this.venues.push({ name: name, official: official });

--- a/js/schedule/ScheduleData.jsx
+++ b/js/schedule/ScheduleData.jsx
@@ -120,7 +120,7 @@ class ScheduleData {
 
     e.startTime = DateTime.fromSQL(e.start_date, { locale: 'en-GB' });
     e.endTime = DateTime.fromSQL(e.end_date, { locale: 'en-GB' });
-    e.officialEvent = e.source === 'database';
+    e.officialEvent = e.is_from_cfp;
 
     e.noRecording = !e.may_record && e.officialEvent && e.type === 'talk';
 


### PR DESCRIPTION
* Hide the age range filter because people can't be trusted with free text fields
* We now have an explicit flag for CFP content, use it
* Force venues with CFP content in them to sort at the top of the venue list - Stages > Workshops > Everything else
* Add a button on the expanded view to request tickets for ticketed events