### PR TITLE
Make flask make_admin idempotent

### DIFF
--- a/apps/base/tasks_admin.py
+++ b/apps/base/tasks_admin.py
@@ -36,9 +36,11 @@ def periodic(force):
 def make_admin(user_id, email):
     """Make a user in the DB an admin"""
     if email:
-        user = User(email, "Initial Admin User")
-        db.session.add(user)
-        db.session.commit()
+        user = User.get_by_email(email)
+        if not user:
+            user = User(email, "Initial Admin User")
+            db.session.add(user)
+            db.session.commit()
     elif user_id:
         user = User.query.get(user_id)
     else:


### PR DESCRIPTION
I've got a small script which bootstraps my development environment including creating myself an admin account and `make_admin` blows up if that account already exists.