### PR TITLE
Cleanup: remove no-longer-used `flask` environment variables

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,6 @@ services:
     environment:
       SETTINGS_FILE: ./config/production.cfg
       IRCCAT: irccat.orga.emfcamp.org:12345
-      FLASK_ENV: production
     logging:
       driver: journald
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - "2342:2342"
     environment:
       SETTINGS_FILE: ./config/development.cfg
-      FLASK_APP: dev_server.py
-      FLASK_ENV: development
       COLORIZE_LOGS: always
       PYTHONUNBUFFERED: 1
       IRCCAT: fakeirccat:12345


### PR DESCRIPTION
  * `FLASK_APP` was [removed in Flask v2.2.0](https://github.com/pallets/flask/commit/99fa3c36abc03cd5b3407df34dce74e879ea377a)
  * `FLASK_ENV` was [removed in Flask v2.3.0](https://github.com/pallets/flask/commit/6650764e9719402de2aaa6f321bdec587699c6b2)