### PR TITLE
Remove broken sponsor purchase links

### DIFF
--- a/templates/sponsors/sponsor.html
+++ b/templates/sponsors/sponsor.html
@@ -48,12 +48,11 @@ we hope support from sponsors will make the following things possible:</p>
     a custom sponsorship package for each sponsor that wishes to be involved with EMF.</p>
 <div id="sponsorship-levels">
     <div class="panel panel-default">
-        <div class="panel-heading"><h4><a href="https://www.emfcamp.org/tickets/sponsor"> Copper: £1000 or lower</a></h4></div>
+        <div class="panel-heading"><h4>Copper: £1000 or lower</h4></div>
         <div class="panel-body">
             <ul>
                 <li>Logo on website</li>
             </ul>
-            Buy this <a href="https://www.emfcamp.org/tickets/sponsor">in our ticket shop</a>
         </div>
     </div>
     <div class="panel panel-default">


### PR DESCRIPTION
Right now these links aren't working because tickets aren't on sale. When tickets are available in the future, this can be reverted.