### PR TITLE
[proposal view] Add video recording host hyperlinks.

### DIFF
--- a/templates/schedule/historic/item.html
+++ b/templates/schedule/historic/item.html
@@ -64,7 +64,7 @@
     <strong>Video Hosts:</strong>
     <ul>
     {% if event.video.ccc %}
-      <li>View this video <a href="{{ event.video.ccc }}">on the Chaos Computer Club's website</a>.</li>
+      <li>View this video <a href="{{ event.video.ccc }}">on media.ccc.de</a>.</li>
     {% endif %}
     {% if event.video.youtube %}
       <li>View this video <a href="{{ event.video.youtube }}">on YouTube</a>.</li>

--- a/templates/schedule/historic/item.html
+++ b/templates/schedule/historic/item.html
@@ -60,8 +60,16 @@
           <button class="youtube-wait-for-click-button">Continue</button>
         </div>
       </div>
-      <p>View this video <a href="{{ event.video.youtube }}">on YouTube</a>.</p>
     {% endif %}
+    <strong>Video Hosts:</strong>
+    <ul>
+    {% if event.video.ccc %}
+      <li>View this video <a href="{{ event.video.ccc }}">on the Chaos Computer Club's website</a>.</li>
+    {% endif %}
+    {% if event.video.youtube %}
+      <li>View this video <a href="{{ event.video.youtube }}">on YouTube</a>.</li>
+    {% endif %}
+    </ul>
   </div>
 {% endif %}
 {% endblock %}

--- a/templates/schedule/historic/item.html
+++ b/templates/schedule/historic/item.html
@@ -66,6 +66,9 @@
     {% if event.video.ccc %}
       <li>View this video <a href="{{ event.video.ccc }}">on media.ccc.de</a>.</li>
     {% endif %}
+    {% if event.video.archiveorg %}
+      <li>View this video <a href="{{ event.video.archiveorg }}">on the Internet Archive</a>.</li>
+    {% endif %}
     {% if event.video.youtube %}
       <li>View this video <a href="{{ event.video.youtube }}">on YouTube</a>.</li>
     {% endif %}

--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -139,7 +139,7 @@
   <strong>Video Hosts:</strong>
   <ul>
   {% if proposal.c3voc_url %}
-    <li>View this video <a href="{{ proposal.c3voc_url }}">on the Chaos Computer Club's website</a>.</li>
+    <li>View this video <a href="{{ proposal.c3voc_url }}">on media.ccc.de</a>.</li>
   {% endif %}
   {% if proposal.youtube_url %}
     <li>View this video <a href="{{ proposal.youtube_url }}">on YouTube</a>.</li>

--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -135,8 +135,16 @@
     <iframe src="{{proposal.youtube_url|replace('youtube.com/watch?v=', 'youtube.com/embed/')}}"
         width="100%" height="500px" frameborder="0" 
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    <p>View this video <a href="{{ proposal.youtube_url }}">on YouTube</a>.</p>
   {% endif %}
+  <p>Direct links to the host(s) of this video recording can be found below:</p>
+  <ul>
+  {% if proposal.c3voc_url %}
+    <li>View this video <a href="{{ proposal.c3voc_url }}">on the Chaos Computer Club's website</a>.</li>
+  {% endif %}
+  {% if proposal.youtube_url %}
+    <li>View this video <a href="{{ proposal.youtube_url }}">on YouTube</a>.</li>
+  {% endif %}
+  </ul>
 </div>
 <p>&nbsp;</p>
 {% endif %}

--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -136,7 +136,7 @@
         width="100%" height="500px" frameborder="0" 
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   {% endif %}
-  <p>Direct links to the host(s) of this video recording can be found below:</p>
+  <strong>Video Hosts:</strong>
   <ul>
   {% if proposal.c3voc_url %}
     <li>View this video <a href="{{ proposal.c3voc_url }}">on the Chaos Computer Club's website</a>.</li>


### PR DESCRIPTION
As part of #1259 we're going to email speakers when their edited video recordings from EMF are first published, and in the emails we're going to link to the proposal view page on the emfcamp.org website.

To make it easier for speakers and viewers to locate the origin hosted copies of the recordings, we should include direct links to each platform (currently CCC, YouTube) on the proposal view.

Note: untested because I don't currently have a functional local dev env (any help testing this is appreciated!)