### PR TITLE
Correct Bosch Sensortec link

### DIFF
--- a/templates/sponsors/sponsors.html
+++ b/templates/sponsors/sponsors.html
@@ -53,7 +53,7 @@
   class="col-xs-6 col-sm-5"
 >
   <h3>Badge</h3>
-  {{ sponsor("https://www.bosch.co.uk/", "bosch.png", "Bosch") }}
+  {{ sponsor("https://www.bosch-sensortec.com/", "bosch.png", "Bosch") }}
   {{ sponsor("https://www.espressif.com/", "espressif-logo.svg", "Espressif") }}
   {{ sponsor("https://www.ti.com/", "texasinstruments.svg", "Texas Instruments") }}
 


### PR DESCRIPTION
Tiny update to change the URL of a sponsor logo. 