### PR TITLE
Volunteer self checkin

### DIFF
--- a/apps/volunteer/role_admin.py
+++ b/apps/volunteer/role_admin.py
@@ -36,7 +36,7 @@ from models.volunteer.shift import (
 class RoleForm(Form):
     name = StringField("Role Name", [InputRequired()])
     full_description_md = StringField(
-        "Description (supprts markdownn)",
+        "Description (supports markdown)",
         [InputRequired()],
         widget=TextArea(),
         description="Displayed in the main role list when signing up.",

--- a/apps/volunteer/role_admin.py
+++ b/apps/volunteer/role_admin.py
@@ -16,7 +16,11 @@ from flask import (
 from flask.typing import ResponseReturnValue
 from flask_login import current_user
 from sqlalchemy import select
+from wtforms import StringField, SubmitField
+from wtforms.validators import URL, InputRequired, Optional
+from wtforms.widgets import TextArea
 
+from apps.common.forms import Form
 from apps.volunteer import v_user_required, volunteer
 from main import db, get_or_404
 from models.user import User
@@ -27,6 +31,28 @@ from models.volunteer.shift import (
     ShiftEntryState,
     ShiftEntryStateException,
 )
+
+
+class RoleForm(Form):
+    name = StringField("Role Name", [InputRequired()])
+    full_description_md = StringField(
+        "Description (supprts markdownn)",
+        [InputRequired()],
+        widget=TextArea(),
+        description="Displayed in the main role list when signing up.",
+    )
+    role_notes = StringField(
+        "Role notes (supports markdown)",
+        [Optional(), InputRequired()],
+        widget=TextArea(),
+        description="Displayed to volunteers when they check in for a shift.",
+    )
+    instructions_url = StringField(
+        "Instructions URL",
+        [Optional(), URL()],
+        description="A link to external instructions. Won't be displayed if role_notes are provided.",
+    )
+    save = SubmitField("Update")
 
 
 @volunteer.route("/role-admin", methods=["GET"])
@@ -116,6 +142,23 @@ def role_admin(role_id):
         offset=offset,
         limit=limit,
     )
+
+
+@volunteer.route("role/<int:role_id>/edit", methods=["GET", "POST"])
+@role_admin_required
+def role_edit(role_id: int) -> ResponseReturnValue:
+    """Allows editing details of a role."""
+    role = get_or_404(db, Role, role_id)
+    form = RoleForm(request.form, obj=role)
+
+    if request.method == "POST" and form.validate():
+        form.populate_obj(role)
+        db.session.add(role)
+        db.session.commit()
+        flash("Role details have been updated.")
+        return redirect(url_for(".role_admin", role_id=role_id))
+
+    return render_template("volunteer/role_edit.html", role=role, form=form)
 
 
 @volunteer.route("role/<int:role_id>/set-state/<int:shift_id>/<int:user_id>", methods=["POST"])

--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -16,14 +16,15 @@ from flask import current_app as app
 from flask.typing import ResponseReturnValue
 from flask_login import current_user
 from icalendar import Calendar, Event
-from sqlalchemy.orm import joinedload
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload, with_parent
 
 from apps.users.calendar import CalendarDict, CalendarEntry, fetch_events
 from main import db, get_or_404
 from models import naive_utcnow
 from models.user import User, generate_api_token
 from models.volunteer.role import Role
-from models.volunteer.shift import Shift, ShiftEntry
+from models.volunteer.shift import Shift, ShiftEntry, ShiftEntryState
 from models.volunteer.venue import VolunteerVenue
 from models.volunteer.volunteer import Volunteer
 
@@ -241,6 +242,149 @@ def shift_cancel(shift_id):
         db.session.commit()
 
     return redirect_next_or_schedule(f"{shift.role.name} shift cancelled")
+
+
+def _get_shift_entry_for_user(shift_id: int, user: User) -> ShiftEntry:
+    """Gets a ShiftEntry and ensures it belongs to a specific user."""
+    shift_entry = db.session.execute(
+        select(ShiftEntry)
+        .where(ShiftEntry.user_id == user.id)
+        .where(ShiftEntry.shift_id == shift_id)
+        .join(ShiftEntry.shift)
+    ).scalar_one_or_none()
+    if shift_entry is None:
+        raise abort(404)
+
+    return shift_entry
+
+
+@volunteer.route("/set-time", methods=["GET"])
+@v_admin_required
+def set_time() -> ResponseReturnValue:
+    """Sets `now` in the session to the value of request.args["now"].
+
+    If the arg isn't set deletes the value from the session and reverts to using
+    realtime. Intended purely for testing purposes.
+    """
+    if not config.get("DEBUG"):
+        # We only allow mocking the time in debug mode because it could be used to
+        # bypass time checks on volunteer checkin.
+        abort(404)
+
+    provided_time = request.args.get("now", None)
+    if provided_time:
+        session["now"] = provided_time
+    else:
+        del session["now"]
+
+    return redirect_next_or_schedule(f"Time set to {provided_time}")
+
+
+def _now() -> datetime:
+    """Allow setting a time as 'now', falling back to datetime.now()."""
+    injected_time = session.get("now", None)
+    if not config.get("DEBUG") or not injected_time:
+        return datetime.now()
+
+    return datetime.strptime(injected_time, "%Y-%m-%dT%H:%M:%S")
+
+
+@volunteer.route("/self-checkin/venue/<venue_id>", methods=["GET"])
+@feature_flag("VOLUNTEERS_SCHEDULE")
+@v_user_required
+def self_checkin(venue_id: int) -> ResponseReturnValue:
+    """Allow a user to check themselves into a shift at a specific venue.
+
+    Intended to be accessed via QR codes in those venues. When loaded we'll check
+    whether the user has a scheduled shift in this venue either starting within
+    the next 15 minutes or currently in progress and if so allow them to mark
+    themselves as arrived.
+
+    If they're already marked as arrived then they'll be able to mark themselves
+    as either abandoning the shift, or if we're within 15 minutes or shift end
+    that they've completed the shift.
+    """
+
+    now = _now()
+    venue = get_or_404(db, VolunteerVenue, venue_id)
+    shift_entries = (
+        db.session.execute(
+            select(ShiftEntry)
+            .where(with_parent(current_user, User.shift_entries))
+            .join(ShiftEntry.shift)
+            .where(ShiftEntry.state.not_in([ShiftEntryState.COMPLETED, ShiftEntryState.ABANDONED]))
+            .where(Shift.venue == venue)
+            .where(Shift.end >= now - timedelta(hours=2))
+            .order_by(Shift.start)
+        )
+        .scalars()
+        .all()
+    )
+
+    # Segment into shifts that can be checked into and shifts that can't yet.
+    open_shift_entries: list[ShiftEntry] = []
+    upcoming_shift_entries: list[ShiftEntry] = []
+    for entry in shift_entries:
+        if entry.shift.start <= now + timedelta(minutes=15):
+            open_shift_entries.append(entry)
+        else:
+            upcoming_shift_entries.append(entry)
+
+    return render_template(
+        "volunteer/self_checkin.html",
+        venue=venue,
+        open_shift_entries=open_shift_entries,
+        upcoming_shift_entries=upcoming_shift_entries,
+        now=now,
+    )
+
+
+@volunteer.route("/self-checkin/arrived", methods=["POST"])
+@feature_flag("VOLUNTEERS_SCHEDULE")
+@v_user_required
+def self_checkin_arrived() -> ResponseReturnValue:
+    shift_entry_id = int(request.form["shift_id"])
+    shift_entry = _get_shift_entry_for_user(shift_entry_id, current_user)
+    if not shift_entry.eligible_for_checkin_at(_now()):
+        return redirect_next_or_schedule("Unexpected volunteer in bagging area.")
+
+    shift_entry.set_state(ShiftEntryState.ARRIVED)
+    db.session.add(shift_entry)
+    db.session.commit()
+
+    return redirect_next_or_schedule("You're checked in.")
+
+
+@volunteer.route("/self-checkin/complete", methods=["POST"])
+@feature_flag("VOLUNTEERS_SCHEDULE")
+@v_user_required
+def self_checkin_complete() -> ResponseReturnValue:
+    shift_entry_id = int(request.form["shift_id"])
+    shift_entry = _get_shift_entry_for_user(shift_entry_id, current_user)
+    if not shift_entry.eligible_for_completion_at(_now()):
+        return redirect_next_or_schedule("Unexpected volunteer in bagging area.")
+
+    shift_entry.set_state(ShiftEntryState.COMPLETED)
+    db.session.add(shift_entry)
+    db.session.commit()
+
+    return redirect_next_or_schedule("Thanks for volunteering!")
+
+
+@volunteer.route("/self-checkin/abandon", methods=["POST"])
+@feature_flag("VOLUNTEERS_SCHEDULE")
+@v_user_required
+def self_checkin_abandon() -> ResponseReturnValue:
+    shift_entry_id = int(request.form["shift_id"])
+    shift_entry = _get_shift_entry_for_user(shift_entry_id, current_user)
+    if not shift_entry.eligible_for_checkout_at(_now()):
+        return redirect_next_or_schedule("Unexpected volunteer in bagging area.")
+
+    shift_entry.set_state(ShiftEntryState.ABANDONED)
+    db.session.add(shift_entry)
+    db.session.commit()
+
+    return redirect_next_or_schedule("You've checked out.")
 
 
 @volunteer.route("/shift/<shift_id>/contact", methods=["GET"])

--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -324,7 +324,12 @@ def self_checkin(venue_id: int) -> ResponseReturnValue:
     # Segment into shifts that can be checked into and shifts that can't yet.
     open_shift_entries: list[ShiftEntry] = []
     upcoming_shift_entries: list[ShiftEntry] = []
+    checked_in_shift_entries: list[ShiftEntry] = []
+
     for entry in shift_entries:
+        if entry.state == ShiftEntryState.ARRIVED:
+            checked_in_shift_entries.append(entry)
+
         if entry.shift.start <= now + timedelta(minutes=15):
             open_shift_entries.append(entry)
         else:
@@ -335,6 +340,7 @@ def self_checkin(venue_id: int) -> ResponseReturnValue:
         venue=venue,
         open_shift_entries=open_shift_entries,
         upcoming_shift_entries=upcoming_shift_entries,
+        checked_in_shift_entries=checked_in_shift_entries,
         now=now,
     )
 

--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -301,7 +301,7 @@ def self_checkin(venue_id: int) -> ResponseReturnValue:
     themselves as arrived.
 
     If they're already marked as arrived then they'll be able to mark themselves
-    as either abandoning the shift, or if we're within 15 minutes or shift end
+    as either abandoning the shift, or if we're within 15 minutes of shift end
     that they've completed the shift.
     """
 
@@ -355,7 +355,6 @@ def self_checkin_arrived() -> ResponseReturnValue:
         return redirect_next_or_schedule("Unexpected volunteer in bagging area.")
 
     shift_entry.set_state(ShiftEntryState.ARRIVED)
-    db.session.add(shift_entry)
     db.session.commit()
 
     return redirect_next_or_schedule("You're checked in.")
@@ -371,7 +370,6 @@ def self_checkin_complete() -> ResponseReturnValue:
         return redirect_next_or_schedule("Unexpected volunteer in bagging area.")
 
     shift_entry.set_state(ShiftEntryState.COMPLETED)
-    db.session.add(shift_entry)
     db.session.commit()
 
     return redirect_next_or_schedule("Thanks for volunteering!")
@@ -387,7 +385,6 @@ def self_checkin_abandon() -> ResponseReturnValue:
         return redirect_next_or_schedule("Unexpected volunteer in bagging area.")
 
     shift_entry.set_state(ShiftEntryState.ABANDONED)
-    db.session.add(shift_entry)
     db.session.commit()
 
     return redirect_next_or_schedule("You've checked out.")

--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -312,7 +312,6 @@ def self_checkin(venue_id: int) -> ResponseReturnValue:
             select(ShiftEntry)
             .where(with_parent(current_user, User.shift_entries))
             .join(ShiftEntry.shift)
-            .where(ShiftEntry.state.not_in([ShiftEntryState.COMPLETED, ShiftEntryState.ABANDONED]))
             .where(Shift.venue == venue)
             .where(Shift.end >= now - timedelta(hours=2))
             .order_by(Shift.start)
@@ -322,25 +321,34 @@ def self_checkin(venue_id: int) -> ResponseReturnValue:
     )
 
     # Segment into shifts that can be checked into and shifts that can't yet.
+    checked_in_roles_with_notes: list[Role] = []
     open_shift_entries: list[ShiftEntry] = []
     upcoming_shift_entries: list[ShiftEntry] = []
-    checked_in_shift_entries: list[ShiftEntry] = []
+    previous_shift_entries: list[ShiftEntry] = []
 
     for entry in shift_entries:
         if entry.state == ShiftEntryState.ARRIVED:
-            checked_in_shift_entries.append(entry)
-
-        if entry.shift.start <= now + timedelta(minutes=15):
             open_shift_entries.append(entry)
+            role = entry.shift.role
+            if role.role_notes or role.instructions_url:
+                checked_in_roles_with_notes.append(role)
+
+        elif entry.state == ShiftEntryState.SIGNED_UP:
+            if entry.shift.start <= now + timedelta(minutes=15):
+                open_shift_entries.append(entry)
+            else:
+                upcoming_shift_entries.append(entry)
+
         else:
-            upcoming_shift_entries.append(entry)
+            previous_shift_entries.append(entry)
 
     return render_template(
         "volunteer/self_checkin.html",
         venue=venue,
+        checked_in_roles_with_notes=checked_in_roles_with_notes,
         open_shift_entries=open_shift_entries,
         upcoming_shift_entries=upcoming_shift_entries,
-        checked_in_shift_entries=checked_in_shift_entries,
+        previous_shift_entries=previous_shift_entries,
         now=now,
     )
 

--- a/css/volunteer_schedule.scss
+++ b/css/volunteer_schedule.scss
@@ -315,6 +315,12 @@ ul.key {
         position: relative;
       }
     }
+
+    &.checkin {
+      td.start_time {
+        display: none !important;
+      }
+    }
   }
 
   .role-admin-shift {

--- a/models/volunteer/role.py
+++ b/models/volunteer/role.py
@@ -94,6 +94,12 @@ class Role(BaseModel):
             return Markup(markdown(content, extensions=["markdown.extensions.nl2br"]))
         return ""
 
+    @property
+    def formatted_role_notes(self) -> Markup | None:
+        if self.role_notes:
+            return Markup(markdown(self.role_notes, extensions=["markdown.extensions.nl2br"]))
+        return None
+
     @classmethod
     def get_by_name(cls, name):
         return cls.query.filter_by(name=name).one_or_none()

--- a/models/volunteer/shift.py
+++ b/models/volunteer/shift.py
@@ -1,6 +1,6 @@
 import enum
 from collections.abc import Sequence
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Self
 
 import pytz
@@ -91,6 +91,25 @@ class ShiftEntry(BaseModel):
 
     def valid_states(self) -> list[ShiftEntryState]:
         return SHIFT_ENTRY_STATES[self.state]
+
+    def eligible_for_checkin_at(self, now: datetime) -> bool:
+        """Checks if we can transition to ARRIVED and the shift starts in 15 minutes or less from now."""
+        return ShiftEntryState.ARRIVED in self.valid_states() and self.shift.start >= now - timedelta(
+            minutes=15
+        )
+
+    def eligible_for_checkout_at(self, now: datetime) -> bool:
+        """Checks if we can transition to a checked out state."""
+        return (
+            ShiftEntryState.ABANDONED in self.valid_states()
+            or ShiftEntryState.COMPLETED in self.valid_states()
+        )
+
+    def eligible_for_completion_at(self, now: datetime) -> bool:
+        """Checks if we can transition to COMPLETED and a sufficient portion of the shift has passed."""
+        return ShiftEntryState.COMPLETED in self.valid_states() and self.shift.end <= now + timedelta(
+            minutes=15
+        )
 
 
 class Shift(BaseModel):

--- a/templates/volunteer/role_admin.html
+++ b/templates/volunteer/role_admin.html
@@ -21,7 +21,9 @@
   {% include "volunteer/_nav.html" %}
   <h2>{{ role }} Admin</h2>
   <div>
-    <a href="{{ url_for('.role_volunteers', role_id=role.id) }}" class="btn btn-primary">All Volunteers</a> <a href="{{ url_for('.train_users', role_id=role.id) }}") }}" class="btn btn-primary">Training</a>
+    <a href="{{ url_for('.role_volunteers', role_id=role.id) }}" class="btn btn-primary">All Volunteers</a>
+    <a href="{{ url_for('.train_users', role_id=role.id) }}") }}" class="btn btn-primary">Training</a>
+    <a href="{{ url_for('.role_edit', role_id=role.id) }}") }}" class="btn btn-primary">Edit Role</a>
   </div>
   <h3>Volunteers on Shift</h3>
   <div class="role-admin-shift well content-well">

--- a/templates/volunteer/role_edit.html
+++ b/templates/volunteer/role_edit.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% from "_formhelpers.html" import render_field %}
+
+{% block title %}
+    Edit {{ role.name }}
+{% endblock %}
+
+{% block body %}
+{% include "volunteer/_nav.html" %}
+
+    <h2>{{ role.name }}</h2>
+    <div class="well">
+        <form class="form-horizontal" method="post">
+            <fieldset>
+                {{ form.hidden_tag() }}
+                {{ render_field(form.name, horizontal=9) }}
+                {{ render_field(form.full_description_md, horizontal=9) }}
+                {{ render_field(form.role_notes, horizontal=9) }}
+                {{ render_field(form.instructions_url, horizontal=9) }}
+                {{ form.save(class_="btn btn-primary debounce pull-right") }}
+            </fieldset>
+        </form>
+    </div>
+
+{% endblock body %}

--- a/templates/volunteer/self_checkin.html
+++ b/templates/volunteer/self_checkin.html
@@ -1,0 +1,101 @@
+{% extends 'base.html' %}
+{% block title %}
+    Volunteer Self Checkin
+{% endblock %}
+{% block body %}
+{% include "volunteer/_nav.html" %}
+
+<h2>Volunteer Check-in - {{ venue.name }}</h2>
+{% if not open_shift_entries and not upcoming_shift_entries %}
+    <div class="alert alert-danger">
+        <h3>No shifts</h3>
+        <p>You've got no shifts scheduled in this location. Are you in the right place?</p>
+        <p>You can check your <a href="{{ url_for('.schedule') }}">volunteer schedule</a> for more details.</p>
+    </div>
+{% endif %}
+
+{% for entry in checked_in_shift_entries %}
+    {% if entry.shift.role.role_notes %}
+        <div class="alert alert-success">
+            <h3>{{ entry.shift.role.name }} guidance</h3>
+            {{ entry.shift.role.formatted_role_notes }}
+        </div>
+    {% elif entry.shift.role.instructions_url %}
+        <h3>{{ entry.shift.role.name }} guidance</h3>
+        <p>Please see the <a href="{{ entry.shift.role.instructions_url }}">documentation here</a>.</p>
+    {% endif %}
+{% endfor %}
+
+{% if open_shift_entries %}
+    <h3>Open shifts</h3>
+    <p>Click the relevant button to check in or out of these active shifts.</p>
+    <table class="table table-bordered responsive-table shifts-table checkin">
+        <thead><tr>
+            <th>Starts</th>
+            <th>Ends</th>
+            <th>Role</th>
+            <th></th>
+        </tr></thead>
+        <tbody id="tbody-{{ active_day }}">
+            {% for shift_entry in open_shift_entries %}
+                {% set shift = shift_entry.shift %}
+                <tr id="shift-{{ shift_entry.id }}">
+                    <td class="start_time">{{ shift.start.strftime("%H:%M") }}</td>
+                    <td class="end_time">{{ shift.end.strftime("%H:%M") }}</td>
+                    <td class="time mobile-only">
+                        {{ shift.start.strftime("%H:%M") }}{% if shift.end %} to {{ shift.end.strftime("%H:%M") }}{% endif %}
+                    </td>
+                    <td class="role">{{ shift.role.name }}</td>
+                    <td class="button">
+                        {% if shift_entry.eligible_for_checkin_at(now) %}
+                            <form method="post" action="{{ url_for('.self_checkin_arrived', next=url_for('.self_checkin', venue_id=venue.id)) }}">
+                                <input type="hidden" name="shift_id" value="{{ shift.id }}">
+                                <button class="btn btn-block btn-success">Check in</button>
+                            </form>
+                        {% elif shift_entry.eligible_for_checkout_at(now) %}
+                            <form method="post" action="{{ url_for('.self_checkin_abandon', next=url_for('.self_checkin', venue_id=venue.id)) }}">
+                                <input type="hidden" name="shift_id" value="{{ shift.id }}">
+                                <button class="btn btn-block btn-danger">Mark Abandoned</button>
+                            </form>
+                            {% if shift_entry.eligible_for_completion_at(now) %}
+                                <form method="post" action="{{ url_for('.self_checkin_complete', next=url_for('.self_checkin', venue_id=venue.id)) }}">
+                                    <input type="hidden" name="shift_id" value="{{ shift.id }}">
+                                    <button class="btn btn-block btn-success">Mark Completed</button>
+                                </form>
+                            {% endif %}
+                        {% else %}
+                            {{ shift_entry.state }}
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if upcoming_shift_entries %}
+    <h3>Upcoming shifts</h3>
+    <p>You can't check in for these shifts yet, shifts are available for self check-in from 15 minutes before their start time.</p>
+    <table class="table table-bordered responsive-table shifts-table">
+        <thead><tr>
+            <th>Starts</th>
+            <th>Ends</th>
+            <th>Role</th>
+        </tr></thead>
+        <tbody id="tbody-{{ active_day }}">
+            {% for shift_entry in upcoming_shift_entries %}
+                {% set shift = shift_entry.shift %}
+                <tr id="shift-{{ shift_entry.id }}">
+                    <td class="start_time">{{ shift.start.strftime("%H:%M") }}</td>
+                    <td class="end_time">{{ shift.end.strftime("%H:%M") }}</td>
+                    <td class="time mobile-only">
+                        {{ shift.start.strftime("%H:%M") }}{% if shift.end %} to {{ shift.end.strftime("%H:%M") }}{% endif %}
+                    </td>
+                    <td class="role">{{ shift.role.name }}</td>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+{% endblock %}

--- a/templates/volunteer/self_checkin.html
+++ b/templates/volunteer/self_checkin.html
@@ -36,7 +36,7 @@
             <th>Role</th>
             <th></th>
         </tr></thead>
-        <tbody id="tbody-{{ active_day }}">
+        <tbody>
             {% for shift_entry in open_shift_entries %}
                 {% set shift = shift_entry.shift %}
                 <tr id="shift-{{ shift_entry.id }}">
@@ -92,7 +92,6 @@
                         {{ shift.start.strftime("%H:%M") }}{% if shift.end %} to {{ shift.end.strftime("%H:%M") }}{% endif %}
                     </td>
                     <td class="role">{{ shift.role.name }}</td>
-                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/templates/volunteer/self_checkin.html
+++ b/templates/volunteer/self_checkin.html
@@ -6,7 +6,7 @@
 {% include "volunteer/_nav.html" %}
 
 <h2>Volunteer Check-in - {{ venue.name }}</h2>
-{% if not open_shift_entries and not upcoming_shift_entries %}
+{% if not open_shift_entries and not upcoming_shift_entries and not previous_shift_entries %}
     <div class="alert alert-danger">
         <h3>No shifts</h3>
         <p>You've got no shifts scheduled in this location. Are you in the right place?</p>
@@ -14,16 +14,15 @@
     </div>
 {% endif %}
 
-{% for entry in checked_in_shift_entries %}
-    {% if entry.shift.role.role_notes %}
-        <div class="alert alert-success">
-            <h3>{{ entry.shift.role.name }} guidance</h3>
-            {{ entry.shift.role.formatted_role_notes }}
-        </div>
-    {% elif entry.shift.role.instructions_url %}
-        <h3>{{ entry.shift.role.name }} guidance</h3>
-        <p>Please see the <a href="{{ entry.shift.role.instructions_url }}">documentation here</a>.</p>
-    {% endif %}
+{% for role in checked_in_roles_with_notes %}
+    <div class="alert alert-success">
+        <h3>{{ role.name }}</h3>
+        {% if role.role_notes %}
+            {{ role.formatted_role_notes }}
+        {% elif role.instructions_url %}
+            <p>Please see the <a href="{{ role.instructions_url }}">documentation here</a>.</p>
+        {% endif %}
+    </div>
 {% endfor %}
 
 {% if open_shift_entries %}
@@ -92,6 +91,42 @@
                         {{ shift.start.strftime("%H:%M") }}{% if shift.end %} to {{ shift.end.strftime("%H:%M") }}{% endif %}
                     </td>
                     <td class="role">{{ shift.role.name }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}
+
+{% if previous_shift_entries %}
+    <h3>Previous shifts</h3>
+    <table class="table table-bordered responsive-table shifts-table">
+        <thead><tr>
+            <th>Starts</th>
+            <th>Ends</th>
+            <th>Role</th>
+            <th>State</th>
+        </tr></thead>
+        <tbody id="tbody-{{ active_day }}">
+            {% for shift_entry in previous_shift_entries %}
+                {% set shift = shift_entry.shift %}
+                <tr id="shift-{{ shift_entry.id }}">
+                    <td class="start_time">{{ shift.start.strftime("%H:%M") }}</td>
+                    <td class="end_time">{{ shift.end.strftime("%H:%M") }}</td>
+                    <td class="time mobile-only">
+                        {{ shift.start.strftime("%H:%M") }}{% if shift.end %} to {{ shift.end.strftime("%H:%M") }}{% endif %}
+                    </td>
+                    <td class="role">{{ shift.role.name }}</td>
+                    <td>
+                        {% if shift_entry.state != "no_show" %}
+                            <form method="post" action="{{ url_for('.self_checkin_arrived', next=url_for('.self_checkin', venue_id=venue.id)) }}">
+                                {{ shift_entry.state | replace('_', ' ') | capitalize }}
+                                <input type="hidden" name="shift_id" value="{{ shift.id }}">
+                                <button class="btn btn-link">Undo</button>
+                            </form>
+                        {% else %}
+                            No Show - Please contact your team lead or the volunteer desk to resolve this
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
UI to allow volunteers to check themselves in for a shift. Once checked in they'll be shown the role notes to provide some guidance on what it is they're meant to be doing.

Role admins now have the ability to edit those notes so they can be evolved during the event as new things are discovered.

Designed to only be accessible via QR codes posted in volunteer venues so it's not linked from anywhere.