### PR TITLE
Feed conflicts to the scheduler, disable tags

### DIFF
--- a/apps/cfp/scheduler.py
+++ b/apps/cfp/scheduler.py
@@ -1,8 +1,9 @@
-from collections import defaultdict
+from collections import Counter, defaultdict
 from datetime import timedelta
+from itertools import combinations
 
 from flask import current_app as app
-from slotmachine import SchedulingProblem, SchedulingSolution, SlotMachine, Talk, VenueTimes
+from slotmachine import Conflict, SchedulingProblem, SchedulingSolution, SlotMachine, Talk, VenueTimes
 from sqlalchemy import and_, not_, select
 from sqlalchemy.orm import joinedload
 
@@ -51,6 +52,7 @@ class Scheduler:
                 Occurrence.scheduled_duration.isnot(None),
             )
             .options(joinedload(Occurrence.schedule_item).joinedload(ScheduleItem.proposal))
+            .options(joinedload(Occurrence.schedule_item).selectinload(ScheduleItem.favourited_by))
             .order_by(ScheduleItem.favourite_count.desc())
         ).all()
 
@@ -74,6 +76,7 @@ class Scheduler:
                     raise Exception(f"Official venue has no capacity defined: {venue}")
                 capacity_by_type[block.type][venue.id] = venue.capacity or 0
 
+        user_faves: dict[int, list[Occurrence]] = defaultdict(list)
         scheduler_talks = []
         for type, occurrences in occurrences_by_type.items():
             # We assign the largest venues as being preferred for the most popular talks
@@ -96,15 +99,21 @@ class Scheduler:
                 # Per-venue allowed time ranges: the intersection of the speaker's availability
                 # and each venue's TimeBlocks for this content type.
                 #
-                # Venue weight is the venue capacity for all venues that
-                # haven't been shifted off already due to talk popularity,
-                # meaning that equal-sized venues have equal weight.
+                # We add the same weight to all venues of the current max
+                # capacity venue, because variable venue weightings cause
+                # serious performance degredation in slotmachine at this scale
+
+                current_venues = [
+                    v
+                    for v in ordered_venues
+                    if self.venues[v].capacity == self.venues[ordered_venues[0]].capacity
+                ]
                 allowed_times = occurrence.allowed_times(True)
                 venue_times = [
                     VenueTimes(
                         venue=venue.id,
                         times=times,
-                        venue_weight=(venue.capacity or 0) if venue.id in ordered_venues else 0,
+                        venue_weight=5 if venue.id in current_venues else 0,
                     )
                     for venue, times in allowed_times.items()
                 ]
@@ -118,15 +127,16 @@ class Scheduler:
                     app.logger.warning(f"Skipping scheduling occurrence {occurrence} - no allowed times.")
                     continue
 
-                proposal = occurrence.schedule_item.proposal
-                tags = set(proposal.tags) if proposal else set()
+                ## tag diversity currently disabled due to performance degredation
+                # proposal = occurrence.schedule_item.proposal
+                # tags = set(proposal.tags) if proposal else set()
 
                 talk = Talk(
                     id=occurrence.id,
                     duration=occurrence.scheduled_duration,
                     speakers={speaker.id for speaker in occurrence.schedule_item.presenters},
                     venue_times=venue_times,
-                    tags=tags,
+                    # tags=tags, # tag diversity currently disabled due to performance degredation
                     minutes_after=total_minutes(occurrence.changeover_time),
                 )
 
@@ -138,6 +148,10 @@ class Scheduler:
 
                 scheduler_talks.append(talk)
 
+                # For conflict detection
+                for user in occurrence.schedule_item.favourited_by:
+                    user_faves[user.id].append(occurrence)
+
                 # Shift to the next venue when we hit the division
                 if count > split_count:
                     count = 0
@@ -145,7 +159,25 @@ class Scheduler:
                 else:
                     count += 1
 
-        return SchedulingProblem(talks=scheduler_talks, slot_duration=total_minutes(SLOT_DURATION))
+        # Calculate the top 1000 most commonly co-starred occurrences
+        # and flag them as conflicts
+        popularity: Counter[tuple[Occurrence, Occurrence]] = Counter()
+        for occurrences in user_faves.values():
+            for o1, o2 in combinations(sorted(occurrences, key=lambda o: o.id), 2):
+                # We don't care about clashes with other occurrences of the
+                # same proposal, we have a hard constraint preventing them
+                # clashing
+                if o1.proposal == o2.proposal:
+                    continue
+                popularity.update([(o1, o2)])
+
+        conflicts = []
+        for (o1, o2), count in popularity.most_common()[:1000]:
+            conflicts.append(Conflict(talks={o1.id, o2.id}, weight=max(1, count)))
+
+        return SchedulingProblem(
+            talks=scheduler_talks, conflicts=conflicts, slot_duration=total_minutes(SLOT_DURATION)
+        )
 
     def generate_potential_schedule(self, solution: SchedulingSolution) -> PotentialSchedule:
         potential_schedule = PotentialSchedule()

--- a/apps/cfp_review/schedule.py
+++ b/apps/cfp_review/schedule.py
@@ -329,41 +329,43 @@ def clashfinder() -> ResponseReturnValue:
 
     ranked: list[tuple[Occurrence, Occurrence, int, int]] = []
 
-    candidates: list[tuple[tuple[Occurrence, Occurrence], int]] = []
-    a_fans = []
-    b_fans = []
-    for (a, b), count in popularity.items():
-        if count < MIN_PEOPLE:
-            continue
-        candidates.append(((a, b), count))
-        a_fans.append(fans[a])
-        b_fans.append(fans[b])
-
-    if candidates:
-        expected = [na * nb / population for na, nb in zip(a_fans, b_fans, strict=True)]
-        pvalues = hypergeom.sf([count - 1 for _, count in candidates], population, a_fans, b_fans)
-        qvalues = false_discovery_control(pvalues, method="bh")
-
-        for ((o1, o2), count), mean, qvalue in zip(candidates, expected, qvalues, strict=True):
-            if count < MIN_LIFT * mean or qvalue > MAX_QVALUE:
+    if request.args.get("old_scoring") == "true":
+        for (a, b), count in popularity.most_common(1000):
+            ranked.append((a, b, count, 0))
+    else:
+        candidates: list[tuple[tuple[Occurrence, Occurrence], int]] = []
+        a_fans = []
+        b_fans = []
+        for (a, b), count in popularity.items():
+            if count < MIN_PEOPLE:
                 continue
+            candidates.append(((a, b), count))
+            a_fans.append(fans[a])
+            b_fans.append(fans[b])
 
-            ranked.append((o1, o2, count, max(1, round(count - mean))))
-        ranked.sort(key=lambda r: r[3], reverse=True)
+        if candidates:
+            expected = [na * nb / population for na, nb in zip(a_fans, b_fans, strict=True)]
+            pvalues = hypergeom.sf([count - 1 for _, count in candidates], population, a_fans, b_fans)
+            qvalues = false_discovery_control(pvalues, method="bh")
+
+            for ((o1, o2), count), mean, qvalue in zip(candidates, expected, qvalues, strict=True):
+                if count < MIN_LIFT * mean or qvalue > MAX_QVALUE:
+                    continue
+
+                ranked.append((o1, o2, count, max(1, round(count - mean))))
+            ranked.sort(key=lambda r: r[3], reverse=True)
 
     show_all = request.args.get("show_all") == "true"
 
     clashes = []
     number = 0
     for o1, o2, favourite_count, weight in ranked:
-        p1 = o1.schedule_item.proposal
-        p2 = o2.schedule_item.proposal
-        if not p1 or not p2:
-            # TODO: this should be rare, do we flag it up?
+        # We don't care about clashes with other occurrences of the same
+        # proposal, we have a hard constraint preventing them clashing
+        if o1.proposal == o2.proposal:
             continue
 
-        if p1.state not in {"accepted", "finalised"} or p2.state not in {"accepted", "finalised"}:
-            # TODO: this also should be rare, do we flag it up?
+        if o1.cancelled or o2.cancelled:
             continue
 
         overlaps = o1.overlaps_with(o2)


### PR DESCRIPTION
This also fixes a bug in the clashfinder and enables comparison of the old conflict model (which this is using, for now)