### PR TITLE
Use .table class on wiki tables

### DIFF
--- a/apps/common/__init__.py
+++ b/apps/common/__init__.py
@@ -444,7 +444,7 @@ def render_untrusted_markdown(markdown_text: str) -> Markup:
         markdown(markdown_text, extensions=extensions),
         tags=(nh3.ALLOWED_TAGS - {"img"}),
         link_rel="noopener nofollow",
-    )
+    ).replace("<table>", '<table class="table">')
     inner_html = render_template("sandboxed-iframe.html", body=Markup(content_html))
     iframe_html = f'<iframe sandbox="allow-scripts allow-top-navigation-by-user-activation" class="embedded-content" srcdoc="{html.escape(inner_html, True)}"></iframe>'
     return Markup(iframe_html)


### PR DESCRIPTION
This PR makes tables on the wiki use the `table.table` class so they look a little less cramped.

<img width="684" height="337" alt="image" src="https://github.com/user-attachments/assets/18aed1a8-67eb-44d0-8de5-ae7cd294a591" />
<img width="990" height="417" alt="image" src="https://github.com/user-attachments/assets/ed9062c2-163d-4c7d-a791-c657d47bad32" />
