### PR TITLE
Export lightning talk information as well

### DIFF
--- a/tests/test_product_view.py
+++ b/tests/test_product_view.py
@@ -40,6 +40,8 @@ def test_product_view_accessible(db, user, monkeypatch):
     db.session.add(proposal)
     db.session.commit()
     proposal.set_state("accepted")
+    db.session.add(proposal)
+    db.session.commit()
 
     assert product_view.is_accessible(
         user


### PR DESCRIPTION
Lightning Talks do not go through the CfP proper, so they sit in the new state.

Hopefully the CfP redesign will get done before 2026, so this is mostly so we can export some semblance of sensible data from 2024.

Fixes #1466.