### PR TITLE
Add DJ schedule item type

### DIFF
--- a/apps/base/dev/fake.py
+++ b/apps/base/dev/fake.py
@@ -265,6 +265,7 @@ class FakeDataGenerator:
             "film": 10,
             "meetup": 10,
             "music": 10,
+            "djset": 10,
         }
 
         if not proposal or proposal.state == "finalised":
@@ -559,6 +560,7 @@ class FakeDataGenerator:
         official_schedule_items: dict[ScheduleItemType, int] = {
             "film": 2,
             "music": 2,
+            "djset": 2,
             "performance": 2,
             "talk": 2,
             "workshop": 1,

--- a/apps/cfp_review/forms.py
+++ b/apps/cfp_review/forms.py
@@ -251,6 +251,10 @@ class UpdateScheduleItemMusicAttributesForm(UpdateAttributesForm):
     pass
 
 
+class UpdateScheduleItemDJSetAttributesForm(UpdateAttributesForm):
+    pass
+
+
 class UpdateScheduleItemMeetupAttributesForm(UpdateAttributesForm):
     pass
 
@@ -296,6 +300,7 @@ UPDATE_SCHEDULE_ITEM_ATTRIBUTES_FORM_TYPES: dict[ScheduleItemType, type[UpdateAt
     "lightning": UpdateScheduleItemLightningTalkAttributesForm,
     "film": UpdateScheduleItemFilmForm,
     "music": UpdateScheduleItemMusicAttributesForm,
+    "djset": UpdateScheduleItemDJSetAttributesForm,
     "meetup": UpdateScheduleItemMeetupAttributesForm,
 }
 

--- a/apps/cfp_review/schedule_item.py
+++ b/apps/cfp_review/schedule_item.py
@@ -6,7 +6,6 @@ import csv
 import json
 from http import HTTPStatus
 from io import BytesIO, StringIO
-from typing import get_args
 
 from flask import (
     abort,
@@ -25,6 +24,7 @@ from sqlalchemy.orm import selectinload, undefer
 from wtforms import FormField
 
 from apps.cfp.views import TimeRangesHandler
+from apps.common import title_add
 from main import db, get_or_404
 from models.content import (
     SCHEDULE_ITEM_INFOS,
@@ -261,8 +261,11 @@ def convert_schedule_item(schedule_item_id: int) -> ResponseReturnValue:
     schedule_item = get_or_404(db, ScheduleItem, schedule_item_id)
 
     form = ConvertScheduleItemForm()
-    types = get_args(ScheduleItemType)
-    form.new_type.choices = [(t, t.title()) for t in types if t != schedule_item.type]
+    form.new_type.choices = [
+        (ti.type, title_add(ti.human_type))
+        for ti in SCHEDULE_ITEM_INFOS.values()
+        if ti.type != schedule_item.type
+    ]
 
     if form.validate_on_submit():
         new_type = form.new_type.data

--- a/apps/common/__init__.py
+++ b/apps/common/__init__.py
@@ -241,6 +241,8 @@ def load_utility_functions(app_obj):
         return Markup(f'<span class="label label-{cls}">{ticket.state}</span>')
 
     app_obj.template_filter("tidy_workshop_cost")(tidy_workshop_cost)
+    app_obj.template_filter("title_add")(title_add)
+    app_obj.template_filter("capitalize_add")(capitalize_add)
 
     @app_obj.context_processor
     def content_processor():
@@ -521,3 +523,16 @@ def tidy_workshop_cost(participant_cost: str) -> str:
         return ""
     except ValueError:
         return participant_cost
+
+
+def title_add(value: str) -> str:
+    # Converts to title case, while preserving any existing capitals.
+    # Replaces whitespace with space, like str.capwords.
+    # e.g. a DJ's set -> A DJ's Set
+    return " ".join(p.title() if p.islower() else p for p in value.split())
+
+
+def capitalize_add(value: str) -> str:
+    # Capitalises the first letter, while preserving any other capitals.
+    # e.g. a DJ's set -> A DJ's set
+    return value[0].upper() + value[1:]

--- a/apps/schedule/base.py
+++ b/apps/schedule/base.py
@@ -55,6 +55,7 @@ LINEUP_TYPE_ORDER: list[ScheduleItemType] = [
     #    "familyworkshop",
     "performance",
     "music",
+    "djset",
     "film",
 ]
 

--- a/models/content/attributes.py
+++ b/models/content/attributes.py
@@ -82,6 +82,11 @@ class MusicAttributes(Attributes):
 
 
 @dataclass
+class DJSetAttributes(Attributes):
+    pass
+
+
+@dataclass
 class MeetupAttributes(Attributes):
     pass
 

--- a/models/content/schedule.py
+++ b/models/content/schedule.py
@@ -43,6 +43,7 @@ from ..user import User
 from . import validate_state_transitions
 from .attributes import (
     Attributes,
+    DJSetAttributes,
     FamilyWorkshopAttributes,
     FilmAttributes,
     LightningTalkAttributes,
@@ -89,6 +90,7 @@ EVENT_SPACING = {
     "installation": 0,
     "film": 2,
     "music": 0,
+    "djset": 0,
     "meetup": 0,
 }
 
@@ -129,6 +131,7 @@ ScheduleItemType = Literal[
     "installation",
     "lightning",
     "music",
+    "djset",
     "meetup",
 ]
 
@@ -338,7 +341,6 @@ class ScheduleItem(BaseModel):
 
     @property
     def human_type_a(self) -> str:
-        # Same as human_type but includes a/an
         return self.type_info.human_type_a
 
     @property
@@ -363,7 +365,9 @@ validate_state_transitions(ScheduleItem.state, SCHEDULE_ITEM_STATE_TRANSITIONS)
 @dataclass
 class ScheduleItemInfo:
     type: ScheduleItemType
+    #: Type to expose to users
     human_type: str
+    #: Same as human_type but includes a/an
     human_type_a: str
     attributes_cls: Type[Attributes]  # noqa: UP006
     supports_lottery: bool = False
@@ -416,8 +420,14 @@ SCHEDULE_ITEM_INFOS: dict[ScheduleItemType, ScheduleItemInfo] = {
     "music": ScheduleItemInfo(
         type="music",
         human_type="music",
-        human_type_a="a music performance",
+        human_type_a="a live music performance",
         attributes_cls=MusicAttributes,
+    ),
+    "djset": ScheduleItemInfo(
+        type="djset",
+        human_type="DJ set",
+        human_type_a="a DJ set",
+        attributes_cls=DJSetAttributes,
     ),
     "meetup": ScheduleItemInfo(
         type="meetup",

--- a/templates/cfp/finalise.html
+++ b/templates/cfp/finalise.html
@@ -24,7 +24,7 @@
     </fieldset>
 
     <fieldset>
-        <legend>Confirm Your {{ schedule_item.human_type | title }}</legend>
+        <legend>Confirm Your {{ schedule_item.human_type | title_add }}</legend>
         <p>Please confirm the details you would like to be publicly visible in the schedule</p>
         {{ render_field(form.title, 9) }}
         <div class="col-md-9 col-md-offset-3"><small>Your description should be about 100-150 words.</small></div>

--- a/templates/cfp/proposals.html
+++ b/templates/cfp/proposals.html
@@ -10,7 +10,7 @@
 {% for proposal in proposals %}
 <div class="well">
     <div class="row">
-    <div class="col-md-12"><h3>{{ proposal.human_type | title }}: {{ proposal.title }}</h3></div>
+    <div class="col-md-12"><h3>{{ proposal.human_type | title_add }}: {{ proposal.title }}</h3></div>
     <div class="col-md-9">
     <dl class="dl-horizontal">
     <dt>Submitted</dt>

--- a/templates/cfp_review/schedule_item/_base.html
+++ b/templates/cfp_review/schedule_item/_base.html
@@ -3,7 +3,7 @@
 {% block body %}
     <h2>Schedule Item: {{schedule_item.title}}<br>
         <small>
-            {{ schedule_item.human_type_a | capitalize }} by
+            {{ schedule_item.human_type_a | capitalize_add }} by
             <a href="{{ url_for('cfp_review.cfp_user', user_id=schedule_item.user.id) }}">{{ schedule_item.user.name }}</small></a>
     </h2>
 {% include "cfp_review/schedule_item/_schedule_item_tabs.html" %}

--- a/templates/emails/cfp-submission.txt
+++ b/templates/emails/cfp-submission.txt
@@ -4,7 +4,7 @@ Hi {{ proposal.user.name }},
 
 This is to confirm your submission to our call for participation. We'll try to process your submission as quickly as possible. Here's a summary of your submission:
 
-{{ proposal.human_type | title }}
+{{ proposal.human_type | title_add }}
 Title: {{ proposal.title }}
 Description: {{ proposal.description }}
 {%- if proposal.type in ['talk', 'familyworkshop', 'workshop', 'performance'] %}

--- a/templates/schedule/_schedule_item_groups.html
+++ b/templates/schedule/_schedule_item_groups.html
@@ -1,0 +1,9 @@
+{% macro human_group_title(type_info) %}
+  {%- if type_info.type == "music" -%}
+    Live Music
+  {%- elif type_info.type == "djset" -%}
+    DJs
+  {%- else -%}
+    {{ type_info.human_type | title_add + "s" }}
+  {%- endif -%}
+{% endmacro %}

--- a/templates/schedule/_schedule_item_lister.html
+++ b/templates/schedule/_schedule_item_lister.html
@@ -1,17 +1,27 @@
 {% from "schedule/_faves.html" import favourite_icons %}
 {% from "schedule/_schedule_item_icons.html" import schedule_item_icons %}
+{% from "schedule/_schedule_item_groups.html" import human_group_title %}
 
 {# List schedule items - works for the current event year only #}
 {% macro list_schedule_items(grouped_schedule_items, ordered_type_infos, jump_links=False) %}
+
     {% if grouped_schedule_items %}
-    {% include "schedule/_icon_key.html" %}
+      {% include "schedule/_icon_key.html" %}
+
+      {% if jump_links %}
+          <p>
+              <strong>Jump to:</strong>
+              {% for type, items in grouped_schedule_items.items() -%}
+                  <a href="#{{ type }}">{{ human_group_title(items[0].type_info) }}</a>
+                  {%- if not loop.last %}, {% endif %}
+              {%- endfor %}
+          </p>
+      {% endif %}
     {% endif %}
-    {% if jump_links and grouped_schedule_items %}
-    <p><strong>Jump to:</strong> {% for type, items in grouped_schedule_items.items() %}<a href="#{{ type }}">{{ items[0].human_type | title }}{% if type != "music" %}s{% endif %}</a>{% if not loop.last %}, {% endif %}{% endfor %}</p>
-    {% endif %}
+
     {% for type_info in ordered_type_infos %}
         {% if grouped_schedule_items[type_info.type] %}
-            <h2 class="event-type" id="{{ type_info.type }}">{{ type_info.human_type | title }}{% if type_info.type != "music" %}s{% endif %}</h2>
+            <h2 class="event-type" id="{{ type_info.type }}">{{ human_group_title(type_info) }}</h2>
             <form method="post" action="{{url_for(".add_favourite")}}">
             <div>
                 {% for schedule_item in grouped_schedule_items[type_info.type] %}
@@ -59,4 +69,5 @@
             </form>
         {% endif %}
     {% endfor %}
+
 {% endmacro %}

--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -8,7 +8,7 @@
 <h2>{{ schedule_item.title }}</h2>
 <h2>
   <small>
-  {{ schedule_item.human_type | title }}{% if schedule_item.names %} by {{ schedule_item.names }}{% if schedule_item.pronouns %} ({{schedule_item.pronouns}}){% endif %}{% endif %}
+  {{ schedule_item.human_type | title_add }}{% if schedule_item.names %} by {{ schedule_item.names }}{% if schedule_item.pronouns %} ({{schedule_item.pronouns}}){% endif %}{% endif %}
   {{ schedule_item_icons(schedule_item) }}
   </small>
 </h2>


### PR DESCRIPTION
I've used `djset` instead of `dj` to avoid confusion on the backend.

Thanks to English, this includes an incomplete attempt to fix capitalisation with a function, instead of extending the `type_info.human_type_` attributes ad nauseam.

Splits "Music" on the line-up into "Live Music" and "DJs". There's now a macro `human_group_title` to return the schedule grouping name.