### PR TITLE
Workshop check in

### DIFF
--- a/apps/schedule/base.py
+++ b/apps/schedule/base.py
@@ -650,7 +650,7 @@ def workshop_steward_venue(venue_id: int):
         .filter(
             WorkshopProposal.type.in_(venue.allowed_types),
             WorkshopProposal.is_accepted,
-            WorkshopProposal.scheduled_time > pendulum.now(event_tz),
+            WorkshopProposal.scheduled_time > pendulum.now(event_tz.zone).naive(),
             WorkshopProposal.scheduled_duration.isnot(None),
             WorkshopProposal.hide_from_schedule.isnot(True),
             WorkshopProposal.user_scheduled.isnot(True),

--- a/apps/schedule/base.py
+++ b/apps/schedule/base.py
@@ -611,3 +611,23 @@ def greenroom():
         upcoming=upcoming,
     )
 
+@schedule.route("/schedule/workshop-steward/<int:proposal_id>")
+@v_user_required
+def workshop_steward(proposal_id):
+    proposal = Proposal.query.get_or_404(proposal_id)
+    # user_role_strs = [r.name for current_user.volunteer.interested_roles.all()]
+
+    # if proposal.type == "youthworkshop" and "Youth Workshop Helper" not in user_role_strs:
+    #     abort(401)
+
+    # if proposal.type == "workshop" and "Workshop Steward" not in user_role_strs:
+    #     abort(401)
+
+    # if (
+    #     datetime.now() < (proposal.scheduled_time - timedelta(minutes=60)) or
+    #     datetime.now() > (proposal.scheduled_time + timedelta(minutes=(proposal.scheduled_duration+60)))
+    # ):
+    #     # please come back later
+    #     pass
+
+    return render_template("schedule/workshop-steward.html", proposal=proposal)

--- a/models/event_tickets.py
+++ b/models/event_tickets.py
@@ -68,7 +68,19 @@ class EventTicket(BaseModel):
 
     # add a way to indicate a code has been used?
     def use_code(self, code):
-        pass
+        all_codes = self.ticket_codes.split(",")
+        if code not in all_codes:
+            raise EventTicketException(f"Code '{code}' not found")
+
+        all_codes.remove(code)
+        self.ticket_codes = ",".join(all_codes)
+        return self
+
+    def use_all_codes(self):
+        if not self.ticket_codes:
+            raise EventTicketException("No codes found")
+        self.ticket_codes = ""
+        return self
 
     def get_users_other_lottery_tickets_for_type(self):
         return [

--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -61,7 +61,7 @@
 {% endif %}
 </div>
 {% if current_user.is_authenticated %}
-  {% if SIGNUP_STATE in ["pending-tickets", "issue-event-tickets"] and event_ticket %}
+  {% if SIGNUP_STATE in ["pending-tickets", "issue-event-tickets"] and event_ticket and event_ticket.ticket_codes %}
     <div class="well">
       You currently have {{event_ticket.ticket_count}} codes for this {{proposal.human_type}}.
       When you attend you can either give your name or a code to get in. Your codes are:

--- a/templates/schedule/workshop-steward.html
+++ b/templates/schedule/workshop-steward.html
@@ -1,0 +1,14 @@
+{% from "_formhelpers.html" import render_field %}
+{% extends "base.html" %}
+{% block title %}Workshop Steward{% endblock %}
+{% block body %}
+
+<h1>Workshop Steward -- {{ proposal.title }}</h1>
+
+<ul>
+  {% for ticket in proposal.tickets if ticket.state == "ticket" %}
+    <li>{{ ticket.user.name }} -- {{ ticket.ticket_codes }} </li>
+  {% endfor %}
+</ul>
+
+{% endblock %}

--- a/templates/schedule/workshop-steward.html
+++ b/templates/schedule/workshop-steward.html
@@ -3,12 +3,41 @@
 {% block title %}Workshop Steward{% endblock %}
 {% block body %}
 
-<h1>Workshop Steward -- {{ proposal.title }}</h1>
+<h1>Workshop Steward -- {{ proposal.published_title }}</h1>
+
+<p>{{ proposal.published_description }}</p>
+
+<p>&nbsp;</p>
 
 <ul>
-  {% for ticket in proposal.tickets if ticket.state == "ticket" %}
-    <li>{{ ticket.user.name }} -- {{ ticket.ticket_codes }} </li>
-  {% endfor %}
+  {% if time_locked %}
+    The full list of attendees will be available after {{ show_list_after }}
+    and for the duration of the {{ proposal.huamn_type }}
+  {% else %}
+    <form method="POST">
+      {{ form.hidden_tag() }}
+      <ul>
+      {% for ticket_form in form.event_tickets %}
+        <li>
+          {{ ticket_form._ticket.user.name }}
+          {{ ticket_form.event_ticket_id() }}
+          {{ ticket_form.use_all_codes(class_="btn btn-primary") }}
+          <ul>
+            {% if ticket_form.codes %}
+              {% for code_form in ticket_form.codes %}
+                <li>
+                  {{code_form.code()}}
+                  {{code_form.code.data}}
+                  {{code_form.use_code(class_="btn btn-warning")}}
+                </li>
+              {% endfor %}
+            {% endif %}
+          </ul>
+        </li>
+      {% endfor %}
+      </ul>
+    </form>
+  {% endif %}
 </ul>
 
 {% endblock %}

--- a/templates/schedule/workshop-steward.html
+++ b/templates/schedule/workshop-steward.html
@@ -3,17 +3,17 @@
 {% block title %}Workshop Steward{% endblock %}
 {% block body %}
 
-<h1>Workshop Steward -- {{ proposal.published_title }}</h1>
+<h1>Workshop Steward -- {{ proposal.published_title or proposal.title }}</h1>
 
-<p>{{ proposal.published_description }}</p>
+<p>{{ proposal.published_description or proposal.description }}</p>
 
 <p>&nbsp;</p>
 
-<ul>
-  {% if time_locked %}
-    The full list of attendees will be available after {{ show_list_after }}
-    and for the duration of the {{ proposal.huamn_type }}
-  {% else %}
+{% if time_locked %}
+  <p>The full list of attendees will be available after {{ show_list_after }}
+     and for the duration of the {{ proposal.type }}.</p>
+{% else %}
+  <ul>
     <form method="POST">
       {{ form.hidden_tag() }}
       <ul>
@@ -37,7 +37,7 @@
       {% endfor %}
       </ul>
     </form>
-  {% endif %}
-</ul>
+  </ul>
+{% endif %}
 
 {% endblock %}

--- a/templates/schedule/workshop-steward/main.html
+++ b/templates/schedule/workshop-steward/main.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Workshop Steward{% endblock %}
+{% block body %}
+
+<h1>Workshop Steward</h1>
+
+<h2>Workshops</h2>
+
+<ul>
+  {% for venue in workshop_venues %}
+    <li><a href="{{ url_for('.workshop_steward_venue', venue_id=venue.id) }}">{{ venue.name }}</a></li>
+  {% endfor %}
+</ul>
+
+<h2>Youth Workshops</h2>
+
+<ul>
+  {% for venue in youthworkshop_venues %}
+    <li><a href="{{ url_for('.workshop_steward_venue', venue_id=venue.id) }}">{{ venue.name }}</a></li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/schedule/workshop-steward/venue.html
+++ b/templates/schedule/workshop-steward/venue.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Workshop Steward -- {{ venue.name }}{% endblock %}
+{% block body %}
+
+<h1>Workshop Steward for {{ venue.name }}</h1>
+
+<ul>
+  {% for workshop in all_workshops %}
+    <li><a href="{{ url_for('.workshop_steward', workshop_id=workshop.id) }}">{{ workshop.scheduled_time }} -- {{ workshop.title }}</a></li>
+  {% endfor %}
+</ul>
+
+{% endblock %}

--- a/templates/schedule/workshop-steward/workshop.html
+++ b/templates/schedule/workshop-steward/workshop.html
@@ -5,6 +5,8 @@
 
 <h1>Workshop Steward -- {{ workshop.published_title or workshop.title }}</h1>
 
+<em>Starts at: {{ workshop.scheduled_time }}</em>
+
 <p>{{ workshop.published_description or workshop.description }}</p>
 
 <p>&nbsp;</p>

--- a/templates/schedule/workshop-steward/workshop.html
+++ b/templates/schedule/workshop-steward/workshop.html
@@ -3,15 +3,15 @@
 {% block title %}Workshop Steward{% endblock %}
 {% block body %}
 
-<h1>Workshop Steward -- {{ proposal.published_title or proposal.title }}</h1>
+<h1>Workshop Steward -- {{ workshop.published_title or workshop.title }}</h1>
 
-<p>{{ proposal.published_description or proposal.description }}</p>
+<p>{{ workshop.published_description or workshop.description }}</p>
 
 <p>&nbsp;</p>
 
 {% if time_locked %}
   <p>The full list of attendees will be available after {{ show_list_after }}
-     and for the duration of the {{ proposal.type }}.</p>
+     and for the duration of the {{ workshop.type }}.</p>
 {% else %}
   <ul>
     <form method="POST">


### PR DESCRIPTION
This is pretty ugly and bare bones but workshop stewards can now get a list of all attendees for a workshop and either sign in all of their codes at once or an individual one.

The pages can be found by going to `/schedule/workshop-steward` and selecting the venue
<img width="1375" alt="Screenshot 2024-05-29 at 02 16 57" src="https://github.com/emfcamp/Website/assets/486265/ba6af48e-4e27-424e-b360-5dfeaeefe3ab">
then the workshop
<img width="645" alt="Screenshot 2024-05-29 at 02 17 05" src="https://github.com/emfcamp/Website/assets/486265/2e720215-eddd-48c6-b0ba-16179a01c009">
then signing people in
<img width="945" alt="Screenshot 2024-05-29 at 02 16 28" src="https://github.com/emfcamp/Website/assets/486265/654ce9be-c91b-46ac-9e75-26503ec97c77">
To help reduce the number of giant lists of attendees about the place the list of attendees is time locked to the hour prior to the workshop and then its duration. The user also has to have signed up as a volunteer and done the 'workshop Steward' training. 

If the timelock is in effect they see the following screen (otherwise they receive a 401)

The timelock can be ignored in `DEBUG` mode by adding `?time_locked=true` to the URL for testing purposes
<img width="934" alt="Screenshot 2024-05-29 at 02 16 40" src="https://github.com/emfcamp/Website/assets/486265/b04e1661-8d6f-42d8-a56f-44ceadd6c53c">
