### PR TITLE
Don't make wiki history public

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -158,6 +158,7 @@ def edit(slug: str) -> ResponseReturnValue:
 
 
 @wiki.route("/<slug>/history")
+@require_permission("wiki")
 def history(slug: str) -> ResponseReturnValue:
     page = WikiPage.get_by_slug(slug)
     if page is None:
@@ -169,6 +170,7 @@ def history(slug: str) -> ResponseReturnValue:
 
 
 @wiki.route("/<slug>/diff/<int:from_txn>/<int:to_txn>")
+@require_permission("wiki")
 def diff(slug: str, from_txn: int, to_txn: int) -> ResponseReturnValue:
     page = WikiPage.get_by_slug(slug)
     if page is None:

--- a/templates/wiki/view.html
+++ b/templates/wiki/view.html
@@ -25,7 +25,9 @@
   {%- if latest_version.transaction.user %} by {{ latest_version.transaction.user.name }}{% endif -%}
   {% endif -%}.
   {% endif %}
-  <a href="{{ url_for('wiki.history', slug=page.slug) }}">View history</a>
+  {%- if current_user.is_authenticated and current_user.has_permission('wiki') %}
+    <a href="{{ url_for('wiki.history', slug=page.slug) }}">View history</a>
+  {% endif -%}
 </p>
 <p class="small"><em>Content on this page is provided by attendees and is not the responsibility of EMF.</em></p>
 {% endblock %}


### PR DESCRIPTION
Previous versions may contain personal information such as email addresses posted for the purpose of exchanging tickets so viewing history now requires the `wiki` permission.

Closes #2156