### PR TITLE
Allow longer village names

### DIFF
--- a/apps/villages/forms.py
+++ b/apps/villages/forms.py
@@ -17,7 +17,7 @@ from ..common.forms import Form
 
 
 class VillageForm(Form):
-    name = StringField("Village Name", [Length(2, 25)])
+    name = StringField("Village Name", [Length(2, 50)])
     description = TextAreaField("Description", [Optional()])
     long_description = TextAreaField("Long Description", [Optional()])
     url = StringField("URL", [URL(), Optional()])


### PR DESCRIPTION
Fixes #1962.

I picked the length of a (classic) tweet arbitrarily.

The [Village model](https://github.com/emfcamp/Website/blob/52701ba379d3bdc1007a58ca934dc9581d4c8bdf/models/village.py#L32) doesn't constrain name length, so just the form needs changing.