### PR TITLE
villages: fix registration and retain form on error

### DIFF
--- a/apps/villages/forms.py
+++ b/apps/villages/forms.py
@@ -11,6 +11,7 @@ from wtforms import (
 from wtforms.validators import URL, Length, Optional
 
 from models import Village
+from models.village import VillageRequirements
 
 from ..common.forms import Form
 
@@ -60,6 +61,9 @@ class VillageForm(Form):
         village.description = self.description.data
         village.url = self.url.data
 
+        if village.requirements is None:
+            village.requirements = VillageRequirements()
+
         village.requirements.num_attendees = self.num_attendees.data
         village.requirements.size_sqm = self.size_sqm.data
         village.requirements.power_requirements = self.power_requirements.data
@@ -86,17 +90,9 @@ class AdminVillageForm(VillageForm):
             self.lon.data = latlon.x
 
     def populate_obj(self, village: Village) -> None:
-        assert self.name.data is not None
-        village.name = self.name.data
-        village.description = self.description.data
-        village.url = self.url.data
+        super().populate_obj(village)
+
         if self.lat.data is not None and self.lon.data is not None:
             village.location = from_shape(Point(self.lon.data, self.lat.data))
         else:
             village.location = None
-
-        village.requirements.num_attendees = self.num_attendees.data
-        village.requirements.size_sqm = self.size_sqm.data
-        village.requirements.power_requirements = self.power_requirements.data
-        village.requirements.noise = self.noise.data
-        village.requirements.structures = self.structures.data

--- a/models/village.py
+++ b/models/village.py
@@ -34,9 +34,13 @@ class Village(BaseModel):
     url: Mapped[str | None]
     location: Mapped[WKBElement | None] = mapped_column(Geometry("POINT", srid=4326, spatial_index=False))
 
-    village_memberships: Mapped[list[VillageMember]] = relationship(back_populates="village")
-    requirements: Mapped[VillageRequirements] = relationship(back_populates="village")
-    venues: Mapped[list[Venue]] = relationship(back_populates="village")
+    village_memberships: Mapped[list[VillageMember]] = relationship(
+        back_populates="village", cascade="all, delete-orphan"
+    )
+    requirements: Mapped[VillageRequirements] = relationship(
+        back_populates="village", cascade="all, delete-orphan"
+    )
+    venues: Mapped[list[Venue]] = relationship(back_populates="village", cascade="all, delete-orphan")
     members = association_proxy("village_memberships", "user")
 
     @classmethod


### PR DESCRIPTION
- Fix `AttributeError` during village registration
- Inject name class error so it appears as a validation error under the
  field
- Retain register/edit form contents on name clash error
- Simplify duplicated village form logic
- Add cascades to villagerequirements/members to make village deletion
  more convenient.
