### PR TITLE
Limit Lightning Talk Slots

### DIFF
--- a/models/cfp.py
+++ b/models/cfp.py
@@ -952,6 +952,9 @@ class LightningTalkProposal(Proposal):
             .filter(cls.state != "withdrawn")
             .group_by(cls.session)
             .all()
+            # This is a horrible hack but we need to limit the LT slots for now
+            # and they have been preseeded as 12 in the DB (which is more than we can fit)
+            .limit(6)
         }
         return {day: (count - day_counts.get(day, 0)) for (day, count) in slots.items()}
 

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -951,10 +951,10 @@ class LightningTalkProposal(Proposal):
             )
             .filter(cls.state != "withdrawn")
             .group_by(cls.session)
-            .all()
             # This is a horrible hack but we need to limit the LT slots for now
             # and they have been preseeded as 12 in the DB (which is more than we can fit)
             .limit(6)
+            .all()
         }
         return {day: (count - day_counts.get(day, 0)) for (day, count) in slots.items()}
 

--- a/templates/cfp/form_lightning_include.html
+++ b/templates/cfp/form_lightning_include.html
@@ -2,7 +2,7 @@
 <p>Lightning talks are super short talks on any topic: be it a random tip you think more people should know about to a quick investigation of complex biology.</p>
 
 <h3>What it's like</h3>
-<p>We'll be running lightning talk sessions Friday to Sunday with each session being up to 12 slots each 10 minutes long.</p>
+<p>We'll be running lightning talk sessions Friday to Sunday with each session being up to 12 slots each a maxiumum of 5 minutes long.</p>
 
 <h3>Selection</h3>
 <p>Slots are allocated first come, first served. Unless you are told otherwise your lightning talk will be accepted, and you should come to the session to give it. You must submit your slides as a pdf as part of the submission and select which day you'd like to talk.</p>


### PR DESCRIPTION
This is a horrible hack but we need to limit the LT slots available and they have been preseeded as 12 in the DB (which is more than we can fit)