### PR TITLE
Use 'hire' rather than 'rental'

### DIFF
--- a/models/product.py
+++ b/models/product.py
@@ -99,7 +99,7 @@ PRODUCT_GROUP_TYPES = [
     ProductGroupType("campervan", "Campervan Ticket", Ticket),
     ProductGroupType("parking", "Parking", Ticket),
     ProductGroupType("merchandise", "Merchandise", Purchase),
-    ProductGroupType("rental", "Rental", Purchase),
+    ProductGroupType("hire", "Hire", Purchase),
     ProductGroupType("sponsorship", "Sponsorship", Purchase),
 ]
 PRODUCT_GROUP_TYPES_DICT = {t.slug: t for t in PRODUCT_GROUP_TYPES}


### PR DESCRIPTION
This is the only place I can see that we use 'rental' (and I assume this dict ultimately drives the choices in the productGroup type dropdown)