### PR TITLE
Tests: payments: dynamic profile_id retrieval

### DIFF
--- a/apps/payments/wise.py
+++ b/apps/payments/wise.py
@@ -185,6 +185,8 @@ def sync_wise_statement(profile_id, wise_balance_id, currency):
 
 
 def wise_business_profile():
+    from main import wise
+
     if app.config.get("TRANSFERWISE_PROFILE_ID"):
         id = int(app.config["TRANSFERWISE_PROFILE_ID"])
         accounts = list(wise.account_details.list(profile_id=id))

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,6 +1,6 @@
 import pytest
 
-from apps.payments.wise import wise_retrieve_accounts
+from apps.payments.wise import wise_business_profile, wise_retrieve_accounts
 from models.payment import BankTransaction
 
 
@@ -14,7 +14,8 @@ def vcr_config():
 
 @pytest.mark.vcr()
 def test_wise_account_retrieval(app):
-    accounts = list(wise_retrieve_accounts(profile_id=123456789))
+    profile_id = wise_business_profile()
+    accounts = list(wise_retrieve_accounts(profile_id=profile_id))
 
     # we merge Wise's local and international details for our GBP account into a single record
     assert len(accounts) == 1


### PR DESCRIPTION
The hardcoded `profile_id=123456789` previously in place here is in conflict with the ability to regenerate pytest-vcr fixtures.

Regeneration of those fixtures requires a valid Wise sandbox token, but the sandbox environment does also restrict the profile IDs accessible by those tokens -- so we need to retrieve information for a valid account linked to the token.

To do that, retrieve the (business) profile ID dynamically.

Follow-up related to #1847.