### PR TITLE
Account page tidy

### DIFF
--- a/css/_panel_grid.scss
+++ b/css/_panel_grid.scss
@@ -1,4 +1,5 @@
 /* A grid of panels. */
+@use "./_variables.scss" as *;
 
 .panel-grid {
   --panel-grid-min-size: 350px;
@@ -10,9 +11,38 @@
   grid-template-columns: repeat(auto-fill, minmax(var(--panel-grid-min-size), var(--panel-grid-max-size)));
   grid-template-rows: masonry;
   margin-bottom: 20px;
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .panel-body {
+    flex-grow: 1;
+
+    p:last-child {
+        margin-bottom: 0;
+        padding-bottom: 0;
+    }
+  }
+
+  .panel-footer {
+    background-color: $highlight-background;
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+  }
+
+  .panel-footer a {
+    font-weight: 700;
+    text-decoration: none;
+    display: block;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 .panel-grid > .panel {
-  block-size: fit-content;
   margin-bottom: 0;
 }

--- a/templates/account/main.html
+++ b/templates/account/main.html
@@ -5,109 +5,112 @@
 {% include "account/_nav.html" %}
 {% set owned_tickets = current_user.get_owned_tickets(True)|list %}
 <p>
-  You're logged in as <strong>{{current_user.name}}</strong> (<strong>{{ current_user.email }}</strong>).
+    You're logged in as <strong>{{current_user.name}}</strong> (<strong>{{ current_user.email }}</strong>).
     <a href="{{url_for('.details')}}">Edit your account details</a>.
 </p>
 <div class="panel-grid">
-  <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Villages</h3>
-      </div>
-      <div class="panel-body">
-        {% if current_user.village %}
-          <p>You're a member of the <strong><a href="{{url_for('villages.view', year=event_year, village_id=current_user.village.id)}}">{{current_user.village.name}}</a></strong> village.</p>
-          {% if current_user.village_membership.admin %}
-            <a class="btn btn-primary" href="{{url_for('villages.edit', year=event_year, village_id=current_user.village.id)}}">
-              Edit village details</a>
-          {% endif %}
-        {% else %}
-          <p>Village registration is open! If you're planning on camping with a group of people,
-          you can let us know about it by registering your village.
-          This will help us try to make sure you have the space and facilities you need.
-          <a href="{{url_for('base.page', page_name='villages')}}">Learn more about villages</a>.
-          </p>
-          <div class="btn-group">
-            <a class="btn btn-primary" href="{{ url_for("villages.register") }}">Register a village</a>
-            <a class="btn btn-default" href="{{url_for("villages.main", year=event_year)}}">View villages</a>
-          </div>
-        {% endif %}
-      </div>
-  </div>
-
-  {% if feature_enabled('CFP') and not feature_enabled('CFP_CLOSED') %}
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Call for Participation</h3>
-      </div>
-      <div class="panel-body">
-        <p>Our Call for Participation is open!<br>
-        We're looking for talks, workshops, or performances at EMF {{event_year}}.
-        </p>
-        <a class="btn btn-primary" href="{{url_for('cfp.main')}}">Submit a proposal</a>
-      </div>
+        <div class="panel-heading">
+            <h3 class="panel-title">Villages</h3>
+        </div>
+        <div class="panel-body">
+            {% if current_user.village %}
+            <p>You're a member of the <strong><a
+                        href="{{url_for('villages.view', year=event_year, village_id=current_user.village.id)}}">{{current_user.village.name}}</a></strong>
+                village.</p>
+            {% if current_user.village_membership.admin %}
+            <a class="btn btn-primary"
+                href="{{url_for('villages.edit', year=event_year, village_id=current_user.village.id)}}">
+                Edit village details</a>
+            {% endif %}
+            {% else %}
+            <p>Village registration is open! If you're planning on camping with a group of people,
+                you can let us know about it by registering your village.
+                This will help us try to make sure you have the space and facilities you need.
+                <a href="{{url_for('base.page', page_name='villages')}}">Learn more about villages</a>.
+            </p>
+            <div class="btn-group">
+                <a class="btn btn-primary" href="{{ url_for('villages.register') }}">Register a village</a>
+                <a class="btn btn-default" href="{{ url_for('villages.main', year=event_year) }}">View villages</a>
+            </div>
+            {% endif %}
+        </div>
     </div>
-  {% endif %}
 
-  {% if feature_enabled('ATTENDEE_CONTENT') %}
+    {% if feature_enabled('CFP') and not feature_enabled('CFP_CLOSED') %}
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Your Content</h3>
-      </div>
-      <div class="panel-body">
-        <p>
-          You can help other people find you or your village's talks, workshops, installations, and gatherings by
-          adding them to the schedule.</p>
-        <p>
-          If you're part of a village you'll be able to schedule content occurring there,
-          and anyone can arrange gatherings in the main bar or lounge.
-        </p>
-        <a class="btn btn-primary" href="{{url_for('schedule.attendee_content')}}">Manage your content</a>
-      </div>
+        <div class="panel-heading">
+            <h3 class="panel-title">Call for Participation</h3>
+        </div>
+        <div class="panel-body">
+            <p>Our Call for Participation is open!<br>
+                We're looking for talks, workshops, or performances at EMF {{event_year}}.
+            </p>
+            <a class="btn btn-primary" href="{{ url_for('cfp.main') }}">Submit a proposal</a>
+        </div>
     </div>
-  {% endif %}
+    {% endif %}
 
-  {% if owned_tickets|length > 1 %}
+    {% if feature_enabled('ATTENDEE_CONTENT') %}
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">Transfer Tickets</h3>
-      </div>
-      <div class="panel-body">
-        <p>
-        You have more than one ticket assigned to you. We recommend you transfer tickets to
-        whoever will be using them, so they can receive updates from us and sign up for workshops.
-        </p>
-        <a class="btn btn-primary" href="{{url_for(".purchases")}}">Transfer tickets</a>
-      </div>
+        <div class="panel-heading">
+            <h3 class="panel-title">Your Content</h3>
+        </div>
+        <div class="panel-body">
+            <p>
+                You can help other people find you or your village's talks, workshops, installations, and gatherings by
+                adding them to the schedule.</p>
+            <p>
+                If you're part of a village you'll be able to schedule content occurring there,
+                and anyone can arrange gatherings in the main bar or lounge.
+            </p>
+            <a class="btn btn-primary" href="{{ url_for('schedule.attendee_content') }}">Manage your content</a>
+        </div>
     </div>
-  {% endif %}
+    {% endif %}
+
+    {% if owned_tickets|length > 1 %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Transfer Tickets</h3>
+        </div>
+        <div class="panel-body">
+            <p>
+                You have more than one ticket assigned to you. We recommend you transfer tickets to
+                whoever will be using them, so they can receive updates from us and sign up for workshops.
+            </p>
+            <a class="btn btn-primary" href="{{ url_for('.purchases') }}">Transfer tickets</a>
+        </div>
+    </div>
+    {% endif %}
 
     <div class="panel panel-default">
         <div class="panel-heading">
-        <h3 class="panel-title">Chat</h3>
+            <h3 class="panel-title">Chat</h3>
         </div>
         <div class="panel-body">
-        <p>Ask us questions and get in touch with other EMF attendees in our Matrix chat channels.
-        </p>
-        <a class="btn btn-primary" href="https://matrix.to/#/#emf:emfcamp.org" target="_blank">EMF Matrix Space</a>
+            <p>Ask us questions and get in touch with other EMF attendees in our Matrix chat channels.
+            </p>
+            <a class="btn btn-primary" href="https://matrix.to/#/#emf:emfcamp.org" target="_blank">EMF Matrix Space</a>
         </div>
     </div>
 
-  {#
-  {% if SITE_STATE in ('sales', 'event') %}
+    {#
+    {% if SITE_STATE in ('sales', 'event') %}
     <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">T-shirts and badges</h3>
-      </div>
-      <div class="panel-body">
-        <p>We still have a limited number of EMF 2024 T-shirts and Tildagon electronic badges available
-        for sale &mdash; order now and collect them at the event.</p>
-        <div class="btn-group">
-          <a class="btn btn-primary" href="{{url_for("tickets.main", flow="tees")}}">Buy t-shirts</a>
-          <a class="btn btn-primary" href="{{url_for("tickets.main", flow="badge")}}">Buy badges</a>
+        <div class="panel-heading">
+            <h3 class="panel-title">T-shirts and badges</h3>
         </div>
-      </div>
+        <div class="panel-body">
+            <p>We still have a limited number of EMF 2024 T-shirts and Tildagon electronic badges available
+                for sale &mdash; order now and collect them at the event.</p>
+            <div class="btn-group">
+                <a class="btn btn-primary" href="{{ url_for('tickets.main', flow='tees') }}">Buy t-shirts</a>
+                <a class="btn btn-primary" href="{{ url_for('tickets.main', flow='badge') }}">Buy badges</a>
+            </div>
+        </div>
     </div>
-  {% endif %}
-  #}
-  </div>
+    {% endif %}
+    #}
+</div>
 {% endblock %}

--- a/templates/account/main.html
+++ b/templates/account/main.html
@@ -13,28 +13,31 @@
         <div class="panel-heading">
             <h3 class="panel-title">Villages</h3>
         </div>
+        {% if current_user.village %}
         <div class="panel-body">
-            {% if current_user.village %}
             <p>You're a member of the <strong><a
                         href="{{url_for('villages.view', year=event_year, village_id=current_user.village.id)}}">{{current_user.village.name}}</a></strong>
                 village.</p>
-            {% if current_user.village_membership.admin %}
-            <a class="btn btn-primary"
-                href="{{url_for('villages.edit', year=event_year, village_id=current_user.village.id)}}">
-                Edit village details</a>
-            {% endif %}
-            {% else %}
+        </div>
+        {% if current_user.village_membership.admin %}
+        <div class="panel-footer">
+            <a href="{{url_for('villages.edit', year=event_year, village_id=current_user.village.id)}}">
+                Edit village details &rarr;</a>
+        </div>
+        {% endif %}
+        {% else %}
+        <div class="panel-body">
             <p>Village registration is open! If you're planning on camping with a group of people,
                 you can let us know about it by registering your village.
                 This will help us try to make sure you have the space and facilities you need.
                 <a href="{{url_for('base.page', page_name='villages')}}">Learn more about villages</a>.
             </p>
-            <div class="btn-group">
-                <a class="btn btn-primary" href="{{ url_for('villages.register') }}">Register a village</a>
-                <a class="btn btn-default" href="{{ url_for('villages.main', year=event_year) }}">View villages</a>
-            </div>
-            {% endif %}
         </div>
+        <div class="panel-footer">
+            <a href="{{ url_for('villages.register') }}">Register a village</a>
+            <a href="{{ url_for('villages.main', year=event_year) }}">View villages</a>
+        </div>
+        {% endif %}
     </div>
 
     {% if feature_enabled('CFP') and not feature_enabled('CFP_CLOSED') %}
@@ -46,7 +49,9 @@
             <p>Our Call for Participation is open!<br>
                 We're looking for talks, workshops, or performances at EMF {{event_year}}.
             </p>
-            <a class="btn btn-primary" href="{{ url_for('cfp.main') }}">Submit a proposal</a>
+        </div>
+        <div class="panel-footer">
+            <a href="{{ url_for('cfp.main') }}">Submit a proposal</a>
         </div>
     </div>
     {% endif %}
@@ -64,7 +69,9 @@
                 If you're part of a village you'll be able to schedule content occurring there,
                 and anyone can arrange gatherings in the main bar or lounge.
             </p>
-            <a class="btn btn-primary" href="{{ url_for('schedule.attendee_content') }}">Manage your content</a>
+        </div>
+        <div class="panel-footer">
+            <a href="{{ url_for('schedule.attendee_content') }}">Manage your content</a>
         </div>
     </div>
     {% endif %}
@@ -79,7 +86,9 @@
                 You have more than one ticket assigned to you. We recommend you transfer tickets to
                 whoever will be using them, so they can receive updates from us and sign up for workshops.
             </p>
-            <a class="btn btn-primary" href="{{ url_for('.purchases') }}">Transfer tickets</a>
+        </div>
+        <div class="panel-footer">
+            <a href="{{ url_for('.purchases') }}">Transfer tickets</a>
         </div>
     </div>
     {% endif %}
@@ -91,7 +100,9 @@
         <div class="panel-body">
             <p>Ask us questions and get in touch with other EMF attendees in our Matrix chat channels.
             </p>
-            <a class="btn btn-primary" href="https://matrix.to/#/#emf:emfcamp.org" target="_blank">EMF Matrix Space</a>
+        </div>
+        <div class="panel-footer">
+            <a href="https://matrix.to/#/#emf:emfcamp.org" target="_blank">EMF Matrix Space</a>
         </div>
     </div>
 
@@ -104,10 +115,10 @@
         <div class="panel-body">
             <p>We still have a limited number of EMF 2024 T-shirts and Tildagon electronic badges available
                 for sale &mdash; order now and collect them at the event.</p>
-            <div class="btn-group">
-                <a class="btn btn-primary" href="{{ url_for('tickets.main', flow='tees') }}">Buy t-shirts</a>
-                <a class="btn btn-primary" href="{{ url_for('tickets.main', flow='badge') }}">Buy badges</a>
-            </div>
+        </div>
+        <div class="panel-footer">
+            <a href="{{ url_for('tickets.main', flow='tees') }}">Buy t-shirts</a>
+            <a href="{{ url_for('tickets.main', flow='badge') }}">Buy badges</a>
         </div>
     </div>
     {% endif %}


### PR DESCRIPTION
Apply the styling built for the [supprting EMF](https://emfcamp.org/supporting-emf) page to the main account page:

- Panels in the grid are the same height for each panel in the
  same row.
- Actions exist in a panel footer, which makes panels with
  significantly differing heights look a bit more balanced.
- Replace action buttons with links.

I've not touched the wider page layout as that's being worked on in #1963 

<img width="899" height="902" alt="Screenshot 2026-04-12 at 14 44 07" src="https://github.com/user-attachments/assets/4c0e7bc7-95b6-47bf-b0c7-3bf436ac48b6" />