### PR TITLE
Move now-and-next feed to /schedule/

### DIFF
--- a/apps/base/redirects.py
+++ b/apps/base/redirects.py
@@ -36,3 +36,9 @@ def wave_talks():
 @base.route("/wave/SiNE")
 def sine():
     return redirect("https://wiki-archive.emfcamp.org/2014/wiki/SiNE")
+
+
+@base.route("/now-and-next.json")
+@base.route("/upcoming.json")
+def old_now_next_feed():
+    return redirect(url_for("schedule.now_and_next_json"), code=301)

--- a/apps/schedule/feeds.py
+++ b/apps/schedule/feeds.py
@@ -172,9 +172,8 @@ def favourites_ical():
     return Response(cal.to_ical(), mimetype="text/calendar")
 
 
-@schedule.route("/now-and-next.json")
-@schedule.route("/upcoming.json")
-def upcoming():
+@schedule.route("/schedule/now-and-next.json")
+def now_and_next_json():
     return Response(
         json.dumps(_get_upcoming(request.args)), mimetype="application/json"
     )


### PR DESCRIPTION
Our [docs](https://developer.emfcamp.org/schedule/#now-and-next) say now-and-next.json lives under /schedule/ but it is actually in the root. All our other feeds are in /schedule/ so we should just move it there for consistency - this won't break anything now as the feed returns nothing between events anyway.