### PR TITLE
Add polyfill for Object.groupBy to schedule

### DIFF
--- a/js/schedule.js
+++ b/js/schedule.js
@@ -1,3 +1,5 @@
+import "core-js/stable/object/group-by";
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
Object.groupBy is from 2024, so for compatibility with older browsers let's pull in some polyfills.