### PR TITLE
Correct session adding logic

### DIFF
--- a/apps/admin/products.py
+++ b/apps/admin/products.py
@@ -156,6 +156,7 @@ def new_price_tier(product_id):
         # Only activate this price tier if it's the first one added.
         pt.active = len(product.price_tiers) == 0
         product.price_tiers.append(pt)
+        db.session.add(pt)
         db.session.commit()
         return redirect(url_for(".price_tier_details", tier_id=pt.id))
 
@@ -482,11 +483,11 @@ def product_view_add(view_id, group_id=None, product_id=None):
     if form.validate_on_submit():
         if form.add_all_products.data:
             for product in group.products:
-                ProductViewProduct(view, product)
+                db.session.add(ProductViewProduct(view, product))
             db.session.commit()
 
         elif form.add_product.data:
-            ProductViewProduct(view, product)
+            db.session.add(ProductViewProduct(view, product))
             db.session.commit()
 
         return redirect(url_for(".product_view", view_id=view.id))
@@ -539,6 +540,7 @@ def product_view_add_voucher(view_id):
             purchases_remaining=form.num_purchases.data,
             tickets_remaining=form.num_tickets.data,
         )
+        db.session.add(voucher)
         db.session.commit()
         flash("Voucher successfully created")
         return redirect(
@@ -649,6 +651,8 @@ def product_view_bulk_add_vouchers_by_email(view_id):
                 connection=conn,
                 html_message=html,
             )
+
+            db.session.add(voucher)
             db.session.commit()
             sent_total += sent_count
             added += 1

--- a/apps/api/schedule.py
+++ b/apps/api/schedule.py
@@ -60,7 +60,6 @@ class ProposalResource(Resource):
             if attribute in payload:
                 setattr(proposal, attribute, payload[attribute])
 
-        db.session.add(proposal)
         db.session.commit()
 
         return {
@@ -229,7 +228,6 @@ class ProposalC3VOCPublishingWebhook(Resource):
                     )
                     proposal.youtube_url = None
 
-            db.session.add(proposal)
             db.session.commit()
         except KeyError as e:
             abort(400, message=f"Missing required field: {e}")

--- a/apps/base/dev/fake.py
+++ b/apps/base/dev/fake.py
@@ -192,9 +192,9 @@ class FakeDataGenerator:
                 self.create_village(user)
 
             db.session.add(user)
-            self.create_fake_tickets(user)
-
             db.session.commit()
+
+            self.create_fake_tickets(user)
 
         scheduler = Scheduler()
         scheduler.set_rough_durations()
@@ -270,6 +270,8 @@ class FakeDataGenerator:
             if random.random() < 0.2:
                 payment.manual_refund()
                 db.session.commit()
+
+        db.session.commit()
 
     def create_fake_lottery_tickets(self, users_list: list[User], proposal):
         n_lottery_tickets = random.randint(0, len(users_list))

--- a/apps/base/scheduled_tasks.py
+++ b/apps/base/scheduled_tasks.py
@@ -31,7 +31,6 @@ def send_email(conn, rec):
     )
     if sent_count > 0:
         rec.sent = True
-        db.session.add(rec)
         db.session.commit()
     return sent_count
 
@@ -58,6 +57,5 @@ def send_volunteer_email(conn, rec):
     )
     if sent_count > 0:
         rec.sent = True
-        db.session.add(rec)
         db.session.commit()
     return sent_count

--- a/apps/payments/refund.py
+++ b/apps/payments/refund.py
@@ -116,6 +116,8 @@ def handle_refund_request(request: RefundRequest) -> None:
     # TODO: set partrefunded state if we have not refunded the whole payment
     payment.state = "refunded"
 
+    if refund:
+        db.session.add(refund)
     db.session.commit()
     send_refund_email(request, refund_amount)
 
@@ -139,6 +141,7 @@ def manual_bank_refund(request: RefundRequest) -> None:
             purchase.refund_purchase(refund)
 
     payment.state = "refunded"
+    db.session.add(refund)
 
     db.session.commit()
     send_refund_email(request, refund_amount)

--- a/apps/volunteer/main.py
+++ b/apps/volunteer/main.py
@@ -155,11 +155,10 @@ def init_workshop_shifts():
             shift.end = proposal.scheduled_time + time_after_start
             shift.min_needed = 1
             shift.max_needed = 1
-            db.session.add(shift)
 
+            db.session.add(shift)
             db.session.commit()
 
-    db.session.commit()
     return redirect(url_for(".schedule"))
 
 

--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -175,7 +175,7 @@ def shift_sign_up(shift_id):
                 f"This shift clashes with your {clash_role} shift at {clash_time}, you have not been signed up."
             )
 
-    shift.entries.append(ShiftEntry(user=user, shift=shift))
+    db.session.add(ShiftEntry(user=user, shift=shift))
     db.session.commit()
 
     return redirect_next_or_schedule(f"Signed up {shift.role.name} shift")

--- a/models/basket.py
+++ b/models/basket.py
@@ -287,7 +287,6 @@ class Basket(MutableMapping):
         # This is where you'd add the premium if it existed
 
         self.user.payments.append(payment)
-        db.session.add(self.user)
 
         app.logger.info("Creating payment for basket %s", self)
         app.logger.info(
@@ -310,7 +309,6 @@ class Basket(MutableMapping):
                 raise Exception(f"Voucher with code {self.voucher} not found")
 
             voucher_obj.consume_capacity(payment)
-            db.session.add(voucher_obj)
 
         return payment
 

--- a/models/payment.py
+++ b/models/payment.py
@@ -227,6 +227,7 @@ class Payment(BaseModel):
 
                 purchase.refund_purchase(refund)
 
+        db.session.add(refund)
         self.state = "refunded"
 
     # TESTME

--- a/models/purchase.py
+++ b/models/purchase.py
@@ -203,7 +203,8 @@ class Purchase(BaseModel):
         self.ticket_issued = False
         self.owner = to_user
 
-        PurchaseTransfer(purchase=self, to_user=to_user, from_user=from_user)
+        transfer = PurchaseTransfer(purchase=self, to_user=to_user, from_user=from_user)
+        db.session.add(transfer)
 
     def redeem(self):
         if not self.product.get_attribute("is_redeemable"):

--- a/tests/test_product_group.py
+++ b/tests/test_product_group.py
@@ -117,6 +117,7 @@ def test_capacity_propagation(db, parent_group, user):
     product2 = Product(name="product2", parent=parent_group)
     tier3 = PriceTier(name="tier3", parent=product2)
     Price(price_tier=tier3, currency="GBP", price_int=30)
+    db.session.add(tier3)
     db.session.commit()
 
     # Check all our items have the correct initial capacity


### PR DESCRIPTION
Since cascade_backrefs was removed in 2.0, some of these objects were not being added to the session.

In general, we should call session.add whenever (and only when) a new object has been created. The cascade logic is finicky enough that it's best not to rely on it in any way:

  https://gist.github.com/marksteward/051be3cd90ebf5f408ffeddca4c13a8f