### PR TITLE
Switch slugify

### DIFF
--- a/ad-hoc-scripts/compare-slugs.py
+++ b/ad-hoc-scripts/compare-slugs.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+import json
+import re
+
+# Both modules use the name slugify. Prepare this script by doing:
+# $ mkdir slugifies
+# $ uv pip install --target slugifies/awesome_slugify awesome-slugify
+# $ uv pip install --target slugifies/python_slugify python-slugify
+# $ touch slugifies{,/awesome_slugify,/python_slugify}/__init__.py
+
+from slugifies.awesome_slugify.slugify import slugify_unicode as slugify_awesome
+from slugifies.python_slugify.slugify import slugify as slugify_python
+
+
+def proposal_slug_awesome(title) -> str:
+    slug = slugify_awesome(title).lower()
+    if len(slug) > 60:
+        words = re.split(" +|[,.;:!?]+", title)
+        break_words = ["and", "which", "with", "without", "for", "-", ""]
+
+        for i, word in reversed(list(enumerate(words))):
+            new_slug = slugify_awesome(" ".join(words[:i])).lower()
+            if word in break_words:
+                if len(new_slug) > 10 and not len(new_slug) > 60:
+                    slug = new_slug
+                    break
+
+            elif len(slug) > 60 and len(new_slug) > 10:
+                slug = new_slug
+
+    if len(slug) > 60:
+        slug = slug[:60] + "-"
+
+    return slug
+
+
+def proposal_slug_python(title) -> str:
+    replacements = [
+        ["'", ""],
+    ]
+    slug = slugify_python(title, replacements=replacements, allow_unicode=True)
+    if len(slug) > 60:
+        words = re.split(" +|[,.;:!?]+", title)
+        break_words = ["and", "which", "with", "without", "for", "-", ""]
+
+        for i, word in reversed(list(enumerate(words))):
+            new_slug = slugify_python(" ".join(words[:i]), replacements=replacements, allow_unicode=True)
+            if word in break_words:
+                if len(new_slug) > 10 and not len(new_slug) > 60:
+                    slug = new_slug
+                    break
+
+            elif len(slug) > 60 and len(new_slug) > 10:
+                slug = new_slug
+
+    if len(slug) > 60:
+        slug = slug[:60] + "-"
+
+    return slug
+
+
+schedules = Path("../exports").glob("*/public/schedule.json")
+
+for schedule in schedules:
+    print(f"Checking {schedule}")
+    items = json.load(open(schedule))
+    for item in items:
+        id, title = item["id"], item["title"]
+        awesome_slug = proposal_slug_awesome(title)
+        python_slug = proposal_slug_python(title)
+
+        if "slug" in item:
+            slug = item["slug"]
+            if awesome_slug != slug:
+                print(f"Exported slug for {id} {slug!r} does not match {awesome_slug!r} ({title!r})")
+                break
+
+        if awesome_slug != python_slug:
+            print(f"Slug for {id} {awesome_slug!r} does not match {python_slug!r} ({title!r})")
+
+
+extra_titles = [
+    "AI & Ethics 🤔",
+    "C++ vs. Rust Shader Showdown",
+    "Why Tabs > Spaces 🚀",
+    "I rm -rf /*'d My Watch",
+    "Über–かわいい (❁´◡`❁) lol",
+    "i always use lowercase, it’s cool",
+    "Internationalization (i18n) & Localization (l10n) In Talk Titles",
+]
+
+for title in extra_titles:
+    awesome_slug = proposal_slug_awesome(title)
+    python_slug = proposal_slug_python(title)
+
+    if awesome_slug != python_slug:
+        print(f"Slug {awesome_slug!r} does not match {python_slug!r} ({title!r})")

--- a/apps/schedule/data.py
+++ b/apps/schedule/data.py
@@ -2,7 +2,7 @@ import pendulum  # preferred over datetime
 from collections import defaultdict
 from werkzeug.datastructures import MultiDict
 from flask_login import current_user
-from slugify import slugify_unicode as slugify
+from slugify import slugify
 
 from models import event_year
 from models.cfp import Proposal, Venue

--- a/models/cfp.py
+++ b/models/cfp.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.mutable import MutableList
 
 from sqlalchemy import UniqueConstraint, func, select, text, or_
 from sqlalchemy.orm import column_property
-from slugify import slugify_unicode
+from slugify import slugify
 from models import (
     export_attr_counts,
     export_attr_edits,
@@ -247,13 +247,16 @@ def get_days_map():
 
 
 def proposal_slug(title) -> str:
-    slug = slugify_unicode(title).lower()
+    replacements = [
+        ["'", ""],
+    ]
+    slug = slugify(title, replacements=replacements, allow_unicode=True)
     if len(slug) > 60:
         words = re.split(" +|[,.;:!?]+", title)
         break_words = ["and", "which", "with", "without", "for", "-", ""]
 
         for i, word in reversed(list(enumerate(words))):
-            new_slug = slugify_unicode(" ".join(words[:i])).lower()
+            new_slug = slugify(" ".join(words[:i]), replacements=replacements, allow_unicode=True)
             if word in break_words:
                 if len(new_slug) > 10 and not len(new_slug) > 60:
                     slug = new_slug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "stripe~=8.0.0",
     "python-dateutil",
     "slotmachine",
-    "awesome-slugify",
     "faker",
     "pyyaml",
     "prometheus-client",
@@ -57,6 +56,7 @@ dependencies = [
     "wtforms-sqlalchemy~=0.3.0",
     "lxml>=6.0.0",
     "cryptography>=44.0.3",
+    "python-slugify>=8.0.4",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -61,16 +61,6 @@ wheels = [
 ]
 
 [[package]]
-name = "awesome-slugify"
-version = "1.6.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "regex" },
-    { name = "unidecode" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/39/79ef4e640c3651b40de7812f5fcd04698abf14de4f57a81e12b6c753d168/awesome-slugify-1.6.5.tar.gz", hash = "sha256:bbdec3fa2187917473a2efad092b57f7125a55f841a7cf6a1773178d32ccfd71", size = 8405, upload-time = "2015-06-05T06:31:13.651Z" }
-
-[[package]]
 name = "bidict"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1521,6 +1511,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "python-socketio"
 version = "5.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1662,28 +1664,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f3/5e0c6ae452cbb74e5436d3445467447e8c32f3021f48f93f15934b8cffc2/rapidfuzz-3.13.0-cp313-cp313-win32.whl", hash = "sha256:0e1d08cb884805a543f2de1f6744069495ef527e279e05370dd7c83416af83f8", size = 1822066, upload-time = "2025-04-03T20:37:14.425Z" },
     { url = "https://files.pythonhosted.org/packages/96/e3/a98c25c4f74051df4dcf2f393176b8663bfd93c7afc6692c84e96de147a2/rapidfuzz-3.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:9a7c6232be5f809cd39da30ee5d24e6cadd919831e6020ec6c2391f4c3bc9264", size = 1615100, upload-time = "2025-04-03T20:37:16.611Z" },
     { url = "https://files.pythonhosted.org/packages/60/b1/05cd5e697c00cd46d7791915f571b38c8531f714832eff2c5e34537c49ee/rapidfuzz-3.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:3f32f15bacd1838c929b35c84b43618481e1b3d7a61b5ed2db0291b70ae88b53", size = 858976, upload-time = "2025-04-03T20:37:19.336Z" },
-]
-
-[[package]]
-name = "regex"
-version = "2025.7.34"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/de/e13fa6dc61d78b30ba47481f99933a3b49a57779d625c392d8036770a60d/regex-2025.7.34.tar.gz", hash = "sha256:9ead9765217afd04a86822dfcd4ed2747dfe426e887da413b15ff0ac2457e21a", size = 400714, upload-time = "2025-07-31T00:21:16.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/16/b709b2119975035169a25aa8e4940ca177b1a2e25e14f8d996d09130368e/regex-2025.7.34-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3c9740a77aeef3f5e3aaab92403946a8d34437db930a0280e7e81ddcada61f5", size = 485334, upload-time = "2025-07-31T00:19:56.58Z" },
-    { url = "https://files.pythonhosted.org/packages/94/a6/c09136046be0595f0331bc58a0e5f89c2d324cf734e0b0ec53cf4b12a636/regex-2025.7.34-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:69ed3bc611540f2ea70a4080f853741ec698be556b1df404599f8724690edbcd", size = 289942, upload-time = "2025-07-31T00:19:57.943Z" },
-    { url = "https://files.pythonhosted.org/packages/36/91/08fc0fd0f40bdfb0e0df4134ee37cfb16e66a1044ac56d36911fd01c69d2/regex-2025.7.34-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d03c6f9dcd562c56527c42b8530aad93193e0b3254a588be1f2ed378cdfdea1b", size = 285991, upload-time = "2025-07-31T00:19:59.837Z" },
-    { url = "https://files.pythonhosted.org/packages/be/2f/99dc8f6f756606f0c214d14c7b6c17270b6bbe26d5c1f05cde9dbb1c551f/regex-2025.7.34-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6164b1d99dee1dfad33f301f174d8139d4368a9fb50bf0a3603b2eaf579963ad", size = 797415, upload-time = "2025-07-31T00:20:01.668Z" },
-    { url = "https://files.pythonhosted.org/packages/62/cf/2fcdca1110495458ba4e95c52ce73b361cf1cafd8a53b5c31542cde9a15b/regex-2025.7.34-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1e4f4f62599b8142362f164ce776f19d79bdd21273e86920a7b604a4275b4f59", size = 862487, upload-time = "2025-07-31T00:20:03.142Z" },
-    { url = "https://files.pythonhosted.org/packages/90/38/899105dd27fed394e3fae45607c1983e138273ec167e47882fc401f112b9/regex-2025.7.34-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:72a26dcc6a59c057b292f39d41465d8233a10fd69121fa24f8f43ec6294e5415", size = 910717, upload-time = "2025-07-31T00:20:04.727Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/f6/4716198dbd0bcc9c45625ac4c81a435d1c4d8ad662e8576dac06bab35b17/regex-2025.7.34-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5273fddf7a3e602695c92716c420c377599ed3c853ea669c1fe26218867002f", size = 801943, upload-time = "2025-07-31T00:20:07.1Z" },
-    { url = "https://files.pythonhosted.org/packages/40/5d/cff8896d27e4e3dd11dd72ac78797c7987eb50fe4debc2c0f2f1682eb06d/regex-2025.7.34-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c1844be23cd40135b3a5a4dd298e1e0c0cb36757364dd6cdc6025770363e06c1", size = 786664, upload-time = "2025-07-31T00:20:08.818Z" },
-    { url = "https://files.pythonhosted.org/packages/10/29/758bf83cf7b4c34f07ac3423ea03cee3eb3176941641e4ccc05620f6c0b8/regex-2025.7.34-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dde35e2afbbe2272f8abee3b9fe6772d9b5a07d82607b5788e8508974059925c", size = 856457, upload-time = "2025-07-31T00:20:10.328Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/30/c19d212b619963c5b460bfed0ea69a092c6a43cba52a973d46c27b3e2975/regex-2025.7.34-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f3f6e8e7af516a7549412ce57613e859c3be27d55341a894aacaa11703a4c31a", size = 849008, upload-time = "2025-07-31T00:20:11.823Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b8/3c35da3b12c87e3cc00010ef6c3a4ae787cff0bc381aa3d251def219969a/regex-2025.7.34-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:469142fb94a869beb25b5f18ea87646d21def10fbacb0bcb749224f3509476f0", size = 788101, upload-time = "2025-07-31T00:20:13.729Z" },
-    { url = "https://files.pythonhosted.org/packages/47/80/2f46677c0b3c2b723b2c358d19f9346e714113865da0f5f736ca1a883bde/regex-2025.7.34-cp313-cp313-win32.whl", hash = "sha256:da7507d083ee33ccea1310447410c27ca11fb9ef18c95899ca57ff60a7e4d8f1", size = 264401, upload-time = "2025-07-31T00:20:15.233Z" },
-    { url = "https://files.pythonhosted.org/packages/be/fa/917d64dd074682606a003cba33585c28138c77d848ef72fc77cbb1183849/regex-2025.7.34-cp313-cp313-win_amd64.whl", hash = "sha256:9d644de5520441e5f7e2db63aec2748948cc39ed4d7a87fd5db578ea4043d997", size = 275368, upload-time = "2025-07-31T00:20:16.711Z" },
-    { url = "https://files.pythonhosted.org/packages/65/cd/f94383666704170a2154a5df7b16be28f0c27a266bffcd843e58bc84120f/regex-2025.7.34-cp313-cp313-win_arm64.whl", hash = "sha256:7bf1c5503a9f2cbd2f52d7e260acb3131b07b6273c470abb78568174fe6bde3f", size = 268482, upload-time = "2025-07-31T00:20:18.189Z" },
 ]
 
 [[package]]
@@ -1908,6 +1888,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2022,15 +2011,6 @@ wheels = [
 ]
 
 [[package]]
-name = "unidecode"
-version = "0.4.21"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/26/6a4295c494e381d56bba986893382b5dd5e82e2643fc72e4e49b6c99ce15/Unidecode-0.04.21.tar.gz", hash = "sha256:280a6ab88e1f2eb5af79edff450021a0d3f0448952847cd79677e55e58bad051", size = 205931, upload-time = "2017-06-28T11:56:50.781Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/a1/9d7f3138ee3d79a1ab865a2cb38200ca778d85121db19fe264c76c981184/Unidecode-0.04.21-py2.py3-none-any.whl", hash = "sha256:61f807220eda0203a774a09f84b4304a3f93b5944110cc132af29ddb81366883", size = 228285, upload-time = "2017-06-28T11:56:53.617Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2098,7 +2078,6 @@ version = "0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
-    { name = "awesome-slugify" },
     { name = "cryptography" },
     { name = "css-inline" },
     { name = "decorator" },
@@ -2133,6 +2112,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "python-levenshtein" },
     { name = "python-memcached" },
+    { name = "python-slugify" },
     { name = "python-stdnum" },
     { name = "pytz" },
     { name = "pywisetransfer" },
@@ -2180,7 +2160,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = "~=1.1" },
-    { name = "awesome-slugify" },
     { name = "cryptography", specifier = ">=44.0.3" },
     { name = "css-inline", specifier = ">=0.14.0,<0.15" },
     { name = "decorator" },
@@ -2215,6 +2194,7 @@ requires-dist = [
     { name = "python-dateutil" },
     { name = "python-levenshtein", specifier = "~=0.12" },
     { name = "python-memcached", specifier = "==1.59" },
+    { name = "python-slugify", specifier = ">=8.0.4" },
     { name = "python-stdnum", specifier = "~=1.19" },
     { name = "pytz" },
     { name = "pywisetransfer", specifier = ">=0.3.1,<0.4" },


### PR DESCRIPTION
Fixes #997 and #1817.

Keeping the current `proposal_slug` (which cuts at stop words when under length pressure) means we would generate identical slugs for all previous talk titles except one:

```
root@461bee3b78ec:/app/ad-hoc-scripts# uv run python compare-slugs.py
Checking ../exports/2022/public/schedule.json
Checking ../exports/2012/public/schedule.json
Checking ../exports/2018/public/schedule.json
Slug for -681 'hack-n-swap-o-rama' does not match 'hack-n-swap-o-ramatm' ('Hack-N-Swap-O-Rama™')
Checking ../exports/2016/public/schedule.json
Slug for -220 'hack-n-swap-o-rama' does not match 'hack-n-swap-o-ramatm' ('Hack-N-Swap-O-Rama™')
Checking ../exports/2014/public/schedule.json
Checking ../exports/2024/public/schedule.json
Checking ../exports/2013/public/schedule.json
```