### PR TITLE
Improve shift schedule date selection

### DIFF
--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
+from datetime import datetime, timedelta
 
-import pendulum
 from flask import (
     Response,
     abort,
@@ -63,13 +63,22 @@ def redirect_next_or_schedule(message: str | None = None) -> ResponseReturnValue
 @feature_flag("VOLUNTEERS_SCHEDULE")
 @v_user_required
 def schedule():
-    if naive_utcnow() < config.event_start:
-        default_day = "wed"
-    elif naive_utcnow() > config.event_end:
-        default_day = "mon"
+    current_volunteer = Volunteer.get_for_user(current_user)
+    earliest, latest = Shift.earliest_and_latest_in_range(*current_volunteer.permitted_shift_times)
+    dates = [earliest.date() + timedelta(days=i) for i in range((latest.date() - earliest.date()).days + 1)]
+
+    if naive_utcnow().date() < dates[0]:
+        default_day = dates[0]
+    elif naive_utcnow().date() > dates[1]:
+        default_day = dates[1]
     else:
-        default_day = pendulum.now().strftime("%a").lower()
-    active_day = request.args.get("day", default=default_day)
+        default_day = datetime.now().date()
+
+    requested_date = request.args.get("day", default=None)
+    if requested_date:
+        active_day = datetime.fromisoformat(requested_date).date()
+    else:
+        active_day = default_day
 
     shifts = Shift.get_all_for_day(active_day)
 
@@ -97,8 +106,10 @@ def schedule():
         roles=roles,
         venues=venues,
         all_shifts=by_time,
+        dates=dates,
         active_day=active_day,
         untrained_roles=untrained_roles,
+        buildup_volunteer=current_volunteer.registered_for_buildup,
         token=token,
     )
 

--- a/models/volunteer/buildup.py
+++ b/models/volunteer/buildup.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, time, timedelta
+from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import ForeignKey, select
@@ -59,16 +59,20 @@ def buildup_start() -> datetime:
     return datetime.combine(config.event_start.date() - timedelta(days=8), time(hour=0))
 
 
-def buildup_end() -> date:
+def buildup_end() -> datetime:
     # End of day 0
     return datetime.combine(config.event_start.date() - timedelta(days=1), time(hour=22))
 
 
-def teardown_start() -> date:
+def teardown_start() -> datetime:
     # We start considering teardown from "midday" on day 5
     return datetime.combine(config.event_end.date() + timedelta(days=1), time(hour=12))
 
 
-def teardown_end() -> date:
+def teardown_end() -> datetime:
     # After PM on day 8
     return datetime.combine(config.event_end.date() + timedelta(days=4), time(hour=22))
+
+
+def date_requires_registration(date: datetime) -> bool:
+    return date <= buildup_end() or date >= teardown_start()

--- a/models/volunteer/shift.py
+++ b/models/volunteer/shift.py
@@ -1,11 +1,11 @@
 import enum
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Self
 
 import pytz
 from pendulum import interval
-from sqlalchemy import ForeignKey, func, select, text
+from sqlalchemy import ForeignKey, desc, func, select, text
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 
@@ -205,17 +205,29 @@ class Shift(BaseModel):
         return cls.query.order_by(Shift.start, Shift.venue_id).all()
 
     @classmethod
-    def get_all_for_day(cls, day: str) -> Sequence[Self]:
+    def get_all_for_day(cls, day: date) -> Sequence[Self]:
         """Return all shifts for the requested day."""
         return (
             db.session.execute(
                 select(cls)
-                .where(text("lower(to_char(start, 'Dy'))=:day").bindparams(day=day.lower()))
+                .where(text("to_char(start, 'YYYY-MM-DD')=:day").bindparams(day=day.strftime("%Y-%m-%d")))
                 .order_by(Shift.start, Shift.venue_id)
             )
             .scalars()
             .all()
         )
+
+    @classmethod
+    def earliest_and_latest_in_range(
+        cls, start: datetime, end: datetime
+    ) -> tuple[datetime | None, datetime | None]:
+        """Return the earliest and latest shift available to a volunteer."""
+
+        query = select(cls.start).where((cls.start >= start) & (cls.end <= end))
+        first = db.session.execute(query.order_by(cls.start)).scalar()
+        last = db.session.execute(query.order_by(desc(cls.end))).scalar()
+
+        return (first, last)
 
     @classmethod
     def generate_for(

--- a/models/volunteer/volunteer.py
+++ b/models/volunteer/volunteer.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from flask_login import UserMixin
@@ -6,7 +7,10 @@ from sqlalchemy import ARRAY, Column, ForeignKey, Integer, String, Table, select
 from sqlalchemy.ext.mutable import Mutable, MutableSet
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from apps.config import config
 from main import db
+from models.volunteer import buildup
+from models.volunteer.buildup import BuildupVolunteer
 
 from .. import BaseModel
 from .shift import ShiftEntry, ShiftEntryState
@@ -158,6 +162,18 @@ class Volunteer(BaseModel, UserMixin):
     @property
     def is_volunteer_admin(self) -> bool:
         return bool(self.volunteer_admin_roles or self.administered_teams)
+
+    @property
+    def registered_for_buildup(self) -> bool:
+        return BuildupVolunteer.get_for_user(self.user) is not None
+
+    @property
+    def permitted_shift_times(self) -> tuple[datetime, datetime]:
+        """Returns the earliest and latest time at which this volunteer can take a shift."""
+        if self.registered_for_buildup:
+            return (buildup.buildup_start(), buildup.teardown_end())
+
+        return (config.event_start, config.event_end)
 
 
 """

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -6,6 +6,11 @@
         <a href="{{ url_for('.schedule', day=day) }}" aria-controls="{{ day }}" role="tab">{{ full_day }}</a>
     </li>
 {% endmacro %}
+{% if buildup_volunteer %}
+    {% set date_format = "%a %d" %}
+{% else %}
+    {% set date_format = "%A" %}
+{% endif %}
 
 {% block title %}
     Volunteer Schedule
@@ -23,14 +28,6 @@
 
     <p>You can get a list of all your shifts as an <a href="{{ url_for('.schedule_ical', token=token) }}">iCal feed</a>.</p>
 
-    {% if active_day == "wed" %}
-        <div class="alert alert-warning">
-            <h3>The EMF site is not open for all ticketholders on Wednesday!</h3>
-            <p>Please do not sign up for Wednesday shifts unless you have already agreed to be on site, either to help with build up, or as part of a village.</p>
-            <p>If you are willing to volunteer <strong>all day</strong> please contact <a href="mailto:volunteer@emfcamp.org">volunteer@emfcamp.org</a> to confirm this before taking shifts.</p>
-        </div>
-    {% endif %}
-
     {% if untrained_roles %}
         <div class="alert alert-danger">
             <h3>You still need training before starting a shift for the following roles:</h3>
@@ -45,22 +42,16 @@
     {% include "volunteer/_schedule_filters.html" %}
 
     <ul class="nav nav-tabs has-nav-select" role="tablist">
-        {{ tabnav('wed', 'Wednesday', active_day) }}
-        {{ tabnav('thu', 'Thursday', active_day) }}
-        {{ tabnav('fri', 'Friday', active_day) }}
-        {{ tabnav('sat', 'Saturday', active_day) }}
-        {{ tabnav('sun', 'Sunday', active_day) }}
-        {{ tabnav('mon', 'Monday', active_day) }}
+        {% for day in dates %}
+          {{ tabnav(day, day.strftime(date_format), active_day) }}
+        {% endfor %}
     </ul>
     <div class="nav-select form-group form-inline">
         <label for="select-day">Day:</label>
         <select id="select-day">
-            <option value="{{ url_for('.schedule', day='wed') }}" {% if active_day == "wed" %}selected{% endif %}>Wednesday</option>
-            <option value="{{ url_for('.schedule', day='thu') }}" {% if active_day == "thu" %}selected{% endif %}>Thursday</option>
-            <option value="{{ url_for('.schedule', day='fri') }}" {% if active_day == "fri" %}selected{% endif %}>Friday</option>
-            <option value="{{ url_for('.schedule', day='sat') }}" {% if active_day == "sat" %}selected{% endif %}>Saturday</option>
-            <option value="{{ url_for('.schedule', day='sun') }}" {% if active_day == "sun" %}selected{% endif %}>Sunday</option>
-            <option value="{{ url_for('.schedule', day='mon') }}" {% if active_day == "mon" %}selected{% endif %}>Monday</option>
+            {% for day in dates %}
+                <option value="{{ url_for('.schedule', day=day) }}" {% if active_day == day %}selected{% endif %}>{{ day.strftime(date_format) }}</option>
+            {% endfor %}
         </select>
     </div>
     <div class="tab-content table-responsive">


### PR DESCRIPTION
This is supported by the fact build/teardown volunteers now need to be registered, which means that we know whether or not they're able to take a shift that occurs before the site is open to the public, rather than having to show a speculative "please don't take these shifts" message. It also opens the door for using shifts throughout build/teardown if needed.

A pleasant side effect of this is that we no longer have a hard coded list of days on which shifts occur and instead dynamically build the list of available days based on when shifts are available.

- Only volunteers registered for buildup will see shifts that occur outside of main event days.
- The range of days displayed is governed by the earliest and latest date on which there is a shift the current volunteer is permitted to take.
- Build volunteers see "Wed 15" rather than "Wednesday" in tabs, as their shifts may span multiple weeks.