### PR TITLE
Move view URL construction into the village model

### DIFF
--- a/apps/api/villages.py
+++ b/apps/api/villages.py
@@ -7,8 +7,7 @@ from flask_restful import Resource
 from geoalchemy2.shape import from_shape, to_shape
 from shapely.geometry import Point
 
-from apps.config import config
-from main import db, external_url
+from main import db
 from models.content import Venue
 from models.user import User
 from models.village import Village, VillageMember
@@ -30,7 +29,7 @@ def render_village(village: Village) -> VillageResponse:
     return {
         "id": village.id,
         "name": village.name,
-        "url": external_url("villages.view", year=config.event_year, village_id=village.id),
+        "url": village.view_url_external,
         "external_url": village.url,
         "description": village.description,
         "location": to_shape(village.location).__geo_interface__ if village.location else None,

--- a/models/village.py
+++ b/models/village.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from flask import url_for
 from geoalchemy2 import Geometry, WKBElement
 from geoalchemy2.shape import to_shape
 from slugify import slugify
@@ -83,7 +84,7 @@ class Village(BaseModel):
                 "id": self.id,
                 "name": self.name,
                 "description": self.description,
-                "url": external_url("villages.view", year=config.event_year, village_id=self.id),
+                "url": self.view_url_external,
                 "external_url": self.url,
                 "num_members": len(self.village_memberships),
             },
@@ -103,6 +104,14 @@ class Village(BaseModel):
             return None
         lat, lon = self.latlon
         return f"https://map.emfcamp.org/#18.5/{lat}/{lon}/m={lat},{lon}"
+
+    @property
+    def view_url_external(self) -> str:
+        return external_url("villages.view", year=config.event_year, village_id=self.id, slug=self.slug)
+
+    @property
+    def view_url(self) -> str:
+        return url_for("villages.view", year=config.event_year, village_id=self.id, slug=self.slug)
 
     @property
     def slug(self) -> str:

--- a/templates/account/main.html
+++ b/templates/account/main.html
@@ -42,7 +42,7 @@
       </div>
       {% if current_user.village %}
         <div class="panel-body">
-          <p>You're a{% if current_user.village_membership.admin %}n admin{% else %} member{% endif %} of the <strong><a href="{{url_for('villages.view', year=event_year, village_id=current_user.village.id)}}">{{current_user.village.name}}</a></strong> village.</p>
+          <p>You're a{% if current_user.village_membership.admin %}n admin{% else %} member{% endif %} of the <strong><a href="{{current_user.village.view_url}}">{{current_user.village.name}}</a></strong> village.</p>
         </div>
         {% if current_user.village_membership.admin %}
           <div class="panel-footer">
@@ -52,7 +52,7 @@
         {% endif %}
       {% elif current_user.village_join_request %}
         <div class="panel-body">
-          <p>You've requested to join the <strong><a href="{{url_for('villages.view', year=event_year, village_id=current_user.village_join_request.village.id)}}">{{current_user.village_join_request.village.name}}</a></strong> village.</p>
+          <p>You've requested to join the <strong><a href="{{current_user.village_join_request.village.view_url}}">{{current_user.village_join_request.village.name}}</a></strong> village.</p>
         </div>
       {% else %}
         <div class="panel-body">

--- a/templates/villages/edit.html
+++ b/templates/villages/edit.html
@@ -4,7 +4,7 @@
 <h1>
   Edit Village: {{village.name}}
   <a href="{{url_for('villages.members', year=event_year, village_id=village.id)}}" class="btn btn-primary btn-lg pull-right">Members</a>
-  <a href="{{url_for('villages.view', year=event_year, village_id=village.id, slug=village.slug)}}" class="btn btn-primary btn-lg pull-right">View</a>
+  <a href="{{village.view_url}}" class="btn btn-primary btn-lg pull-right">View</a>
   <a href="{{url_for('villages.members_leave', year=event_year, village_id=village.id)}}" class="btn btn-danger btn-lg pull-right">Leave</a>
 </h1>
 

--- a/templates/villages/members.html
+++ b/templates/villages/members.html
@@ -4,7 +4,7 @@
 <h1>
   Village Members: {{village.name}}
   <a href="{{url_for('villages.edit', year=event_year, village_id=village.id)}}" class="btn btn-primary btn-lg pull-right">Edit</a>
-  <a href="{{url_for('villages.view', year=event_year, village_id=village.id, slug=village.slug)}}" class="btn btn-primary btn-lg pull-right">View</a>
+  <a href="{{village.view_url}}" class="btn btn-primary btn-lg pull-right">View</a>
   <a href="{{url_for('villages.members_leave', year=event_year, village_id=village.id)}}" class="btn btn-danger btn-lg pull-right">Leave</a>
 </h1>
 

--- a/templates/villages/villages.html
+++ b/templates/villages/villages.html
@@ -19,7 +19,7 @@ If you have a ticket, you can <a href="{{url_for('users.login', next=url_for('.r
   {% if current_user.is_authenticated and current_user.village %}
   <li class="village-table-village">
     <h4 class="village-table-title">
-      <a href="{{ url_for('villages.view', year=event_year, village_id=current_user.village.id, slug=current_user.village.slug) }}">
+      <a href="{{ current_user.village.view_url }}">
       {{- current_user.village.name -}}
       </a>
       <span class="badge bg-primary">Your Village</span>
@@ -41,7 +41,7 @@ If you have a ticket, you can <a href="{{url_for('users.login', next=url_for('.r
   {% if not (current_user.is_authenticated and current_user.village and village.id == current_user.village.id) %}
   <li class="village-table-village">
     <h4 class="village-table-title">
-      <a href="{{ url_for('villages.view', year=event_year, village_id=village.id, slug=village.slug) }}">
+      <a href="{{ village.view_url }}">
       {{- village.name -}}
       </a>
     </h4>


### PR DESCRIPTION
This is a little ugly but the {{url_for}} logic is getting a bit verbose for this and is duplicated all over the place.

In Django land this would be called `get_absolute_url`, by convention.

This fixes a bug where the villages API actually returns an unslugged URL that ends in a hyphen, which is a bit gross, but does work.