### PR TITLE
Allow recording permission for performances

### DIFF
--- a/templates/cfp/finalise.html
+++ b/templates/cfp/finalise.html
@@ -106,7 +106,7 @@
 
     <fieldset>
         <legend>Final Requirements</legend>
-        {% if proposal.type == 'talk' %}
+        {% if proposal.type in ['talk', 'performance'] %}
         {{ render_field(form.may_record, 7) }}
         {{ render_field(form.needs_laptop, 7) }}
         {% endif %}

--- a/templates/cfp_review/proposal.html
+++ b/templates/cfp_review/proposal.html
@@ -197,7 +197,7 @@
                             <dl class="dl-horizontal">
                                 {{ render_dl_field(form.telephone_number) }}
                                 {{ render_dl_field(form.eventphone_number) }}
-                                {% if proposal.type == 'talk' %}
+                                {% if proposal.type in ['talk', 'performance'] %}
                                     {{ render_dl_field(form.may_record) }}
                                     {{ render_radio_field(form.needs_laptop) }}
                                 {% endif %}

--- a/templates/volunteer/info/emergency.md
+++ b/templates/volunteer/info/emergency.md
@@ -17,6 +17,6 @@ If you encounter a fire (and it's not meant to be there), follow the steps below
 
 In most cases people who need first aid should make their own way to the first aid tent, which can be found near the bar.
 
-If someone is unable to safely get to the first aid tent, request the first aid team either via radio, or by calling First Aid: 1008 / First Aid Emergency 1009. Unless you are qualified to do so, or the person is in imminent danger, you should not attempt to perform first aid yourself.
+If someone is unable to safely get to the first aid tent, request the first aid team either via radio, or by calling First Aid: 1090 / First Aid Emergency 1099. Unless you are qualified to do so, or the person is in imminent danger, you should not attempt to perform first aid yourself.
 
 Do not call 999, we have an ambulance on site and people will get help quicker by calling first aid.

--- a/templates/volunteer/info/index.md
+++ b/templates/volunteer/info/index.md
@@ -33,12 +33,12 @@ Click the button below to register as a volunteer, which will allow you to choos
 
 ## Queries
 
-If you have any queries about volunteering (or issues during a shift) you can get in touch with the volunteer desk by emailing [volunteer@emfcamp.org](mailto:volunteer@emfcamp.org), calling 1038 on the internal EMF phone system, or stopping by the desk in the [Info tent](https://map.emfcamp.org/#21.46/52.0416706/-2.3770618).
+If you have any queries about volunteering (or issues during a shift) you can get in touch with the volunteer desk by emailing [volunteer@emfcamp.org](mailto:volunteer@emfcamp.org), calling 1009 on the internal EMF phone system, or stopping by the desk in the [Info tent](https://map.emfcamp.org/#21.46/52.0416706/-2.3770618).
 
 <!-- TODO: Move these somewhere else -->
 # Important numbers
 
-From external phones:  
+From external phones (tbc):  
 
 <dl class="dl-horizontal">
   <dt>EMERGENCY <br />First Aid</dt><dd>01908 870909</dd>
@@ -51,14 +51,14 @@ Internal to EMF phone system:
 
 <dl class="dl-horizontal">
   <dt>Infodesk <br />(switchboard)</dt><dd>1001</dd>
-  <dt>Logistics</dt><dd>1002</dd>
+  <dt>Logistics</dt><dd>1030</dd>
   <dt>Site Manager</dt><dd>1004</dd>
-  <dt>Creche</dt><dd>1005</dd>
-  <dt>First Aid Tent</dt><dd>1008</dd>
-  <dt>EMERGENCY <br />First Aid</dt><dd>1009</dd>
+  <dt>Creche</dt><dd>1040</dd>
+  <dt>First Aid Tent</dt><dd>1090</dd>
+  <dt>EMERGENCY <br />First Aid</dt><dd>1099</dd>
   <dt>HQ</dt><dd>1011</dd>
-  <dt>Conduct</dt><dd>1012</dd>
-  <dt>Volunteer desk</dt><dd>1038</dd>
+  <dt>Conduct</dt><dd>1234</dd>
+  <dt>Volunteer desk</dt><dd>1009</dd>
 </dl>
 
 <a href="{{ url_for('base.page', page_name='volunteering') }}">About volunteering (orga-side)</a>

--- a/templates/volunteer/info/index.md
+++ b/templates/volunteer/info/index.md
@@ -38,27 +38,25 @@ If you have any queries about volunteering (or issues during a shift) you can ge
 <!-- TODO: Move these somewhere else -->
 # Important numbers
 
-From external phones (tbc):  
+The festival runs an internal phone system - [this guide explains the types of phone it works with and how to use it](/about/phones) if you bring one with you. The [internal directory](https://phones.emfcamp.org) covers most numbers but you should also receive a contacts sticker as part of your training.
+
+Please avoid contacting HQ or the duty Site Manager except for [genuine emergencies](/volunteer/info/emergency) (e.g. fire where fire shouldn't be) where a member of staff or other team isn't available to help.
 
 <dl class="dl-horizontal">
-  <dt>EMERGENCY <br />First Aid</dt><dd>01908 870909</dd>
-  <dt>First aid Tent</dt><dd>01908 870908</dd>
-  <dt>Site manager</dt><dd>01908 870904</dd>
-  <dt>Conduct</dt><dd>01908 870912</dd>
-</dl>
-
-Internal to EMF phone system: 
-
-<dl class="dl-horizontal">
+  <dt>Volunteer desk</dt><dd>1009</dd>
   <dt>Infodesk <br />(switchboard)</dt><dd>1001</dd>
-  <dt>Logistics</dt><dd>1030</dd>
-  <dt>Site Manager</dt><dd>1004</dd>
-  <dt>Creche</dt><dd>1040</dd>
+  <dt>Conduct</dt><dd>1234</dd>
   <dt>First Aid Tent</dt><dd>1090</dd>
   <dt>EMERGENCY <br />First Aid</dt><dd>1099</dd>
+  <dt>Site Manager</dt><dd>1010</dd>
   <dt>HQ</dt><dd>1011</dd>
-  <dt>Conduct</dt><dd>1234</dd>
-  <dt>Volunteer desk</dt><dd>1009</dd>
+</dl>
+
+If you're just using your usual mobile and SIM card, you'll only be able to call external numbers and you may find reception poor. Smart phones with WiFi calling may get better coverage that way. The on-site team will be able to get emergency help to someone more quickly than by calling 999.
+
+<dl class="dl-horizontal">
+  <dt>Conduct</dt><dd>0333 112 2944</dd>
+  <dt>Medical Emergency</dt><dd>(tbc)</dd>
 </dl>
 
 <a href="{{ url_for('base.page', page_name='volunteering') }}">About volunteering (orga-side)</a>


### PR DESCRIPTION
Fix for issue #1590

Updated the admin form and proposer form to show the checkbox for allowing recording for performances, not just talks as before. Tested both locally and ran the unit tests, all good.