### PR TITLE
Initial cleanup of ages

### DIFF
--- a/models/cfp.py
+++ b/models/cfp.py
@@ -110,21 +110,16 @@ AGE_RANGE_OPTIONS = [
         "Aimed at adults, but supervised kids welcome.",
         "Aimed at adults, but supervised kids welcome.",
     ),
-    ("3+", "3+"),
-    ("4+", "4+"),
     ("5+", "5+"),
-    ("6+", "6+"),
-    ("7+", "7+"),
+    ("6+", "6+"), # TODO: Remove in future to simplify ages
+    ("7+", "7+"), # TODO: Remove in future to simplify ages
     ("8+", "8+"),
-    ("9+", "9+"),
     ("10+", "10+"),
-    ("11+", "11+"),
+    ("11+", "11+"), # TODO: Remove in future to simplify ages
     ("12+", "12+"),
-    ("13+", "13+"),
     ("14+", "14+"),
-    ("15+", "15+"),
     ("16+", "16+"),
-    ("17+", "17+"),
+    ("17+", "17+"), # TODO: Remove in future to simplify ages
     ("18+", "18+"),
 ]
 


### PR DESCRIPTION
First pass for only ages not currently in use for 2024. Goal being to remove other ages for 2026.

Removes
- 3+
- 4+
- 9+
- 13+
- 15+

As there are no workshops currently using these values.