### PR TITLE
calendar subscription links

### DIFF
--- a/apps/common/__init__.py
+++ b/apps/common/__init__.py
@@ -32,7 +32,7 @@ from werkzeug.exceptions import HTTPException
 from werkzeug.wrappers import Response
 from yaml import safe_load as parse_yaml
 
-from main import db, external_url
+from main import db, external_url, webcal_url
 from models import Currency, User, naive_utcnow
 from models.basket import Basket
 from models.capacity import UnlimitedType
@@ -126,6 +126,7 @@ def load_utility_functions(app_obj):
             REFUND_STATE=REFUND_STATE,
             CURRENCY_SYMBOLS=CURRENCY_SYMBOLS,
             external_url=external_url,
+            webcal_url=webcal_url,
             feature_enabled=feature_enabled,
             get_user_currency=get_user_currency,
             year=naive_utcnow().year,

--- a/main.py
+++ b/main.py
@@ -419,3 +419,11 @@ def external_url(endpoint: str, **values: Any) -> str:
     you're probably doing something wrong.
     """
     return url_for(endpoint, _external=True, **values)
+
+
+def webcal_url(endpoint: str, **values: Any) -> str:
+    """Generate an absolute URL with the webcal:// scheme, so calendar
+    clients subscribe to the feed rather than downloading it once.
+    """
+    _, _, rest = external_url(endpoint, **values).partition("://")
+    return f"webcal://{rest}"

--- a/templates/schedule/favourites.html
+++ b/templates/schedule/favourites.html
@@ -5,7 +5,7 @@
 <h2>Favourites</h2>
 
 <p>You can <a href="{{ webcal_url('.favourites_ical', token=token) }}">subscribe to this list in your calendar</a>
-   so it stays up to date, download it as an <a href="{{ url_for('.favourites_ical') }}?token={{ token }}">iCal feed</a>,
+   so it stays up to date, download it as an <a href="{{ url_for('.favourites_ical') }}?token={{ token }}">iCal file</a>,
    or get a <a href="{{ url_for('.favourites_json') }}?token={{ token }}">json feed</a> for your giant robot.
 </p>
 {% if not feature_enabled('SCHEDULE') %}

--- a/templates/schedule/favourites.html
+++ b/templates/schedule/favourites.html
@@ -4,8 +4,9 @@
 {% block body %}
 <h2>Favourites</h2>
 
-<p>You can also get this list as an <a href="{{ url_for('.favourites_ical') }}?token={{ token }}">iCal feed</a>
-   for your calendar, and a <a href="{{ url_for('.favourites_json') }}?token={{ token }}">json feed</a> for your giant robot.
+<p>You can <a href="{{ webcal_url('.favourites_ical', token=token) }}">subscribe to this list in your calendar</a>
+   so it stays up to date, download it as an <a href="{{ url_for('.favourites_ical') }}?token={{ token }}">iCal feed</a>,
+   or get a <a href="{{ url_for('.favourites_json') }}?token={{ token }}">json feed</a> for your giant robot.
 </p>
 {% if not feature_enabled('SCHEDULE') %}
 <p>The feed will only contain talks or workshops once they've been allocated a stage and time.</p>

--- a/templates/schedule/line-up.html
+++ b/templates/schedule/line-up.html
@@ -14,7 +14,7 @@
     </p>
     {% if feature_enabled('SCHEDULE') %}
     <p>You can <a href="{{ webcal_url('.schedule_ical', year=event_year) }}">subscribe to this list in your calendar</a>
-       so it stays up to date, download it as an <a href="{{ url_for('.schedule_ical', year=event_year) }}">iCal feed</a>,
+       so it stays up to date, download it as an <a href="{{ url_for('.schedule_ical', year=event_year) }}">iCal file</a>,
        or get a <a href="{{ url_for('.schedule_json', year=event_year) }}">json feed</a> for your giant robot.
     </p>
     {% endif %}

--- a/templates/schedule/line-up.html
+++ b/templates/schedule/line-up.html
@@ -13,8 +13,9 @@
         our scheduling algorithm place them in the best slot.
     </p>
     {% if feature_enabled('SCHEDULE') %}
-    <p>You can also get this list as an <a href="{{ url_for('.schedule_ical', year=event_year) }}">iCal feed</a>
-       for your calendar, and a <a href="{{ url_for('.schedule_json', year=event_year) }}">json feed</a> for your giant robot.
+    <p>You can <a href="{{ webcal_url('.schedule_ical', year=event_year) }}">subscribe to this list in your calendar</a>
+       so it stays up to date, download it as an <a href="{{ url_for('.schedule_ical', year=event_year) }}">iCal feed</a>,
+       or get a <a href="{{ url_for('.schedule_json', year=event_year) }}">json feed</a> for your giant robot.
     </p>
     {% endif %}
   {% else %}

--- a/templates/schedule/user_schedule.html
+++ b/templates/schedule/user_schedule.html
@@ -12,6 +12,7 @@
   <div id="schedule-app" data-api-token="{{ token }}" data-debug="{{ debug }}"></div>
   <p>
     <strong>Schedule feeds:</strong>
+    <a href="{{ webcal_url('.schedule_ical', year=year) }}">Subscribe</a> |
     <a href="{{ url_for('.schedule_json', year=year) }}">JSON</a> |
     <a href="{{ url_for('.schedule_ical', year=year) }}">iCal</a> |
     <a href="{{ url_for('.schedule_frab_xml', year=year) }}">Frab XML</a> |

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -27,7 +27,8 @@
     <h2 class="sr-only">Pick your shifts</h2>
     {# <p>Select a day to sign up for shifts. You can also <a href="{{ url_for('.choose_role') }}">change which roles you're interested in</a>.</p>
 
-    <p>You can get a list of all your shifts as an <a href="{{ url_for('.schedule_ical', token=token) }}">iCal feed</a>.</p> #}
+    <p>You can <a href="{{ webcal_url('.schedule_ical', token=token) }}">subscribe to your shifts in your calendar</a>,
+       or get them as an <a href="{{ url_for('.schedule_ical', token=token) }}">iCal feed</a>.</p> #}
 
     {% if untrained_roles %}
         <div class="alert alert-danger">

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -28,7 +28,7 @@
     {# <p>Select a day to sign up for shifts. You can also <a href="{{ url_for('.choose_role') }}">change which roles you're interested in</a>.</p>
 
     <p>You can <a href="{{ webcal_url('.schedule_ical', token=token) }}">subscribe to your shifts in your calendar</a>,
-       or get them as an <a href="{{ url_for('.schedule_ical', token=token) }}">iCal feed</a>.</p> #}
+       or get them as an <a href="{{ url_for('.schedule_ical', token=token) }}">iCal file</a>.</p> #}
 
     {% if untrained_roles %}
         <div class="alert alert-danger">


### PR DESCRIPTION
#1722

Adds a `webcal://` url where `.ics` calendar downloads are available. Instead of downloading a static list of calendar events, this will allow calendar clients to subscribe to the calendar and poll for updates