### PR TITLE
Make the schedule more WCAG compliant

### DIFF
--- a/css/schedule.scss
+++ b/css/schedule.scss
@@ -66,7 +66,7 @@
 }
 
 .schedule-event {
-  background-color: $schedule-block;
+  background-color: darken($schedule-block, 10%);
   color: $schedule-text;
   padding: 0.5em;
   border-radius: 5px;


### PR DESCRIPTION
I wanted to just use the theme colour for the talk cards, but it's a bit light, and the text contrast doesn't quite meet WCAG AA. Let's just darken it by 10% so it meets AA for normal text, at least.