### PR TITLE
Hire stuff has type "rental"

### DIFF
--- a/apps/admin/hire.py
+++ b/apps/admin/hire.py
@@ -10,7 +10,7 @@ from . import admin
 
 def get_hires():
     purchases = (
-        ProductGroup.query.filter_by(type="hire")
+        ProductGroup.query.filter_by(type="rental")
         .join(Product)
         .join(Purchase)
         .join(Purchase.owner)

--- a/apps/common/receipt.py
+++ b/apps/common/receipt.py
@@ -14,7 +14,7 @@ from models.purchase import Purchase, PurchaseTransfer
 
 from ..config import config
 
-RECEIPT_TYPES = ["admissions", "parking", "campervan", "merchandise", "hire"]
+RECEIPT_TYPES = ["admissions", "parking", "campervan", "merchandise", "rental"]
 
 
 def render_receipt(user, png=False, pdf=False):
@@ -33,7 +33,7 @@ def render_receipt(user, png=False, pdf=False):
     campervan_tickets = purchases.filter(ProductGroup.type == "campervan").all()
 
     merch = purchases.filter(ProductGroup.type == "merchandise").all()
-    hires = purchases.filter(ProductGroup.type == "hire").all()
+    hires = purchases.filter(ProductGroup.type == "rental").all()
 
     transferred_tickets = (
         user.transfers_from.join(Purchase)


### PR DESCRIPTION
I think these are the places where we care about `ProductGroup.type` which doesn't have a hire _type_ (the `type` is rental, the name is `hire` though...)