### PR TITLE
Add /arcade and program

### DIFF
--- a/apps/base/__init__.py
+++ b/apps/base/__init__.py
@@ -198,7 +198,7 @@ def orga_links():
 
 from . import redirects  # noqa
 from . import about  # noqa
-#from . import arcade 
+from . import arcade 
 from . import organisation  # noqa
 from . import scheduled_tasks  # noqa
 from . import tasks_admin  # noqa

--- a/apps/base/__init__.py
+++ b/apps/base/__init__.py
@@ -198,7 +198,7 @@ def orga_links():
 
 from . import redirects  # noqa
 from . import about  # noqa
-from . import arcade 
+from . import arcade # noqa
 from . import organisation  # noqa
 from . import scheduled_tasks  # noqa
 from . import tasks_admin  # noqa

--- a/apps/base/__init__.py
+++ b/apps/base/__init__.py
@@ -198,6 +198,7 @@ def orga_links():
 
 from . import redirects  # noqa
 from . import about  # noqa
+#from . import arcade 
 from . import organisation  # noqa
 from . import scheduled_tasks  # noqa
 from . import tasks_admin  # noqa

--- a/apps/base/arcade.py
+++ b/apps/base/arcade.py
@@ -1,0 +1,61 @@
+"""
+    Pages under /arcade - the arcade program.
+
+    Content about EMF the organisation should go in /organisation (organisation.py),
+    although some legacy content remains here.
+"""
+
+from flask import (
+    abort,
+    current_app as app,
+    render_template,
+    render_template_string,
+)
+from markdown import markdown
+from os import path
+from pathlib import Path
+
+from markupsafe import Markup
+from yaml import safe_load as parse_yaml
+from . import base
+
+
+def page_template(metadata):
+    if "page_template" in metadata:
+        return metadata["page_template"]
+
+    if "show_nav" not in metadata or metadata["show_nav"] is True:
+        return "arcade/template.html"
+    else:
+        return "static_page.html"
+
+
+def render_markdown(source, **view_variables):
+    template_root = Path(path.join(app.root_path, app.template_folder)).resolve()
+    source_file = template_root.joinpath(f"{source}.md").resolve()
+
+    if not source_file.is_relative_to(template_root) or not source_file.exists():
+        return abort(404)
+
+    with open(source_file, "r") as f:
+        source = f.read()
+        (metadata, content) = source.split("---", 2)
+        metadata = parse_yaml(metadata)
+        content = Markup(
+            markdown(
+                render_template_string(content),
+                extensions=["markdown.extensions.nl2br"],
+            )
+        )
+
+    view_variables.update(content=content, title=metadata["title"])
+    return render_template(page_template(metadata), **view_variables)
+
+
+@base.route("/arcade/<page_name>")
+def arcade_page(page_name: str):
+    return render_markdown(f"arcade/{page_name}", page_name=page_name)
+
+@base.route("/arcade")
+def arcade():
+    return render_template("arcade/index.html")

--- a/templates/arcade/alba.md
+++ b/templates/arcade/alba.md
@@ -1,0 +1,14 @@
+title: Alba A Wildlife Adventure
+---
+# Alba: A Wildlife Adventure
+## ustwo games, 2020
+
+**URL**: [https://www.albawildlife.com/](https://www.albawildlife.com/)
+
+Even the smallest person can make a big difference. Join Alba, as she sets out to save her beautiful island and its wildlife. And possibly start a revolution.
+
+### Awards
+Apple Design Awards, Social (2021).
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/animal-well.md
+++ b/templates/arcade/animal-well.md
@@ -1,0 +1,11 @@
+title: Animal Well
+---
+# Animal Well
+## Shared Memory, 2024
+
+**URL**: [https://bigmode.com/games/animal-well](https://bigmode.com/games/animal-well)
+
+Explore a dense, interconnected labyrinth, and unravel its many secrets. Collect items to manipulate your environment in surprising and meaningful ways. Encounter beautiful and unsettling creatures, as you attempt to survive what lurks in the dark. There is more than what you see.
+
+### Age
+Suitable for ages 7+.

--- a/templates/arcade/assemble-with-care.md
+++ b/templates/arcade/assemble-with-care.md
@@ -1,0 +1,14 @@
+title: Assemble With Care
+---
+# Assemble With Care
+## ustwo games, 2019
+
+**URL**: [https://www.assemblegame.com/](https://www.assemblegame.com/)
+
+Repair old-school objects in this cozy puzzle game.
+
+### Awards
+BAFTA - EE Mobile Game of the Year Nominee 2020
+
+### Age
+Suitable for 4+.

--- a/templates/arcade/climate-survivors.md
+++ b/templates/arcade/climate-survivors.md
@@ -1,0 +1,11 @@
+title: Climate Survivors
+---
+# Climate Survivors
+## Terragami, 2024
+
+**URL**: [http://climate-survivors.com/](http://climate-survivors.com/)
+
+In Climate Survivors, you’re tackling the climate crisis head on and guns blazing. Fight hordes of environmental hazards empowered by global heating, dodge their merciless attacks and … survive! Climate Survivors is a top-down shoot 'em up infused by climate science, where players travel to different locations in the world and face climate hazards most pressing there — droughts, floods, invasive species and many more. They fight back using weapons and upgrades based on low-carbon options available to society already today. Their strategic choices affect how dangerous hazards and how hard — or easy — the fight against them will become… and what life on Earth might look like in 2100. Climate Survivors is currently a constantly evolving prototype. In its current version, the game is focused on the core action, where players dodge and fight against looming climate hazards in Austria. The next versions will see the implementation of a wider range of weapons and hazard monsters, as well as a more elaborate upgrade system.
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/demo.md
+++ b/templates/arcade/demo.md
@@ -1,0 +1,5 @@
+title: Demo Schedule
+---
+# Demo Schedule
+
+Check back soon for a list of demos by games developers!

--- a/templates/arcade/dikdik.md
+++ b/templates/arcade/dikdik.md
@@ -1,0 +1,12 @@
+title: Dikdik
+---
+# Dikdik
+## Izzy Kestrel & Clover Greenhalgh, 2014
+
+**URL**: [https://virtually-competent.itch.io/](https://virtually-competent.itch.io/)
+
+A competitive game for two players!
+
+### Age
+
+Suitable for everyone.

--- a/templates/arcade/downpour.md
+++ b/templates/arcade/downpour.md
@@ -1,0 +1,12 @@
+title: EMF Downpour Game Extravaganza
+---
+# EMF Downpour Game Extravaganza
+## Downpour game engine: V Buckenham, 2022
+
+**URL**: [https://downpour.games/](https://downpour.games/)
+
+Downpour is the best way to make games on your phone. Collage together photos, drawings and text, and then connect them into an interactive story. It's genuinely quick and easy to use — you can make a game before your tea has gone cold.
+
+Download the app, make a game, and tag it with #EMF for it to show up on this machine! 
+
+V Buckenham is giving a talk on [Friday at 4:40pm, Stage C](https://www.emfcamp.org/schedule/2024/320-downpour-more-how-and-why-to-make-creative-tools).

--- a/templates/arcade/game-jam.md
+++ b/templates/arcade/game-jam.md
@@ -1,0 +1,12 @@
+title: Game Jam
+---
+# Game Jam
+##  Mel Halsey
+
+There will be a 48 hour game jam over the weekend, run by Mel Halsey. 
+
+Opening session and more info here: [https://www.emfcamp.org/schedule/2024/353-game-jam](https://www.emfcamp.org/schedule/2024/353-game-jam)
+
+Closing session and show and tell here: [https://www.emfcamp.org/schedule/2024/559-game-jam-show-and-tell](https://www.emfcamp.org/schedule/2024/559-game-jam-show-and-tell)
+
+If you create a game for Downpour, tag it in the title of the game with #EMF and it should load up on the Downpour cabinet!

--- a/templates/arcade/gameboys.md
+++ b/templates/arcade/gameboys.md
@@ -1,0 +1,20 @@
+title: Matt Gray's Free Play Game Boys
+---
+# Matt Gray's Free Play Game Boys
+
+**URL**: [https://mattg.co.uk](https://mattg.co.uk)
+
+* Multiple Game Boys of various vintages
+    * Game Boy
+    * Game Boy Color
+    * Game Boy Advance
+    * Game Boy Advance SP
+* Multiple Game Boy Games
+* Multiple Game Boy Cameras
+
+All free to play, just return them when you're done and put the batteries on charge if needed!
+
+All Game Boys are free to pick up and play within the Arcade.
+
+### Age 
+Varies based on which game you pick.

--- a/templates/arcade/gamestation.md
+++ b/templates/arcade/gamestation.md
@@ -1,0 +1,16 @@
+title: Johan Peitz' Gamestation
+---
+# Johan Peitz' PICO-8 Arcade Game Bonanza
+## Johan Peitz
+
+**URL**: https://apskeppet.se/
+
+An arcade machine packed with small and easy to play arcade games.
+
+### Accessibility
+This game supports:
+* Variable difficulty settings,
+* Subtitles for spoken text. 
+
+### Age 
+Most games are suitable for children. Some fantasy violence in one of the titles.

--- a/templates/arcade/hades-ii.md
+++ b/templates/arcade/hades-ii.md
@@ -1,0 +1,14 @@
+title: Hades II
+---
+# Hades II
+## Supergiant Games, 2024
+
+**URL**: [https://www.supergiantgames.com/games/hades-ii/](https://www.supergiantgames.com/games/hades-ii/)
+
+Battle beyond the Underworld using dark sorcery to take on the Titan of Time in this bewitching sequel to the award-winning rogue-like dungeon crawler.
+
+### Accessibility
+Provides subtitles for spoken text.
+
+### Age
+This game is suitable for ages 12+.

--- a/templates/arcade/heatwav.md
+++ b/templates/arcade/heatwav.md
@@ -1,0 +1,14 @@
+title: HEAT.wav
+---
+# HEAT.wav
+## Aric McBay, 2024
+
+**URL**: [https://www.aricmcbay.org/](https://www.aricmcbay.org/)
+
+HEAT.wav is a turn-based tactical game; you play a heat demon trying to expand your domain, all under the watchful eyes of your diabolical supervisor, Beelzebud. In eight short levels, HEAT.wav playfully explores the intersection of capitalism and heat emergencies through humorous dialogue, with game mechanics inspired by real-world environmental hazards and symptoms. It was created for the March 2024 IGDA Climate SIG Microjam by Aric McBay, a gamedev and climate justice organizer.
+
+### Accessibility
+This game supports text to speech, and provides subtitles for spoken text.
+
+### Age
+The game displays a ghoulish figure that might be scary to very young children (e.g., under 6). However, there is no violence. The vocabulary and subject matter is intended for ages 12+.

--- a/templates/arcade/hyperrogue.md
+++ b/templates/arcade/hyperrogue.md
@@ -1,0 +1,19 @@
+title: HyperRogue
+---
+# HyperRogue
+## Zeno Rogue (and friends), 2011
+
+**URL**: [https://www.roguetemple.com/z/hyper/](https://www.roguetemple.com/z/hyper/)
+
+A single-character tactical game where you can use the properties of hyperbolic geometry to your tactical advantage. As the biggest non-Euclidean game, it also has lots of customization where you can change the geometry, change the gameplay, etc.
+
+### Accessibility
+This game supports:
+
+* Variable difficulty,
+* Variable control sensitivity,
+* Changing the font size,
+* Alternate colour schemes.
+
+### Age
+Suitable for everyone, some cartoon violence.

--- a/templates/arcade/index.html
+++ b/templates/arcade/index.html
@@ -1,0 +1,49 @@
+{% extends "arcade/template.html" %}
+{% block title %}About{% endblock %}
+{% block body %}
+<div id="arcade-page">
+<h1>Electromagnetic Field Arcade</h1>
+<p>Welcome to the Electromagnetic Field Arcade!</p>
+<p>Thanks to the incredible variety of cool creative people that attend and surround EMF, this year we’ve created a homemade arcade to showcase some of their fantastic work. We’re extremely grateful to the developers, publishers, and engineers who have allowed us to feature their creations for our entertainment this weekend.</p>
+
+<p>We have over 30 games in the arcade this year, including unique physical arcade machines, unusual arcade machines made out of things that were not built to be arcade machines, latest indie releases, developer platform showcases for Pico-8 and Downpour, and obscure game jam games.</p>
+
+<p>We’d especially like to highlight that a large number of games in the arcade were in some way led (created, published, lead dev/art role, etc.) by people of historically underrepresented groups in the games industry. These are:</p>
+
+<ul>
+    <li>Downpour</li>
+    <li>Pip Pepper: Park Planner</li>
+    <li>Dikdik & Tune it up!</li>
+    <li>Monument Valley 2</li>
+    <li>Alba: A Wildlife Adventure</li>
+    <li>Assemble With Care</li>
+    <li>Roundguard</li>
+    <li>Out and About</li>
+    <li>Pupperazzi</li>
+    <li>The Shrouded Isle</li>
+    <li>Mutazione</li>
+    <li>Saltsea Chronicles</li>
+    <li>Moon Hunters</li>
+    <li>Climate Survivors</li>
+    <li>Hades II</li>
+</ul>
+
+<p>We also have a selection of climate and solarpunk related games to fit with the theme. Most of these have been donated by members of the <a href="https://www.igdaclimatesig.org/">IGDA Climate Special Interest Group</a>, please enjoy:</p>
+
+<ul>
+    <li>Alba: A Wildlife Adventure</li>
+    <li>Monument Valley 2</li>
+    <li>Out and About</li>
+    <li>Climate Survivors</li>
+    <li>HEAT.wav</li>
+    <li>Was it always like this, dad?</li>
+    <li>Saltsea Chronicles</li>
+    <li>Mutazione</li>
+</ul>
+
+<p>Please check out the schedule for developer demo and Q&A sessions, information about the game jam, and browse the games we will have on display!</p>
+
+<p>The arcade will be open from some time on Thursday depending on how quickly we can get it built.</p>
+<p>9-10am each day will be a quiet session for those who would like to experience the games with low levels of sound. The more delicate machines that require attending will be closed off from 8pm at night until 9am the next day, but the main arcade machines will be open all night.</p>
+<p>Curators: Jonathan Hogg, Joe Nash, Catherine Flick & Katie Steckles</p>
+{% endblock %}

--- a/templates/arcade/index.html
+++ b/templates/arcade/index.html
@@ -46,4 +46,5 @@
 <p>The arcade will be open from some time on Thursday depending on how quickly we can get it built.</p>
 <p>9-10am each day will be a quiet session for those who would like to experience the games with low levels of sound. The more delicate machines that require attending will be closed off from 8pm at night until 9am the next day, but the main arcade machines will be open all night.</p>
 <p>Curators: Jonathan Hogg, Joe Nash, Catherine Flick & Katie Steckles</p>
+</div>
 {% endblock %}

--- a/templates/arcade/last-call-bbs.md
+++ b/templates/arcade/last-call-bbs.md
@@ -1,0 +1,22 @@
+title: Last Call BBS
+---
+# Last Call BBS
+
+## Zachtronics, 2022
+
+**URL**: [https://www.zachtronics.com/last-call-bbs/](https://www.zachtronics.com/last-call-bbs/)
+
+Boot up your Z5 Powerlance and dial into Last Call BBS, the last game from Zachtronics!
+
+The Barkeep’s loaded up his retro computer with a full set of puzzle games for you to download and play. No need to worry about copy protection, they’re all fully cracked and ready to enjoy!
+
+Games available:
+
+* **20th Century Food Court**: Design factories to produce food just like they did over 700 years ago in the 20th century. Keep your machines running fast!
+* **STEED FORCE Hobby Studio**: Assemble robot models based on the anime smash hit Steed Force right on your computer. No sandpaper required!
+* **X’BPGH**: The Forbidden Path: Enter a cursed world and create bizarre flesh sculptures in exchange for eternal life… but can you trust the master?
+* **Sawayama Solitaire**: It wouldn’t be a Zachtronics release without a brand-new solitaire game. This time it’s a fresh take on the classic Klondike.
+* **Dungeons & Diagrams**: Try your hand at these beguiling tile-based logic puzzles. Can you map out the dungeons and steal all the treasure?
+* **ChipWizard™ Professional**: Build integrated circuits using wires, transistors, and capacitors. Wait a second, is this a game or a CAD program?
+* **HACK*MATCH**: The tile-matching minigame from * EXAPUNKS, completely remastered with a single player campaign and local multiplayer.
+* **Kabufuda Solitaire**: Create matching sets of Japanese kabufuda cards in this retro-demake of the challenging original solitaire game from Eliza.

--- a/templates/arcade/lunar-lander.md
+++ b/templates/arcade/lunar-lander.md
@@ -1,0 +1,11 @@
+title: Lunar Lander
+---
+# Lunar Lander
+## Iain Sharp, 2022
+
+**URL**: [http://lushprojects.com/lunarlandermk2/](http://lushprojects.com/lunarlandermk2/)
+
+A physical model of the arcade classic Lunar Lander.
+
+### Age 
+Suitable for everyone.

--- a/templates/arcade/marathon.md
+++ b/templates/arcade/marathon.md
@@ -1,0 +1,11 @@
+title: Janey Thomson's Marathon
+---
+# Janey Thomson's Marathon
+## Matt Round, 2009
+
+**URL**: [https://mattround.com/flash/](https://mattround.com/flash/)
+
+The ultimate sporting challenge.
+
+### Age 
+Suitable for everyone.

--- a/templates/arcade/mathsteroids.md
+++ b/templates/arcade/mathsteroids.md
@@ -1,0 +1,11 @@
+title: Mathsteroids
+---
+# Mathsteroids
+## Matthew Scroggs, 2018
+
+**URL**: [https://www.mscroggs.co.uk/mathsteroids/](https://www.mscroggs.co.uk/mathsteroids/)
+
+The classic arcade game Asteroids with added maths.
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/monument-valley-2.md
+++ b/templates/arcade/monument-valley-2.md
@@ -1,0 +1,20 @@
+title: Monument Valley 2
+---
+# Monument Valley 2
+## ustwo games, 2022
+
+**URL**: [https://www.monumentvalleygame.com/mv2](https://www.monumentvalleygame.com/mv2)
+
+A game about impossibility and architecture, and a chapter about forests.
+
+### Awards
+
+* The Game Awards 2017, Best Mobile Game
+* Italian Video Game Awards, Best Mobile Game
+* 2018 Webby Awards, Best Puzzle Game
+
+### Accessibility
+This game requires sound.
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/moon-hunters.md
+++ b/templates/arcade/moon-hunters.md
@@ -1,0 +1,22 @@
+title: Moon Hunters
+---
+# Moon Hunters
+## Kitfox Games, 2016
+
+**URL**: [https://www.kitfoxgames.com/](https://www.kitfoxgames.com/)
+
+A co-op personality test about exploring an ancient, occult world in 5 days. How will you be remembered?
+
+### Awards
+
+* Montreal Independent Game Festival: Narrative Design Award,
+* PAX East 2015: Best Co-Op Experience.
+
+### Accessibility
+
+This game supports:
+* Variable difficulty settings,
+* Variable control sensitivity.
+
+### Age
+Suitable for ages 7+.

--- a/templates/arcade/mutazione.md
+++ b/templates/arcade/mutazione.md
@@ -1,0 +1,21 @@
+title: Mutazione
+---
+# Mutazione
+## Die Gute Fabrik, 2019
+
+**URL**: [https://akuparagames.itch.io/mutazione](https://akuparagames.itch.io/mutazione)
+
+A mutant soap opera where small-town gossip meets the supernatural. An adventure game where the juicy personal drama is just as important as the high-stakes adventure part of the story.
+
+### Awards
+* Excellence in Audio - IGF Awards 2020,
+* Indiecade Grand Prize 2020,
+* Spilprisen 2020 Excellence in Narrative.
+
+### Accessibility
+This game requires sound to play, but provides subtitles for spoken text.
+
+This game supports adjustable font size.
+
+### Age
+Suitable for 7+.

--- a/templates/arcade/other-games.md
+++ b/templates/arcade/other-games.md
@@ -1,0 +1,16 @@
+title: Games in Other Places
+---
+# Games in Other Places
+There are several other games around the festival site - try to find them all!
+
+* In the bar we have Appy Bird by Iain Sharp, Climax by Tim Hunkin, NERF Shooting Range by Brian Corteil, Cyber Coin Pusher by Elger Jonker and the ZAPP tabletop game by Alison,
+* In the youth lounge we have a solar-powered arcade cabinet made by Leigh Hackspace running a selection of PICO-8 games by Johan Peitz,
+* Flock by Ricky Haggett can be found in a dome,
+* We have a Monumental GameBoy by Jonathan Leach,
+* Anthony Goacher will be running regular games of Lasertag,
+* Also, keep an eye out around the site for the various games that make up the Clippy Puzzlehunt!
+
+Some games were offered for the arcade but couldn't make it in for various reasons, but you can play them from the comfort of your own phone/desktop PC!
+
+These are:
+* [Reforest Rainforest by Andreas Wildgrube](https://www.gamesfortheplanet.com/#26d7debe-785f-46d9-ba70-2f9879af2a12), where the monetisation funds reforestation efforts.

--- a/templates/arcade/out-and-about.md
+++ b/templates/arcade/out-and-about.md
@@ -1,0 +1,18 @@
+title: Wholesome Out and About
+---
+# Wholesome - Out and About
+## Yaldi Games, 2024
+
+**URL**: [https://www.yaldigames.com/](https://www.yaldigames.com/)
+
+Set out on a foraging adventure to restore your childhood home after a devastating storm! Help the community find harmony in nature! Learn real-world techniques to identify wild flora and fungi, cure plant blindness, cook tasty recipes and master herbal remedies in this cozy, sustainable life sim.
+
+### Awards
+Young Innovator Award.
+
+### Accessibility
+This game requires sound, but does have subtitles for in-game dialogue.
+
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/pip-pepper.md
+++ b/templates/arcade/pip-pepper.md
@@ -1,0 +1,14 @@
+title: Pip Pepper Park Planner
+---
+# Pip Pepper: Park Planner
+## Anzal Baig & Jose Luis Pacheco Boscan, 2024
+
+**URL**: [https://sites.google.com/view/pip-pepper](https://sites.google.com/view/pip-pepper)
+
+Pip Pepper: Park Planner is cozy park-building strategy game in which you play as a bird called Pip tasked with building a public park for animals.
+
+### Awards
+Design Achievement and Grand Prize Winner at the Just Play Awards, South by Southwest 2024.
+
+## Age
+Suitable for everyone.

--- a/templates/arcade/polybius.md
+++ b/templates/arcade/polybius.md
@@ -1,0 +1,12 @@
+title: Polybius
+---
+# Polybius
+## PBT Entertainment
+This machine just showed up in the arcade, we don't know where it came from. It's ringing a few bells though... what is this game? Could it be...?
+
+A mysterious note was left by the machine: 
+
+Warning: playing this arcade machine may cause intense psychoactive and addictive responses in players. This game is in no way associated with the US government. Please disregard any data collection activities by men in black suits. You have been warned. 
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/pupperazzi.md
+++ b/templates/arcade/pupperazzi.md
@@ -1,0 +1,17 @@
+title: Pupperazzi
+---
+# Pupperazzi
+## Sundae Month, 2022
+
+**URL**: [https://sundaemonth.com/](https://sundaemonth.com/)
+
+Photograph dogs! Take photos for fame, fortune, or just plain fun. Don’t lose yourself along the way. Your career is riding on this. Whose dogs are these??
+
+### Awards
+Best Mobile/Casual Game, Canadian Indie Game Awards.
+
+### Accessibility
+This game provides subtitles for spoken text.
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/revolution.md
+++ b/templates/arcade/revolution.md
@@ -1,0 +1,9 @@
+title: Revolution
+---
+# Revolution
+## Tim Hunkin, 2024
+
+**URL**: [https://www.timhunkin.com/index.htm](https://www.timhunkin.com/index.htm)
+
+"I think Trump and Brexit both stem from the frustration of ever growing inequality. The rich keep getting richer while the poor struggle. So I feel people will enjoy venting their frustration by humbling the super rich." - Tim Hunkin
+

--- a/templates/arcade/roundguard.md
+++ b/templates/arcade/roundguard.md
@@ -1,0 +1,22 @@
+title: Roundguard
+---
+# Roundguard
+## Wonderbelly Games, 2020
+
+**URL**: [http://wonderbellygames.com/](http://wonderbellygames.com/)
+
+Roundguard is a bouncy dungeon crawler with pinball physics, lots of loot, and a randomized castle full of oddballs. Press your luck against hordes of dangerously cute monsters and challenging roguelike elements in this all-round bouncy adventure!
+
+### Awards
+Roundguard was nominated for several game of the year awards in 2020 from sources including Golden Joystick, Destructoid, and Pocket Gamer and has appeared in many festival selections including “The PAX 10,” “Indie MEGABOOTH,” and “Day of the Devs.”
+
+### Accessibility
+
+This game supports:
+
+* Variable difficulty modes,
+* Arachnophobia mode (hides spiders in-game),
+* Zoom on action
+
+### Age
+Suitable for ages 3+, some cartoon violence.

--- a/templates/arcade/saltsea-chronicles.md
+++ b/templates/arcade/saltsea-chronicles.md
@@ -1,0 +1,23 @@
+title: Saltsea Chronicles
+---
+# Saltsea Chronicles
+## Die Gute Fabrik, 2024
+
+**URL**: [http://saltseachronicles.com/](http://saltseachronicles.com/)
+
+Saltsea Chronicles is a new story-driven adventure game from the award-winning indie studio Die Gute Fabrik (Mutazione, Sportsfriends). Captain Maja’s misfit crew must heist their impounded ship and mount a rescue. Guide the crew across islands of a post-flood world known as ‘Saltsea’. Explore strange and wonderful communities, uncover a deep conspiracy, choose where to go and which crew members to investigate with, and chart a journey through twists and turns, difficulties and delights.
+
+### Awards
+Nominations and honourable mentions: SXSW Sydney, Spilprisen, IGF awards.
+
+### Accessibility
+
+This game requires sound to play, but provides subtitles for spokne text.
+
+This game supports;
+* Variable control sensitivity,
+* Variable font sizes,
+* Alternative colour schemes.
+
+### Age
+ESRB rating is Everyone 10+ / PEGI 7

--- a/templates/arcade/shrouded-isle.md
+++ b/templates/arcade/shrouded-isle.md
@@ -1,0 +1,15 @@
+title: The Shrouded Isle
+---
+# The Shrouded Isle
+## Jongwoo Kim, Erica Lahaie, FX Bilodeau, Tanya Short, 2017
+
+**URL**: [https://www.kitfoxgames.com/shrouded-isle/](https://www.kitfoxgames.com/shrouded-isle/)
+
+The Shrouded Isle is a cult village manager. Your people look to you for leadership. Five families vie for power as the storms roll in and the world ends. You have only five years before your God awakens, but purging sinners may be difficult without confessions…
+
+### Awards
+* Polygon’s “2017’s most horrifying and heartfelt indie games”,
+* (Prototype) Ludum Dare 33 Graphics 2nd place, Mood 3rd place, Audio 4th place.
+
+### Age
+15+, contains horror themes.

--- a/templates/arcade/teletype.md
+++ b/templates/arcade/teletype.md
@@ -1,0 +1,10 @@
+title: Teletype ASR 33
+---
+# Teletype ASR 33
+## Lovingly restored by Malcolm Clark
+
+**URL**: [https://en.wikipedia.org/wiki/Teletype_Model_33](https://en.wikipedia.org/wiki/Teletype_Model_33)
+
+Come and play games on a historic icon of the computer industry from around 1963, the Teletype ASR 33.
+
+

--- a/templates/arcade/template.html
+++ b/templates/arcade/template.html
@@ -16,6 +16,7 @@
     {{view("EMF Arcade", "base.arcade")}}
     {{page("Demo Schedule", "demo")}}
     {{page("Game Jam", "game-jam")}}
+    <details>
     {{page("Last Call BBS", "last-call-bbs")}}
     {{page("Pip Pepper: Park Planner", "pip-pepper")}}
     {{page("Weasel Words", "weasel-words")}}
@@ -46,6 +47,7 @@
     {{page("Lunar Lander", "lunar-lander")}}
     {{page("Revolution", "revolution")}}
     {{page("Teletype", "teletype")}}
+    </details>
     {{page("MattG's Gameboy Space", "gameboys")}}
     {{page("Polybius", "polybius")}}
     {{page("Games in Other Places", "other-games")}}

--- a/templates/arcade/template.html
+++ b/templates/arcade/template.html
@@ -1,0 +1,56 @@
+{% macro view(title, view_name) -%}
+  <li class="{{ 'active' if request.endpoint == view_name }}">
+    <a href="{{url_for(view_name)}}">{{title}}</a>
+  </li>
+{%- endmacro %}
+{% macro page(title, target_page) -%}
+  <li class="{{ 'active' if request.endpoint == 'base.arcade_page' and page_name==target_page }}">
+    <a href="{{url_for('base.arcade_page', page_name=target_page)}}">{{title}}</a>
+  </li>
+{%- endmacro %}
+{% extends "base.html" %}
+{% set main_class = "arcade" %}
+{% block title %}{{title}}{% endblock %}
+{% block secondary_nav %}
+  <ul role="navigation list" aria-label="Arcade">
+    {{view("EMF Arcade", "base.arcade")}}
+    {{page("Demo Schedule", "demo")}}
+    {{page("Game Jam", "game-jam")}}
+    {{page("Last Call BBS", "last-call-bbs")}}
+    {{page("Pip Pepper: Park Planner", "pip-pepper")}}
+    {{page("Weasel Words", "weasel-words")}}
+    {{page("Dikdik", "dikdik")}}
+    {{page("Tune it up!", "tune-it-up")}}
+    {{page("Monument Valley 2", "monument-valley-2")}}
+    {{page("Alba: A Wildlife Adventure", "alba")}}
+    {{page("Assemble With Care", "assemble-with-care")}}
+    {{page("HyperRogue", "hyperrogue")}}
+    {{page("Roundguard", "roundguard")}}
+    {{page("Out and About", "out-and-about")}}
+    {{page("Climate Survivors", "climate-survivors")}}
+    {{page("HEAT.wav", "heatwav")}}
+    {{page("Pupperazzi", "pupperazzi")}}
+    {{page("The Shrouded Isle", "shrouded-isle")}}
+    {{page("Mutazione", "mutazione")}}
+    {{page("Saltsea Chronicles", "saltsea-chronicles")}}
+    {{page("Animal Well", "animal-well")}}
+    {{page("Moon Hunters", "moon-hunters")}}
+    {{page("Hades II", "hades-ii")}}
+    {{page("TowerFall", "towerfall")}}
+    {{page("The Book Ritual", "the-book-ritual")}}
+    {{page("Johan Peitz' Gamestation", "gamestation")}}
+    {{page("Janey Thomson's Marathon", "marathon")}}
+    {{page("Mathsteroids", "mathsteroids")}}
+    {{page("Downpour", "downpour")}}
+    {{page("Was it always like this dad?", "was-it")}}
+    {{page("Lunar Lander", "lunar-lander")}}
+    {{page("Revolution", "revolution")}}
+    {{page("Teletype", "teletype")}}
+    {{page("MattG's Gameboy Space", "gameboys")}}
+    {{page("Polybius", "polybius")}}
+    {{page("Games in Other Places", "other-games")}}
+  </ul>
+{% endblock %}
+{% block body %}
+  {{content}}
+{% endblock %}

--- a/templates/arcade/template.html
+++ b/templates/arcade/template.html
@@ -17,6 +17,7 @@
     {{page("Demo Schedule", "demo")}}
     {{page("Game Jam", "game-jam")}}
     <details>
+    <summary>Games</summary>
     {{page("Last Call BBS", "last-call-bbs")}}
     {{page("Pip Pepper: Park Planner", "pip-pepper")}}
     {{page("Weasel Words", "weasel-words")}}
@@ -47,9 +48,9 @@
     {{page("Lunar Lander", "lunar-lander")}}
     {{page("Revolution", "revolution")}}
     {{page("Teletype", "teletype")}}
-    </details>
     {{page("MattG's Gameboy Space", "gameboys")}}
     {{page("Polybius", "polybius")}}
+    </details>
     {{page("Games in Other Places", "other-games")}}
   </ul>
 {% endblock %}

--- a/templates/arcade/the-book-ritual.md
+++ b/templates/arcade/the-book-ritual.md
@@ -1,0 +1,23 @@
+title: The Book Ritual
+---
+# The Book Ritual
+## Alistair Aitcheson, 2018
+
+**URL**: [https://www.alistairaitcheson.com/games/thebookritual.html](https://www.alistairaitcheson.com/games/thebookritual.html)
+
+An interactive art-piece played using a real-world book of your choice.
+
+Write in your book to tell it about yourself. Deface its pages in creativity exercises, so that your book can understand you. Tear out pages to keep the conversation going, as it reveals to you how it came to be and why it wants to know you.
+
+The Book Ritual is about dealing with loss and accepting grief. The process of tearing up a book allows players to live out the experience of loss and examine the emotions that arise.
+
+
+### Awards
+
+* EGX Leftfield Collection 2018,
+* Nominee Alt-Ctrl GDC Award 2019,
+* Nominee - Most Creative Game PLAY18,
+* Honourable Mention A MAZE Berlin 2019.
+
+### Age 
+Suitable for children, but is aimed at adults. No objectionable content in it.

--- a/templates/arcade/towerfall.md
+++ b/templates/arcade/towerfall.md
@@ -1,0 +1,18 @@
+title: TowerFall
+---
+# TowerFall
+## Maddy Makes Games, 2013
+
+**URL**: [http://www.towerfall-game.com/](http://www.towerfall-game.com/)
+
+Inspired by classics from the golden age of couch multiplayer, TowerFall centers around hilarious, intense versus matches - best played against friends.The core mechanics are simple and accessible, but hard to master, with a huge amount of gameplay variants, arrow types, power-ups, and levels. And when you need a break from the competition, team up in 1-4 player co-op modes, where you’ll fight off a wide variety of monsters, enemy archers, and bosses.
+
+### Awards
+
+* Evo Showcase 2013,
+* Fantastic Arcade Selection 2013,
+* PAX 10 Selection 2013,
+* Indiecade winner Media Choice 2013.
+
+### Age
+Suitable for ages 7+.

--- a/templates/arcade/tune-it-up.md
+++ b/templates/arcade/tune-it-up.md
@@ -1,0 +1,14 @@
+title: Tune it Up!
+---
+# Tune it Up!
+## Izzy Kestrel & Clover Greenhalgh, 2016
+
+**URL**: https://virtually-competent.itch.io/tune-it-up
+
+Tune It Up! is a digital music toy that allows players to create a short composition using a drag and drop interface.
+
+### Accessibility
+This game requires sound.
+
+### Age
+Suitable for everyone.

--- a/templates/arcade/was-it.md
+++ b/templates/arcade/was-it.md
@@ -1,0 +1,14 @@
+title: Was it always like this, dad?
+---
+# Was it always like this, dad?
+## Art & game design by Kristofer "Kritzlof" Vaske, music & sound by "Dolphinflavored", 2023
+
+**URL**: [https://kritzlof.itch.io/was-it-always-like-this-dad](https://kritzlof.itch.io/was-it-always-like-this-dad)
+
+A short survival game about survival of a parent and child after climate collapse.
+
+### Awards
+The game was ranked "Best overall" in the Apocalypse jam 2023 on itch.io and won 6 other categories that it was eligible for!
+
+### Age 
+Suitable for everyone.

--- a/templates/arcade/weasel-words.md
+++ b/templates/arcade/weasel-words.md
@@ -1,0 +1,17 @@
+title: Weasel Words
+---
+# Weasel Words
+## Foxdog Studios & Alex Marczak, 2021
+
+**URL**: [https://foxdogstudios.com/](https://foxdogstudios.com/)
+
+_[The Typing of the Dead](https://en.wikipedia.org/wiki/The_Typing_of_the_Dead)_ with a taxidermy weasel.
+
+### Awards
+12th place Ludum Dare Game Jam 49.
+
+### Accessibility
+This game provides Subtitles.
+
+### Age
+Suitable for everyone.


### PR DESCRIPTION
This PR adds /arcade, and subpages for the content.
I copied the structure and generation of /about because having `.md` files for the entries appealed to me, but it might have been a slightly jank way of achieving this, open to suggestions. The `<details>` tag to make the nav usable might need some styling work.