### PR TITLE
Handle talks in other states during round close

### DIFF
--- a/apps/cfp_review/base.py
+++ b/apps/cfp_review/base.py
@@ -477,9 +477,13 @@ def rank(round_id: int) -> ResponseReturnValue:
             count = 0
             round.minimum_score = min_score
             for proposal, score in scored_proposals:
-                # We often bounce some things to manual review so skip them
-                if proposal.state == "manual-review":
+                # If the proposal is no longer in anonymised state we shouldn't
+                # touch it, because we've probably rejected, pulled, or
+                # accepted it during round close review. If we don't do this
+                # then we can set accepted talks back to anonymised.
+                if proposal.state != "anonymised":
                     continue
+
                 proposal_round = (
                     db.session.query(ProposalRound)
                     .where(
@@ -505,7 +509,6 @@ def rank(round_id: int) -> ResponseReturnValue:
                         send_email_for_proposal(proposal, reason="accepted")
 
                 else:
-                    proposal.state = "anonymised"
                     proposal_round.outcome = "still-considering"
                     if (
                         form.confirm_type.data == "accepted_unaccepted"


### PR DESCRIPTION
We no longer have the "reviewed" state during round close, so proposals no longer need to be set back to "anonymised".

This was causing issues when talks were rejected/accepted during the round close process because the set of proposals being reviewed is now frozen in the round close object, so refreshing the page would not remove any that were modified. Upon closing the round talks that were accepted manually but _not_ accepted in the round would be set back to anonymised.

We also should not be considering any talk that is in a state other than "anonymised" so when executing the round close we now skip over them.