### PR TITLE
Account area improvements for usability & accessibility 

### DIFF
--- a/css/_forms.scss
+++ b/css/_forms.scss
@@ -1,12 +1,12 @@
 @use "sass:color";
 @use "./_variables.scss" as *;
 
-
 .form-control {
     background-color: $form-element;
 }
 
-.form-horizontal .form-group .help-block {
+.form-horizontal .form-group .form-control ~ .help-block,
+.form-horizontal .form-group .input-group ~ .help-block {
     padding-left: 0.5em;
 }
 
@@ -20,7 +20,7 @@ fieldset legend {
     margin-bottom: 10px;
 }
 
-input[type=range] {
+input[type="range"] {
     appearance: none;
     border: none;
     box-shadow: none;
@@ -28,7 +28,7 @@ input[type=range] {
     margin-bottom: 6px;
 }
 
-input[type=range]::range-track {
+input[type="range"]::range-track {
     appearance: none;
     height: 8.4px;
     cursor: pointer;
@@ -36,11 +36,11 @@ input[type=range]::range-track {
     border-radius: 3px;
 }
 
-input[type=range]:focus::range-track {
+input[type="range"]:focus::range-track {
     background: color.adjust($main-link-hover, $lightness: 5%);
 }
 
-input[type=range]::range-thumb {
+input[type="range"]::range-thumb {
     appearance: none;
     box-shadow: 1px 1px 1px color.adjust($main-background, $lightness: 50%);
     border: 1px solid $main-background;

--- a/templates/account/_nav.html
+++ b/templates/account/_nav.html
@@ -5,16 +5,21 @@
 {% endmacro %}
 
 {% macro menuitem(text, view, badge_count=0, classes="") %}
-<li class="{% if view_name == view %}active{% endif %} {{classes}}">
+<li class="{% if request.endpoint == view %}active{% endif %} {{classes}}">
     <a href="{{ url_for(view) }}">{{text}}</a>
     {{badge(badge_count)}}
   </li>
 {% endmacro %}
 
-<nav>
+<div class="well well-sm">
+  You're logged in as <strong>{{ current_user.name }}</strong> ({{ current_user.email }}).
+  <a class="pull-right" href="{{ url_for('users.logout') }}">Log out</a>
+</div>
+<nav class="mb-3" style="margin-bottom: 1em;">
   <ul class="nav nav-tabs">
     {{ menuitem("Account", "users.account") }}
-    {{ menuitem("My Tickets", "users.purchases") }}
+    {{ menuitem("Your Details", "users.details") }}
+    {{ menuitem("Your Tickets", "users.purchases") }}
 
     {% if feature_enabled('CFP') %}
       {% if current_user.proposals | length > 0 %}
@@ -47,8 +52,6 @@
     {% if current_user.has_permission('admin') %}
       {{ menuitem("Admin", "admin.home") }}
     {% endif %}
-
-    {{ menuitem("Log Out", "users.logout", classes="pull-right") }}
   </ul>
 </nav>
 

--- a/templates/account/details.html
+++ b/templates/account/details.html
@@ -2,23 +2,17 @@
 {% from "_diversityform.html" import render_diversity_fields %}
 
 {% extends "base.html" %}
-{% block title %}My Account{% endblock %}
+{% block title %}Your Details{% endblock %}
 {% block body %}
 {% include "account/_nav.html" %}
 <h3>Your Details</h3>
 
 <div class="panel panel-default">
-  <div class="panel-heading">
-    {% if feature_enabled('CFP') %}
-      <div>If you've made a submission to the CfP then your name (as it's set here) will be used
-           in the schedule.</div>
-    {% endif %}
-  </div>
   <div class="panel-body">
   <form method="post" class="form-horizontal">
     {{ form.hidden_tag() }}
     <fieldset>
-      <h4>Account details</h4>
+      <h4>Your details</h4>
       <div class="col-sm-12">
         <div class="form-group">
           <label class="col-sm-2 control-label">Email</label>

--- a/templates/account/main.html
+++ b/templates/account/main.html
@@ -4,10 +4,6 @@
 {% block body %}
 {% include "account/_nav.html" %}
 {% set owned_tickets = current_user.get_owned_tickets(True)|list %}
-<p>
-  You're logged in as <strong>{{current_user.name}}</strong> (<strong>{{ current_user.email }}</strong>).
-    <a href="{{url_for('.details')}}">Edit your account details</a>.
-</p>
 <div class="panel-grid">
   <div class="panel panel-default">
       <div class="panel-heading">
@@ -34,16 +30,29 @@
       </div>
   </div>
 
-  {% if feature_enabled('CFP') and not feature_enabled('CFP_CLOSED') %}
+  {% if feature_enabled('CFP') %}
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title">Call for Participation</h3>
       </div>
       <div class="panel-body">
-        <p>Our Call for Participation is open!<br>
-        We're looking for talks, workshops, or performances at EMF {{event_year}}.
-        </p>
-        <a class="btn btn-primary" href="{{url_for('cfp.main')}}">Submit a proposal</a>
+        {% set proposal_count = current_user.proposals | length %}
+        {% if not feature_enabled('CFP_CLOSED') %}
+          <p>Our Call for Participation is open!<br>
+          We're looking for talks, workshops, or performances at EMF {{event_year}}.
+          </p>
+        {% endif %}
+        {% if proposal_count %}
+          <p>You've already submitted {{ proposal_count }} {{ 'proposal' if proposal_count == 1 else 'proposals' }}.</p>
+        {% endif %}
+        <div class="btn-group">
+          {% if not feature_enabled('CFP_CLOSED') %}
+            <a class="btn btn-primary" href="{{url_for('cfp.main')}}">Submit {{ 'another' if proposal_count else 'a' }} proposal</a>
+          {% endif %}
+          {% if proposal_count %}
+            <a class="btn btn-default" href="{{ url_for('cfp.proposals') }}">View or edit your {{ 'proposal' if proposal_count == 1 else 'proposals' }}</a>
+          {% endif %}
+        </div>
       </div>
     </div>
   {% endif %}

--- a/templates/account/purchases.html
+++ b/templates/account/purchases.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% set main_class = 'account-purchases' %}
 
-{% block title %}Your tickets{% endblock %}
+{% block title %}Your Tickets{% endblock %}
 {% block body %}
 {% include "account/_nav.html" %}
 {% if tickets %}
-  <h3>Your tickets</h2>
+  <h3>Your Tickets</h3>
   <a id="tickets"></a>
   {% if not config['ISSUE_TICKETS'] %}
   <p>We'll send you a scannable ticket by email shortly before the event.

--- a/templates/cfp/closed.html
+++ b/templates/cfp/closed.html
@@ -8,19 +8,19 @@
         {#
         <p>If you have been asked to submit a new proposal for a talk, performance, workshop, youth workshop or installation, please
         #}
-        <p>If you need to submit a new proposal for an installation or lightning talk, please
+        <p>You can still
             {% if proposal_type %}
-            <a href="{{ url_for('cfp.create_proposal', proposal_type=proposal_type) + '?closed' }}">click here</a>.</p>
+            <a href="{{ url_for('cfp.create_proposal', proposal_type=proposal_type) + '?closed' }}">submit a new proposal for an installation or lightning talk</a>.</p>
             {% else %}
-            <a href="{{ url_for('cfp.main') + '?closed' }}">click here</a>.</p>
+            <a href="{{ url_for('cfp.main') + '?closed' }}">submit a new proposal for an installation or lightning talk</a>.</p>
             {% endif %}
 
         {% if current_user.is_authenticated %}
           {% if current_user.proposals %}
-          <a class="btn btn-default" href="{{ url_for('cfp.proposals') }}">View my proposals</a>
+          <a class="btn btn-default" href="{{ url_for('cfp.proposals') }}">View your proposals</a>
           {% endif %}
         {% else %}
-          <a class="btn btn-default" href="{{ url_for('users.login', next=url_for('cfp.proposals')) }}">View my proposals</a>
+          <a class="btn btn-default" href="{{ url_for('users.login', next=url_for('cfp.proposals')) }}">View your proposals</a>
         {% endif %}
 
     </div>

--- a/templates/cfp/complete.html
+++ b/templates/cfp/complete.html
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="alert alert-success">Thanks for your submission!</div>
 <p>We'll be in touch by email as soon as we can.</p>
-<p><a href="{{ url_for('.proposals') }}" target="_blank">Click here</a> to view or edit your proposals.
+<p>You can still <a href="{{ url_for('.proposals') }}" target="_blank">view or edit your proposals</a>.
 You will be able to make changes until we start the anonymisation process.</p>
 
 {% if not current_user.diversity %}

--- a/templates/cfp/new.html
+++ b/templates/cfp/new.html
@@ -27,7 +27,7 @@
           <div class="alert alert-warning">
               This email address already exists in our system, possibly because you previously tried to submit a proposal and
               we automatically created an account for you.
-              Please <a class="alert-link" href="{{ url_for('users.login', next=url_for('.main', proposal_type=proposal_type) + ('?closed' if ignore_closed else ''), email=form.email.data) }}" target="_new">click here</a> to log in.
+              Please <a class="alert-link" href="{{ url_for('users.login', next=url_for('.main', proposal_type=proposal_type) + ('?closed' if ignore_closed else ''), email=form.email.data) }}" target="_new">log in</a> to continue.
           </div>
           {% else %}
           <p>
@@ -44,7 +44,17 @@
             </div>
           </div>
         {% endif %}
-        {{ render_field(form.name, horizontal=9, placeholder="Your name" + (' (or pseudonym)' if proposal_type != 'youthworkshop' else '')) }}
+        {% if current_user.is_authenticated %}
+          <div class="form-group">
+            <label class="col-sm-3 control-label">Name</label>
+            <div class="col-sm-9">
+              <div class="form-control-static">{{ current_user.name }}</div>
+              <p class="help-block">If your proposal is accepted, you can edit your name before it's publicly shown as part of the schedule.</p>
+            </div>
+          </div>
+        {% else %}
+          {% call render_field(form.name, horizontal=9, placeholder="Your name" + (' (or pseudonym)' if proposal_type != 'youthworkshop' else '')) %}If your proposal is accepted, you can edit your name before it's publicly shown as part of the schedule.{% endcall %}
+        {% endif %}
         {% if current_user.is_anonymous %}
         {{ render_field(form.email, horizontal=9, placeholder="Your email address") }}
         {% endif %}

--- a/templates/cfp/proposals.html
+++ b/templates/cfp/proposals.html
@@ -90,7 +90,6 @@
 </table>
 
 <div class="pull-right">
-  <a href="{{ url_for('users.account') }}" class="btn btn-default">Back</a>
   <a href="{{ url_for('cfp.main') }}" class="btn btn-success">Submit a new proposal</a>
 </div>
 

--- a/templates/tickets/cutoff.html
+++ b/templates/tickets/cutoff.html
@@ -17,8 +17,8 @@
             please follow us on <a href="https://social.emfcamp.org/@emf">the Fediverse</a>.</p>
         {% endif %}
         {% if SALES_STATE != 'sales-ended' %}
-        <p>If you have a ticket to EMF and need to order parking tickets, please
-            <a href="{{ url_for('tickets.main', flow='other') }}">click here</a>.
+        <p>If you have a ticket to EMF you can still 
+            <a href="{{ url_for('tickets.main', flow='other') }}">order parking tickets</a>.</p>
         {% endif %}
     </div>
 {% endblock %}

--- a/templates/tickets/payment-choose.html
+++ b/templates/tickets/payment-choose.html
@@ -51,7 +51,7 @@
     <div class="alert alert-warning">
         This email address already exists in our system, possibly because you previously tried to buy a ticket and
         we automatically created an account for you.
-        Please <a class="alert-link" href="{{ url_for('users.login', next=url_for('tickets.pay', flow=flow), email=form.email.data) }}">click here</a> to log in.
+        Please <a class="alert-link" href="{{ url_for('users.login', next=url_for('tickets.pay', flow=flow), email=form.email.data) }}">log in</a> to continue.
     </div>
     {% endif %}
 

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -19,7 +19,7 @@
     </noscript>
 
     <h2>Pick your shifts</h2>
-    <p>Select a day to sign up for shifts. To change which roles you're interested in, <a href="{{ url_for('.choose_role') }}">click here</a>.</p>
+    <p>Select a day to sign up for shifts. You can also <a href="{{ url_for('.choose_role') }}">change which roles you're interested in</a>.</p>
 
     <p>You can get a list of all your shifts as an <a href="{{ url_for('.schedule_ical', token=token) }}">iCal feed</a>.</p>
 

--- a/templates/volunteer/sign-up.html
+++ b/templates/volunteer/sign-up.html
@@ -37,7 +37,7 @@
         {% if form.volunteer_email.was_duplicate %}
         <div class="alert alert-warning">
             This email address already exists in our system.
-            Please <a class="alert-link" href="{{ url_for('users.login', next=url_for('.main'), email=form.volunteer_email.data) }}">click here</a> to log in.
+            Please <a class="alert-link" href="{{ url_for('users.login', next=url_for('.main'), email=form.volunteer_email.data) }}">log in</a> to continue.
         </div>
         {% endif %}
 


### PR DESCRIPTION
### Account area navigation tidy up

* Created a "user bar" that shows logged in user details + logout link. This is currently shown only in `/account` routes but we could decide to make it more global in the future
* "Edit your details" moved to a dedicated "Your Details" tab
* Changed labelling from "My" to "Your" (e.g. "My Tickets" --> "Your Tickets") to be more consistent with the language used elsewhere throughout the site
* Fixed highlighting of currently active account sub-navigation tab which was previously broken

<img width="976" height="126" alt="image" src="https://github.com/user-attachments/assets/a29c1d0f-d88a-4b0c-a5dd-eb38b304186d" />

### Account dashboard: more details in CfP widget

* CfP widget now shows when you've already submitted proposals and shows link to view and edit them. Previously it was just a link to submit new proposals, and seen on its own it looked like your currently submitted proposals did not exist (unless you actively went to look for them in the proposals tab)
* This means that this widget will now still be visible after CfP closes, if you have active proposals

<img width="470" height="236" alt="image" src="https://github.com/user-attachments/assets/280c5401-f85e-4e34-bacf-a0b5bc9bf8ce" />

### Clarification around name used on schedule

* Removed from `/account/details` the text _"If you've made a submission to the CfP then your name (as it's set here) will be used in the schedule."_ since (as per discussion on IRC) people will be given the chance to update their name before accepted proposals are being published
* On CfP form, the name is now non-editable for logged-in users, since editing it didn't do anything for this path. There is now help text next to the name to clarify that "If your proposal is accepted, you can edit your name before it's publicly shown as part of the schedule."

<img width="931" height="284" alt="image" src="https://github.com/user-attachments/assets/ca0d908f-c963-46c9-b2c1-1a07cbac7001" />

### Removed redundant "Back" button from `cfp/proposals`

Removed the "Back" button linking to /account, as the account nav is now consistently available on account pages and the proposals page already includes navigation context.

### Accessible link text

Replaced all instances of "click here" with more specific link text (rationale: see "Writing link text " in https://www.gov.uk/guidance/content-design/links)

So for example "You already have an account, please _click here_ to log in" becomes "You already have an account, please _log in_ to continue" (link in italics)

### Malformed HTML tag fix in `purchases.html`

Fixes a mismatched closing tag
```
<h3>Your tickets</h2> 
```

### CSS fix in `_forms.scss`

The .help-block padding selector was made more specific so padding-left: 0.5em only applies when a help-block follows a form control or input group. This was needed because the new non-editable name field in `cfp/new.html` uses `form-control-static` (not `form-control`), and without this fix the adjacent help text would receive unintended left padding.
