### PR TITLE
Closes #1701 to add the 2024 Contact Form

### DIFF
--- a/templates/code-of-conduct.html
+++ b/templates/code-of-conduct.html
@@ -58,6 +58,9 @@ block body %}
   get in touch with us by:
 </p>
 <ul>
+  <li>Filling out our <a href="https://forms.gle/P6NAYsWzZuViDrud9">
+      contact form</a>.
+  </li>
   <li>
     Sending us an email at
     <a href="mailto:{{ config['CONDUCT_EMAIL'][1] }}"


### PR DESCRIPTION
Adds quick link to the Google Form for reporting Code of Conduct issues / comments etc, as well as the number & email address.