### PR TITLE
Tweak age ranges

### DIFF
--- a/models/cfp.py
+++ b/models/cfp.py
@@ -189,9 +189,8 @@ OCCURRENCE_STATE_TRANSITIONS: dict[OccurrenceState, set[OccurrenceState]] = {
 # Options for age range displayed to the user
 AGE_RANGE_OPTIONS = [
     ("all", "Suitable for all ages"),
-    ("u12", "Under 12"),
-    ("12+", "Age 12+"),
-    ("14+", "Age 14+"),
+    ("u12", "Under 12 with parent/guardian"),
+    ("teens", "Teens 13-17 with parent/guardian"),
     ("16+", "Age 16+"),
     ("18+", "Age 18+"),
     ("other", "Other"),


### PR DESCRIPTION
Something very small for consideration on #1919. If age ranges are going to be used, the 12+ and 14+ categories I'm not sure will be overly used. Unless you've got kids or work with kids, I'm not sure most folks will be able to effectively differentiating between these.
Instead, it might make more sense to focus on suitability for **all ages**, plus then the age restrictions for families (16+ and 18+).
I took out the 12+ category itself as well, as I can't see a differentiator between all ages and 12+? Maybe at the push, something like a soldering workshop? But that's probably better putting in the notes so they can be more specific and make it all ages.

Additionally, with the (I'm assuming?) increase in teenagers this year due to the move to school holidays (and away from exams season), it might make sense if there's already a category for under 12, to also have a category for teenagers specific workshops. A workshop for a teenage is generally pretty different than that for a younger kid.
**Maybe teen though better suits ages 13-16?**

Finally, I've included in the description the specific with parent/guardian element so that it's clear. **Not sure if "_with parent/guardian_" is needed though here?**