### PR TITLE
Link to the ticket lottery about page from the schedule

### DIFF
--- a/templates/schedule/event_tickets.html
+++ b/templates/schedule/event_tickets.html
@@ -39,7 +39,7 @@
 
 <div>
   For more details about how the lottery works please see
-  <a href="{{ url_for('.about_event_tickets') }}">our about page.</a>
+  <a href="{{ url_for('.about_event_tickets') }}">our about page</a>.
 </div>
 
 <noscript>
@@ -108,7 +108,7 @@
     </form>
   </div>
 {% else %}
-  <div class="well">You don't currently have any workshop or youthworkshop tickets. Checkout
+  <div class="well">You don't currently have any workshop or youth workshop tickets. Checkout
     the <a href="{{url_for('.main_year', year=2024)}}">line up</a> to add some!</div>
 
 {% endif %}

--- a/templates/schedule/line-up.html
+++ b/templates/schedule/line-up.html
@@ -13,10 +13,6 @@
     <p>You can favourite talks which sound interesting, which will let you keep track of them, and help
         our scheduling algorithm place them in the best slot.
     </p>
-    <p>
-      <strong><a class="btn btn-lg btn-primary" href="{{ url_for('.favourites') }}">View your favourites</a></strong>
-      <strong><a class="btn btn-lg btn-primary" href="{{ url_for('.event_tickets') }}">View your workshop tickets</a></strong>
-    </p>
     {% if feature_enabled('SCHEDULE') %}
     <p>You can also get this list as an <a href="{{ url_for('.schedule_ical', year=event_year) }}">iCal feed</a>
        for your calendar, and a <a href="{{ url_for('.schedule_json', year=event_year) }}">json feed</a> for your giant robot.
@@ -27,6 +23,18 @@
     Please <a class="alert-link" href="{{ url_for('users.login', next=url_for('.main')) }}" target="_new">log in</a> to let us know your favourite talks or workshops.
     You'll be able to download a calendar of these for the event.
   </div>
+  {% endif %}
+
+  <p>
+    Workshops that require you to sign up for a ticket will be allocated via
+    <a href="{{ url_for('.about_event_tickets') }}" title="About the workshop ticket lottery">a lottery</a>.
+  </p>
+
+  {% if current_user.is_authenticated %}
+    <p>
+      <strong><a class="btn btn-lg btn-primary" href="{{ url_for('.favourites') }}">View your favourites</a></strong>
+      <strong><a class="btn btn-lg btn-primary" href="{{ url_for('.event_tickets') }}">View your workshop tickets</a></strong>
+    </p>
   {% endif %}
 </div>
 


### PR DESCRIPTION
Make it easier to find the ticket lottery about page from the schedule
without having to "view your workshop tickets", which you wouldn't do
until after you've signed up to a lottery you know nothing about.
    
The "View" buttons have to be moved down otherwise putting text below
them looks odd.

Add missing space and adjust punctuation on the ticket lottery page.
