### PR TITLE
Add price to ticket list page

### DIFF
--- a/templates/account/purchases/other-items-list.html
+++ b/templates/account/purchases/other-items-list.html
@@ -2,6 +2,7 @@
 <thead>
 <tr>
   <th>Type</th>
+  <th>Price</th>
   <th>Status</th>
   <th class="table-actions"></th>
 </tr>
@@ -16,6 +17,7 @@
 {%- if item.payment and item.payment.expired %} expired {%- endif -%}
 ">
 <td>{{ item.price_tier.parent.display_name }}</td>
+<td>{{ item.price.value | price(item.price.currency) }}</td>
 <td>
     {%- if item.is_paid_for %}
     Paid

--- a/templates/account/purchases/ticket-list.html
+++ b/templates/account/purchases/ticket-list.html
@@ -12,6 +12,7 @@
   <thead>
     <tr>
       <th>Type</th>
+      <th>Price</th>
       <th>Status</th>
       <th class="table-actions"></th>
     </tr>
@@ -25,6 +26,7 @@
 {%- if t.payment and t.payment.expired %} expired {%- endif -%}
 ">
 <td>{{ t.price_tier.parent.display_name }}</td>
+<td>{{ t.price.value | price(t.price.currency) }}</td>
 <td>
     {%- if t.is_paid_for %}
     Paid


### PR DESCRIPTION
closes #755 

Add a price on the ticket page. Note that the price tier doesn't have a name (only an id/slug)

Before:
<img width="708" height="549" alt="vivaldi_iNGxdnBmgW" src="https://github.com/user-attachments/assets/c8e7843e-cde6-4442-9e2a-2f2bcb768456" />

After:
<img width="716" height="555" alt="vivaldi_HtfQ7kUwdT" src="https://github.com/user-attachments/assets/ded47b3d-fd42-4f64-ac94-738cdc3832c3" />
