### PR TITLE
Add Music and Meetup Schedule item types

### DIFF
--- a/apps/cfp_review/forms.py
+++ b/apps/cfp_review/forms.py
@@ -247,6 +247,14 @@ class UpdateScheduleItemFilmForm(UpdateAttributesForm):
     classification = StringField("Classification")
 
 
+class UpdateScheduleItemMusicAttributesForm(UpdateAttributesForm):
+    pass
+
+
+class UpdateScheduleItemMeetupAttributesForm(UpdateAttributesForm):
+    pass
+
+
 # And now the additional Proposal-only fields.
 class UpdateProposalTalkAttributesForm(UpdateScheduleItemTalkAttributesForm):
     pass
@@ -269,7 +277,7 @@ class UpdateProposalInstallationAttributesForm(UpdateAttributesForm):
     grant_requested = StringField("Installation Grant Requested")
 
 
-# Lightning talks don't exist as Proposals
+# Lightning talks, music, and meetups don't exist as Proposals
 
 
 UPDATE_PROPOSAL_ATTRIBUTES_FORM_TYPES: dict[ProposalType, type[UpdateAttributesForm]] = {
@@ -287,6 +295,8 @@ UPDATE_SCHEDULE_ITEM_ATTRIBUTES_FORM_TYPES: dict[ScheduleItemType, type[UpdateAt
     "performance": UpdateScheduleItemPerformanceAttributesForm,
     "lightning": UpdateScheduleItemLightningTalkAttributesForm,
     "film": UpdateScheduleItemFilmForm,
+    "music": UpdateScheduleItemMusicAttributesForm,
+    "meetup": UpdateScheduleItemMeetupAttributesForm,
 }
 
 

--- a/apps/schedule/attendee_content.py
+++ b/apps/schedule/attendee_content.py
@@ -104,7 +104,13 @@ class AttendeeContentForm(Form):
     type = SelectField(
         "Type of content",
         default="workshop",
-        choices=[("talk", "Talk"), ("performance", "Performance"), ("workshop", "Workshop")],
+        choices=[
+            ("talk", "Talk"),
+            ("workshop", "Workshop"),
+            ("performance", "Performance"),
+            ("music", "Music"),
+            ("meetup", "Meetup"),
+        ],
     )
     # Attendees cannot hide or unhide schedule items but we still show the details
     state = SelectField(

--- a/apps/schedule/base.py
+++ b/apps/schedule/base.py
@@ -56,6 +56,7 @@ LINEUP_TYPE_ORDER: list[ScheduleItemType] = [
     #    "familyworkshop",
     #    "performance",
     "film",
+    "music",
 ]
 
 

--- a/models/content/attributes.py
+++ b/models/content/attributes.py
@@ -76,6 +76,16 @@ class FilmAttributes(Attributes):
     classification: str | None = None
 
 
+@dataclass
+class MusicAttributes(Attributes):
+    pass
+
+
+@dataclass
+class MeetupAttributes(Attributes):
+    pass
+
+
 # Attributes only used by the review process
 # These won't get copied across when creating a schedule item
 

--- a/models/content/schedule.py
+++ b/models/content/schedule.py
@@ -46,6 +46,8 @@ from .attributes import (
     FamilyWorkshopAttributes,
     FilmAttributes,
     LightningTalkAttributes,
+    MeetupAttributes,
+    MusicAttributes,
     PerformanceAttributes,
     TalkAttributes,
     WorkshopAttributes,
@@ -86,6 +88,8 @@ EVENT_SPACING = {
     "familyworkshop": 2,
     "installation": 0,
     "film": 2,
+    "music": 0,
+    "meetup": 0,
 }
 
 # The size of a scheduling slot
@@ -124,6 +128,8 @@ ScheduleItemType = Literal[
     "familyworkshop",
     "installation",
     "lightning",
+    "music",
+    "meetup",
 ]
 
 
@@ -406,6 +412,18 @@ SCHEDULE_ITEM_INFOS: dict[ScheduleItemType, ScheduleItemInfo] = {
         human_type="lightning talk",
         human_type_a="a lightning talk",
         attributes_cls=LightningTalkAttributes,
+    ),
+    "music": ScheduleItemInfo(
+        type="music",
+        human_type="music",
+        human_type_a="a music performance",
+        attributes_cls=MusicAttributes,
+    ),
+    "meetup": ScheduleItemInfo(
+        type="meetup",
+        human_type="meetup",
+        human_type_a="a meetup",
+        attributes_cls=MeetupAttributes,
     ),
 }
 

--- a/templates/cfp_review/_nav.html
+++ b/templates/cfp_review/_nav.html
@@ -84,8 +84,10 @@
                 {{ menuitem("Talks", ".schedule_items", type="talk") }}
                 {{ menuitem("Workshops", ".schedule_items", type="workshop") }}
                 {{ menuitem("Performances", ".schedule_items", type="performance") }}
+                {{ menuitem("Music", ".schedule_items", type="music") }}
                 {{ menuitem("Family Workshops", ".schedule_items", type="familyworkshop") }}
                 {{ menuitem("Lightning Talks", ".lightning_talks") }}
+                {{ menuitem("Meetups", ".schedule_items", type="meetup") }}
                 <li role="separator" class="divider"></li>
                 {{ menuitem('Published', ".schedule_items", schedule_item_counts['published'], state='published')}}
                 {{ menuitem('Unpublished', ".schedule_items", schedule_item_counts['unpublished'], state='unpublished')}}


### PR DESCRIPTION
This allows both us and attendees to create and schedule Music and Meetup types.

This was _way_ easier to implement than I expected - a+ content system refactoring. It all works fine, but let me know if I missed something here?

Fixes #1515