### PR TITLE
Add jump links to content types in line-up

### DIFF
--- a/templates/schedule/_schedule_item_lister.html
+++ b/templates/schedule/_schedule_item_lister.html
@@ -2,9 +2,12 @@
 {% from "schedule/_schedule_item_icons.html" import schedule_item_icons %}
 
 {# List schedule items - works for the current event year only #}
-{% macro list_schedule_items(grouped_schedule_items, ordered_type_infos) %}
+{% macro list_schedule_items(grouped_schedule_items, ordered_type_infos, jump_links=False) %}
     {% if grouped_schedule_items %}
     {% include "schedule/_icon_key.html" %}
+    {% endif %}
+    {% if jump_links and grouped_schedule_items %}
+    <p><strong>Jump to:</strong> {% for type, items in grouped_schedule_items.items() %}<a href="#{{ type }}">{{ items[0].human_type | title }}{% if type != "music" %}s{% endif %}</a>{% if not loop.last %}, {% endif %}{% endfor %}</p>
     {% endif %}
     {% for type_info in ordered_type_infos %}
         {% if grouped_schedule_items[type_info.type] %}

--- a/templates/schedule/favourites.html
+++ b/templates/schedule/favourites.html
@@ -14,7 +14,7 @@
 <p><strong><a class="btn btn-lg btn-primary" href="{{ url_for('schedule.main_year', year=event_year) }}">View line-up</a></strong></p>
 </div>
 <div class="line-up">
-{{ list_schedule_items(grouped_schedule_items, ordered_type_infos) }}
+{{ list_schedule_items(grouped_schedule_items, ordered_type_infos, jump_links=True) }}
 </div>
 
 {% if grouped_schedule_items | count == 0 %}

--- a/templates/schedule/line-up.html
+++ b/templates/schedule/line-up.html
@@ -6,11 +6,11 @@
 
 <h2>Line-up</h2>
 <div class="well">
-  <p>This is a list of the talks &amp; workshops that we're planning at EMF {{ event_year }}.
+  <p>This is a list of the events we're planning at EMF {{ event_year }}.
      Not all of them are announced yet, so check back frequently.</p>
   {% if current_user.is_authenticated %}
-    <p>You can favourite talks which sound interesting, which will let you keep track of them, and help
-        our scheduling algorithm place them in the optimal slot.
+    <p>You can favourite events which sound interesting - this lets you keep track of them, and helps
+        our scheduling algorithm place them in the optimal time.
     </p>
     {% if feature_enabled('SCHEDULE') %}
     <p>You can <a href="{{ webcal_url('.schedule_ical', year=event_year) }}">subscribe to this list in your calendar</a>
@@ -43,7 +43,7 @@
 </div>
 
 <div class="line-up">
-{{ list_schedule_items(grouped_schedule_items, ordered_type_infos) }}
+{{ list_schedule_items(grouped_schedule_items, ordered_type_infos, jump_links=True) }}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Also rewords the header, because it's much more than talks and workshops now.