### PR TITLE
Don't tell people their shift conflicts with their shift

### DIFF
--- a/js/volunteer_schedule.js
+++ b/js/volunteer_schedule.js
@@ -243,8 +243,7 @@ function init_volunteer_schedule() {
   function showConflictModal(details) {
     const time = (iso) =>
       new Date(iso).toLocaleTimeString([], {
-        hour: "2-digit",
-        minute: "2-digit",
+        timeStyle: "short",
       });
     const msgEl = document.getElementById("conflict-modal-message");
     msgEl.innerHTML = "";
@@ -259,13 +258,22 @@ function init_volunteer_schedule() {
 
   document.querySelectorAll("td.conflicts").forEach((cell) => {
     const row = cell.closest("tr");
-    if (!row.getAttribute("data-conflicts-with")) return;
+    if (
+      !row.getAttribute("data-conflicts-with") ||
+      row.getAttribute("data-signed-up") == "True"
+    )
+      return;
+
     cell.style.cursor = "pointer";
+
     cell.addEventListener("click", () => {
       const details = JSON.parse(
         row.getAttribute("data-conflicts-detail") || "[]",
       );
-      showConflictModal(details);
+
+      if (row.getAttribute("data-signed-up") != "True") {
+        showConflictModal(details);
+      }
     });
   });
 }

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -90,7 +90,7 @@
                                         {{ hour }}{% if shift.end %} to {{ shift.end_time }}{% endif %}
                                     {% endif %}
                                 </td>
-                                <td class="conflicts"></td>
+                                <td class="conflicts" {% if shift.is_user_shift %}title="You're signed up for this shift"{% endif %}></td>
                                 <td class="venue"><a href="{{ shift.venue.mapref }}">{{ shift.venue.name }}</a></td>
                                 <td class="role">{{ shift.role.name }}</td>
                                 <td class="staffing">


### PR DESCRIPTION
Previously we were popping up a conflict modal saying that a shift conflicted with itself when you clicked the indicator for a signed up shift. We now don't do that.

Also switched to just using whatever time format the user has set in their locale on those modals rather than trying to force one.