### PR TITLE
Inline edit for village long_description

### DIFF
--- a/apps/villages/forms.py
+++ b/apps/villages/forms.py
@@ -75,6 +75,14 @@ class VillageForm(Form):
         field.data = (field.data or "").strip()
 
 
+class VillageDescriptionForm(Form):
+    long_description = TextAreaField("Long Description", [Optional()])
+    submit = SubmitField("Submit")
+
+    def populate(self, village: Village) -> None:
+        self.long_description.data = village.long_description
+
+
 class DeleteVillageForm(Form):
     submit = SubmitField("Delete")
 

--- a/apps/villages/views.py
+++ b/apps/villages/views.py
@@ -20,6 +20,7 @@ from .forms import (
     JoinVillageForm,
     LeaveVillageForm,
     PromoteVillageMemberForm,
+    VillageDescriptionForm,
     VillageForm,
 )
 
@@ -89,24 +90,31 @@ def main(year: int) -> ResponseReturnValue:
 @villages.route("/<int:year>/<int:village_id>")
 def view(year: int, village_id: int) -> ResponseReturnValue:
     village = load_village(year, village_id)
+
+    return view_or_editdesc(village)
+
+
+def view_or_editdesc(
+    village: Village, edit_desc_form: VillageDescriptionForm | None = None
+) -> ResponseReturnValue:
     user_is_village_admin = (
         current_user.is_authenticated
         and current_user.village is not None
-        and current_user.village.id == village_id
+        and current_user.village.id == village.id
         and current_user.village_membership.admin
     )
 
     user_is_village_member = (
         current_user.is_authenticated
         and current_user.village is not None
-        and current_user.village.id == village_id
+        and current_user.village.id == village.id
         and not current_user.village_membership.admin
     )
 
     user_has_requested_join_village = (
         current_user.is_authenticated
         and current_user.village_join_request is not None
-        and current_user.village_join_request.village.id == village_id
+        and current_user.village_join_request.village.id == village.id
     )
 
     user_can_join_village = (
@@ -126,6 +134,7 @@ def view(year: int, village_id: int) -> ResponseReturnValue:
         village_long_description_html=(
             render_markdown(village.long_description) if village.long_description else None
         ),
+        edit_desc_form=edit_desc_form,
     )
 
 
@@ -175,6 +184,26 @@ def edit(year: int, village_id: int) -> ResponseReturnValue:
             return redirect(url_for(".view", year=year, village_id=village_id))
 
     return render_template("villages/edit.html", form=form, village=village)
+
+
+# An extra edit page which makes inline editing of the long_description look better
+@villages.route("/<int:year>/<int:village_id>/editdesc", methods=["GET", "POST"])
+@login_required
+def editdesc(year: int, village_id: int) -> ResponseReturnValue:
+    village = load_village(year, village_id, require_admin=True)
+
+    form = VillageDescriptionForm()
+    if request.method == "GET":
+        form.populate(village)
+
+    if form.validate_on_submit():
+        # Just update the long_description
+        village.long_description = form.long_description.data
+        db.session.commit()
+        flash("Your village's long description has been updated.")
+        return redirect(url_for(".view", year=year, village_id=village_id))
+
+    return view_or_editdesc(village, form)
 
 
 # View (and manage) village members.

--- a/templates/villages/view.html
+++ b/templates/villages/view.html
@@ -1,3 +1,4 @@
+{% from "_formhelpers.html" import render_field %}
 {% extends "base.html" %}
 {% block title %}Village: {{village.name}}{% endblock %}
 {% block body %}
@@ -23,11 +24,33 @@
 <p>{{village.description}}</p>
 {% endif %}
 
-{% if village_long_description_html %}
-{# This is render-blocking, but we want the listener ready for the iframe.
-   Better to delay first render than to have a two-way handshake that flashes. #}
-<script src="{{static_url_for('static', filename="js/sandboxed-iframe-parent.js")}}"></script>
-<p>{{village_long_description_html}}</p>
+{% if edit_desc_form %}
+<div class="well">
+  <form method="post" class="form-horizontal village-form" role="form">
+    {{ edit_desc_form.hidden_tag() }}
+    <fieldset>
+      {% call render_field(edit_desc_form.long_description,
+            placeholder="A longer description of your village using Markdown. Project details etc.") %}
+        <a href="https://www.markdown-cheatsheet.com">Standard Markdown</a> supported <em>apart from</em> images.
+      {% endcall %}
+    </fieldset>
+    <fieldset>
+      <div class="form-actions">
+        <button type="submit" name="Update" class="btn btn-primary btn-lg pull-right debounce">Update</button>
+        <a class="btn btn-default btn-lg pull-right" href="{{ url_for('.view', village_id=village.id, year=year) }}">Back</a>
+      </div>
+    </fieldset>
+  </form>
+</div>
+{% elif village_long_description_html %}
+  {% if user_is_village_admin %}
+  <a class="pull-right" href="{{ url_for('.editdesc', village_id=village.id, year=year) }}">Edit</a>
+  {% endif %}
+
+  {# This is render-blocking, but we want the listener ready for the iframe.
+    Better to delay first render than to have a two-way handshake that flashes. #}
+  <script src="{{static_url_for('static', filename="js/sandboxed-iframe-parent.js")}}"></script>
+  <p>{{village_long_description_html}}</p>
 {% endif %}
 
 <div>


### PR DESCRIPTION
This isn't so different to a normal edit but is neater UI and prevents accidentally changing something you didn't intend to.

Admin editting:
<img width="1298" height="519" alt="Screenshot_20260531_090847" src="https://github.com/user-attachments/assets/b8cbc1c1-ec66-408e-827b-93525ba9a3bd" />
<img width="1298" height="719" alt="Screenshot_20260531_090929" src="https://github.com/user-attachments/assets/0a92b576-775e-4b74-b1e9-0a45c41b151d" />
Non-admin doesn't see edit link:
<img width="1298" height="478" alt="Screenshot_20260531_091004" src="https://github.com/user-attachments/assets/d6becd9b-921b-47ab-a551-5f48213c7efe" />
