### PR TITLE
Show links to more ticket types

### DIFF
--- a/apps/tickets/choose.py
+++ b/apps/tickets/choose.py
@@ -44,6 +44,8 @@ def main(flow="main"):
     allowing us to have different categories of items on sale, for example tickets
     on one page, and t-shirts on a separate page.
     """
+    # NB. Some of this logic appears in templates which link to this view for certain flows.
+
     # Fetch the ProductView and determine if this user is allowed to view it.
     view = get_product_view(flow)
 

--- a/templates/account/purchases.html
+++ b/templates/account/purchases.html
@@ -55,9 +55,24 @@
   Entrance to the festival is subject to our <a href="{{url_for('payments.terms')}}">Terms
   and Conditions</a> and the <a href="{{url_for('base.code_of_conduct')}}">Code of Conduct</a>.
 </p>
+{% if SALES_STATE != 'sales-ended' or SITE_STATE == 'event' %}
+{#
+We can sell main tickets in site_state available (and sometimes unavailable (e.g. vouchers or reservations)) (i.e. not sold-out and not sales-ended)
+parking tickets until sales end (even if we've sold out of main tickets)
+but badges even after sales end as long as the event is still on
+#}
 <div class="pull-right ticket-actions">
+    {% if SALES_STATE != 'sales-ended' and SALES_STATE != 'sold-out' %}
     <a href="{{ url_for('tickets.main') }}" class="btn btn-primary">Buy another ticket</a>
+    {% endif %}
+
+    {% if SALES_STATE != 'sales-ended' %}
+    <a href="{{ url_for('tickets.main', flow='other') }}" class="btn btn-default">Buy a parking ticket</a>
+    {% endif %}
+
+    <a href="{{ url_for('tickets.main', flow='badge') }}" class="btn btn-default">Buy a badge</a>
 </div>
+{% endif %}
 <div class="clearfix"></div>
 <p>If you have any problems with your tickets, please contact us at <a href="mailto:{{config['TICKETS_EMAIL'][1]}}">{{config['TICKETS_EMAIL'][1]}}</a>.</p>
 {% endblock %}

--- a/templates/tickets/cutoff.html
+++ b/templates/tickets/cutoff.html
@@ -4,7 +4,7 @@
     <div class="well">
         {% if SALES_STATE == 'sales-ended' %}
             <p class="emphasis">We're sorry, ticket sales for Electromagnetic Field {{ event_year }} have now ended.</p>
-            <p>There are no tickets for sale on at the gate, so please do not travel to EMF
+            <p>There are no tickets for sale at the gate, so please do not travel to EMF
             if you haven't got a ticket.</p>
             <p>For updates on future EMF events, please follow us on
                 <a href="https://social.emfcamp.org/@emf">the Fediverse</a> or
@@ -16,9 +16,17 @@
         <p>There may be a small number of returned tickets available before the event. For updates on these,
             please follow us on <a href="https://social.emfcamp.org/@emf">the Fediverse</a>.</p>
         {% endif %}
-        {% if SALES_STATE != 'sales-ended' %}
-        <p>If you have a ticket to EMF you can still 
-            <a href="{{ url_for('tickets.main', flow='other') }}">order parking tickets</a>.</p>
+        {% if SALES_STATE != 'sales-ended' or SITE_STATE == 'event' %}
+        {#
+        We can sell parking tickets until sales end
+        but badges even after sales end as long as the event is still on
+        #}
+        <p>If you have a ticket to EMF you can still
+            {% if SALES_STATE != 'sales-ended' %}
+            <a href="{{ url_for('tickets.main', flow='other') }}">order parking tickets</a> or
+            {% endif %}
+            <a href="{{ url_for('tickets.main', flow='badge') }}">order a badge</a>.
+        </p>
         {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Show links to parking and badge tickets from the "Your Tickets" page and a link to badge from the cutoff (i.e. sold-out) page for the main tickets.

This doesn't consider if the other or badge ProductView actually exists but I believe they will do now until after this event?

(NB. I tidied the grammar on the badge link after taking the screenshot)

<img width="1298" height="444" alt="Screenshot_20260529_223802" src="https://github.com/user-attachments/assets/3b2bf120-0f02-43c0-8787-74107165670e" />
<img width="1298" height="444" alt="Screenshot_20260529_223721" src="https://github.com/user-attachments/assets/be3cb749-2219-4119-a5ac-b118736e64fd" />
<img width="1298" height="586" alt="Screenshot_20260529_223852" src="https://github.com/user-attachments/assets/73958d84-1379-4e4f-b53b-a113b03962d2" />
<img width="1298" height="429" alt="Screenshot_20260529_223927" src="https://github.com/user-attachments/assets/c73d67ca-48a5-42e6-95e7-242d8b7451c1" />
