### PR TITLE
Fix for issue #1590 (Allow recording permission for performances)

### DIFF
--- a/templates/cfp/finalise.html
+++ b/templates/cfp/finalise.html
@@ -106,7 +106,7 @@
 
     <fieldset>
         <legend>Final Requirements</legend>
-        {% if proposal.type == 'talk' %}
+        {% if proposal.type in ['talk', 'performance'] %}
         {{ render_field(form.may_record, 7) }}
         {{ render_field(form.needs_laptop, 7) }}
         {% endif %}

--- a/templates/cfp_review/proposal.html
+++ b/templates/cfp_review/proposal.html
@@ -197,7 +197,7 @@
                             <dl class="dl-horizontal">
                                 {{ render_dl_field(form.telephone_number) }}
                                 {{ render_dl_field(form.eventphone_number) }}
-                                {% if proposal.type == 'talk' %}
+                                {% if proposal.type in ['talk', 'performance'] %}
                                     {{ render_dl_field(form.may_record) }}
                                     {{ render_radio_field(form.needs_laptop) }}
                                 {% endif %}


### PR DESCRIPTION
Fix for issue https://github.com/emfcamp/Website/issues/1590

Updated the admin form and proposer form to show the checkbox for allowing recording for performances, not just talks as before. Tested both locally and ran the unit tests, all good.