### PR TITLE
Display full display name for non-admissions type

### DIFF
--- a/models/product.py
+++ b/models/product.py
@@ -333,6 +333,8 @@ class Product(BaseModel, CapacityMixin, InheritedAttributesMixin):
 
     @property
     def checkin_display_name(self):
+        if self.parent.type != "admissions":
+            return self.display_name
         return re.sub(r" \(.*\)", "", self.display_name)
 
     def get_price_tier(self, name):

--- a/templates/arrivals/checkin.html
+++ b/templates/arrivals/checkin.html
@@ -114,7 +114,7 @@
 {% for purchase in transferred_purchases %}
 <tr>
   <td class="hidden-xs">{{ purchase.id }}</td>
-  <td>{{ purchase.product.display_name }}</td>
+  <td>{{ purchase.product.checkin_display_name }}</td>
   <td><a href="{{ url_for('.checkin', user_id=purchase.owner.id) }}">{{ purchase.owner.name }}</a></td>
   <td>
     {%- if purchase.redeemed %}
@@ -153,7 +153,7 @@
 {% for purchase in other_purchases %}
 <tr>
   <td class="hidden-xs">{{ purchase.id }}</td>
-  <td>{{ purchase.product.display_name }}</td>
+  <td>{{ purchase.product.checkin_display_name }}</td>
   <td>
     {%- if purchase.redeemed %}
       Redeemed {{ purchase.redemption_version().transaction.issued_at.strftime('%A %H:%M') }}


### PR DESCRIPTION
T-shirt sizes are in parentheses, and it's not very useful telling the shop to just issue an arbitrary size t-shirt if we're trying to do stock control.