### PR TITLE
Make phone number links deliberate

### DIFF
--- a/templates/about/deliveries.md
+++ b/templates/about/deliveries.md
@@ -25,7 +25,7 @@ EMF Electromagnetic Field 2024
 Eastnor Deer Park
 Access from A438
 Eastnor, LEDBURY HR8 1RQ
-Phone: 07441 101723
+Phone: [07441 101723](tel:07441101723)
 
 It's important you get all of this in; if the service you're using doesn't have that many address lines, combine some (the name/village name line and the Deer Park/A438 lines could be combined).
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="format-detection" content="telephone=no">
         <meta name="color-scheme" content="only light">
         <title>{% block title %}{% endblock %}{% if self.title() %} - {% endif %}Electromagnetic Field</title>
         {% if self.title() -%}


### PR DESCRIPTION
* Disable phone number detection on Safari, because it pick up spurious things like OS Grid References 
* Add tel: link to legitimate phone numbers (only one one found right now is hidden in deliveries page, but I assume will be re-enabled at some point)

<img width="603" height="1311" alt="IMG_1303" src="https://github.com/user-attachments/assets/68ceabf0-0d02-4ba9-b4ac-6109b97b0103" />
