### PR TITLE
Add Orchestrator configs

### DIFF
--- a/config/orchestrator.cfg
+++ b/config/orchestrator.cfg
@@ -1,0 +1,134 @@
+import hmac, hashlib, os
+
+def _make_secret(w):
+    seed = os.environ.get('ORCHESTRATOR_SECRET_SEED', '')
+    assert seed
+    return hmac.new(seed.encode(), w.encode(), hashlib.sha256).hexdigest()
+
+DEBUG = False
+LOG_COLOR = False
+EXTRA_DEBUG_HANDLER = False
+ASSETS_DEBUG = False
+DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+STAGING_WARNING = True
+
+# Warning: set the following to False if you put
+# any secret keys or passwords in this config
+DEBUG_TB_ENABLED = False
+
+SECRET_KEY = _make_secret('SECRET_KEY')
+FEED_SECRET_KEY = _make_secret('FEED_SECRET_KEY')
+
+# Uncomment to log every query to the console - handy when using flask shell
+#SQLALCHEMY_ECHO=True
+SQLALCHEMY_DATABASE_URI = "postgresql://postgres:postgres@postgres/emf_site"
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = "Lax"
+HSTS = True
+
+CACHE_TYPE = "flask_caching.backends.SimpleCache"
+NO_INDEX = True
+
+STRIPE_SECRET_KEY = ""
+STRIPE_PUBLIC_KEY = ""
+STRIPE_WEBHOOK_KEY = ""
+STRIPE_LIVEMODE = False
+
+TRANSFERWISE_ENVIRONMENT = "sandbox"
+TRANSFERWISE_API_TOKEN = ""
+
+MAILCHIMP_KEY = ""
+MAILCHIMP_LIST = ""
+
+MAIL_BACKEND = "smtp"
+MAIL_SERVER = "maildev"
+MAIL_PORT = 1025
+MAIL_TIMEOUT = 15
+
+BULK_MAIL_BACKEND = "apps.common.backends.bulk.BulkEmailBackend"
+BULK_MAIL_SERVER = "maildev"
+BULK_MAIL_PORT = 1025
+BULK_MAIL_TIMEOUT = 15
+
+# Feature flags
+TICKET_SALES = True
+BANK_TRANSFER = True
+BANK_TRANSFER_EURO = True
+STRIPE = True
+
+CFP = True
+CFP_FINALISE = False
+CFP_CLOSED = False
+VOLUNTEERS_SCHEDULE = True
+ISSUE_TICKETS = False
+LINE_UP = False
+SCHEDULE = False
+REFUND_REQUESTS = False
+VOLUNTEERS_SIGNUP = True
+
+EXPIRY_DAYS_TRANSFER = 10
+EXPIRY_DAYS_TRANSFER_EURO = 12
+EXPIRY_DAYS_STRIPE = 3
+
+TICKETS_EMAIL = ("Electromagnetic Field", "tickets@emfcamp-test.org")
+TICKETS_NOTICE_EMAIL = ("Electromagnetic Field", "tickets@emfcamp-test.org")
+CONTACT_EMAIL = ("Electromagnetic Field", "contact@emfcamp-test.org")
+CONTENT_EMAIL = ("Electromagnetic Field", "content@emfcamp-test.org")
+CONDUCT_EMAIL = ("Electromagnetic Field", "conduct@emfcamp-test.org")
+SPEAKERS_EMAIL = ("Electromagnetic Field", "speakers@emfcamp-test.org")
+VILLAGECONTENT_EMAIL = ("Electromagnetic Field", "villagecontent@emfcamp-test.org")
+DUTY_EMAIL = ("Electromagnetic Field", "contact@emfcamp-test.org")
+VOLUNTEER_EMAIL = ("Electromagnetic Field", "volunteer@emfcamp-test.org")
+
+SERVER_NAME = os.environ.get('PORT_WEB_HOSTNAME', '')
+CHECKIN_BASE = f"https://{{ SERVER_NAME }}/"
+PREFERRED_URL_SCHEME = 'https'
+
+BAR_TRAINING_FORM = ''
+
+VIDEO_API_KEY = "video-api-token"
+
+GOOGLE_API_KEY = ''
+
+LISTMONK_URL = "https://broadcast.emfcamp.org"
+LISTMONK_LISTS = {
+  "main": "e4f02d85-5f8f-458f-9f83-051edf25bfb0",
+  "volunteer": "ee88b1a2-a9da-4235-9223-7e537a3a44cc"
+}
+
+RESERVE_LIST_TICKET_LINK = "http://www.emfcamp.org/tickets/token/invalid"
+
+# When updating these update/hide times in about/arrival-times.html
+EVENT_START = '2026-07-16 11:00:00'
+EVENT_END   = '2026-07-19 23:00:00'
+
+DEFAULT_FLOW = 'main'
+
+# Days before and after to allow arrivals and departures
+# Presented to volunteers when signing up
+ARRIVAL_DAYS = 2
+DEPARTURE_DAYS = 2
+
+# After 2024 we can remove these as we'll be fully using the dropdows
+GENDER_MATCHERS = {
+    "female": r"^(female|woman|f|fem|femme)$",
+    "male": r"^(male|man|m|masc)$",
+    "non-binary": r"^(nb|enby|non[ -]?binary)$",
+    "other": r"^other$",
+}
+ETHNICITY_MATCHERS = {
+    "asian": r"^(asian|indian|chinese|pakistani)$",
+    "black": r"^(black ?(british)?)$",
+    "mixed": r"^mixed$",
+    "white": ( \
+        # white, white british, white uk etc. \
+        r"^(white ?(british|irish|welsh|scottish|uk|european|english)?" \
+        # just british, caucasian etc. \
+        r"|caucasian|british|irish|welsh|scottish|uk|european|english)$" \
+    ),
+    "other": r"^other$",
+}

--- a/docker-compose.orchestrator.yml
+++ b/docker-compose.orchestrator.yml
@@ -1,0 +1,64 @@
+services:
+  app:
+    build:
+      context: "./"
+    init: true
+    networks:
+      - emfweb
+    depends_on:
+      - postgres
+    volumes:
+      - .:/app
+      - ./var/vat_invoices:/vat_invoices
+    ports:
+      - "127.0.0.1:${PORT_WEB}:2342"
+    restart: unless-stopped
+    environment:
+      SETTINGS_FILE: ./config/orchestrator.cfg
+      FLASK_APP: dev_server.py  # Required for flask-admin 1.6.1 to work (see #1769)
+      COLORIZE_LOGS: always
+      PYTHONUNBUFFERED: 1
+      IRCCAT: fakeirccat:12345
+      ORCHESTRATOR_SECRET_SEED: "${ORCHESTRATOR_SECRET_SEED}"
+      PORT_WEB_HOSTNAME: "${PORT_WEB_HOSTNAME}"
+
+  rsbuild:
+    restart: unless-stopped
+    build:
+      context: "./docker/rsbuild"
+    init: true
+    volumes:
+      - .:/app
+
+  maildev:
+    restart: unless-stopped
+    image: 'maildev/maildev:2.2.1'
+    ports:
+      - "127.0.0.1:${PORT_MAIL}:1080"
+    networks:
+      - emfweb
+
+  postgres:
+    restart: unless-stopped
+    image: 'postgis/postgis:16-3.4-alpine'
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    networks:
+      - emfweb
+
+  fakeirccat:
+    restart: unless-stopped
+    build:
+      context: "./docker/netcat"
+    command: -k -l -p 12345
+    init: true
+    networks:
+      - emfweb
+
+networks:
+  emfweb:
+
+volumes:
+  postgres:


### PR DESCRIPTION
These are staging-like configs that are designed for setting up quick review environments, using inputs from outside in order to configure them (e.g. setting the ports in docker compose, and generating random secrets). They'll be exposed under subdomains of pr.emfcamp-test.org - e.g. https://calm-hawk-9959.pr.emfcamp-test.org/. There's a mini-management web UI on pr.emfcamp-test.org.