### PR TITLE
Allow shift notes

### DIFF
--- a/apps/volunteer/role_admin.py
+++ b/apps/volunteer/role_admin.py
@@ -328,6 +328,7 @@ def update_shift(role_id: int, shift_id: int) -> ResponseReturnValue:
     shift = get_or_404(db, Shift, shift_id)
     shift.min_needed = int(request.form["min_needed"])
     shift.max_needed = int(request.form["max_needed"])
+    shift.notes = request.form["notes"] if len(request.form["notes"].strip()) > 0 else None
     db.session.add(shift)
     db.session.commit()
 

--- a/migrations/versions/e63fbbc558ff_shift_notes.py
+++ b/migrations/versions/e63fbbc558ff_shift_notes.py
@@ -1,0 +1,30 @@
+"""shift notes
+
+Revision ID: e63fbbc558ff
+Revises: c2f0c1f7d1ee
+Create Date: 2026-07-05 19:55:34.607434
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e63fbbc558ff"
+down_revision = "3b7a93819f43"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    with op.batch_alter_table("volunteer_shift", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("notes", sa.String(), nullable=True))
+
+    with op.batch_alter_table("volunteer_shift_version", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("notes", sa.String(), autoincrement=False, nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("volunteer_shift_version", schema=None) as batch_op:
+        batch_op.drop_column("notes")
+
+    with op.batch_alter_table("volunteer_shift", schema=None) as batch_op:
+        batch_op.drop_column("notes")

--- a/models/volunteer/shift.py
+++ b/models/volunteer/shift.py
@@ -302,6 +302,10 @@ class Shift(BaseModel):
     #: The ShiftTemplate that resulted in this shift
     generated_from: Mapped[ShiftTemplate | None] = relationship(back_populates="shifts")
 
+    #: Additional notes for this shift, primarily used for workshop helpers where every
+    #: shift has slightly different requirements.
+    notes: Mapped[str | None] = mapped_column(default=None)
+
     current_count = column_property(
         select(func.count(ShiftEntry.shift_id))
         .where(ShiftEntry.shift_id == id)
@@ -386,6 +390,7 @@ class Shift(BaseModel):
             "max_needed": self.max_needed,
             "role": self.role.to_dict(),
             "venue": self.venue.to_dict(),
+            "notes": self.notes,
             "current_count": self.current_count,
         }
 

--- a/templates/volunteer/role_admin/role.html
+++ b/templates/volunteer/role_admin/role.html
@@ -66,6 +66,11 @@
           <input name="max_needed" type="number" class="form-control" value="{{ shift.max_needed }}">
         </div>
         <div class="form-group">
+          <label class="control-label" for="notes">Notes</label>
+          <input name="notes" type="text" class="form-control" value="{{ shift.notes }}">
+          <p class="help-block">Notes to make available for volunteers signing up to this shift. Leave blank if none required. Primarily intended for workshop helpers.</p>
+        </div>
+        <div class="form-group">
           <button type="button" class="btn btn-danger shift-editor-cancel" data-shift-id="{{ shift.id }}">Cancel</button>
           <button type="submit" class="btn btn-primary">Update</button>
         </div>
@@ -77,6 +82,9 @@
         <li><strong>Current:</strong> {{ shift.entries | count }}</li>
         <li><a href="#shift-status-{{ shift.id }}" class="shift-status-edit" data-shift-id="{{ shift.id }}">Edit</a></li>
       </ul>
+      {% if shift.notes %}
+        <p><strong>Notes:</strong><br>{{ shift.notes }}</p>
+      {% endif %}
       {% for se in shift.entries|sort(attribute="user_id") %}
         <div class="volunteer">
           <p>

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -88,7 +88,12 @@
                                 </td>
                                 <td class="conflicts" {% if shift.is_user_shift %}title="You're signed up for this shift"{% endif %}></td>
                                 <td class="venue"><a href="{{ shift.venue.mapref }}">{{ shift.venue.name }}</a></td>
-                                <td class="role">{{ shift.role.name }}</td>
+                                <td class="role">
+                                    {{ shift.role.name }}
+                                    {% if shift.notes %}
+                                        <p class="help-block">{{ shift.notes}}</p>
+                                    {% endif %}
+                                </td>
                                 <td class="staffing">
                                     {{ staffing_icon(shift) }}
                                     {{ shift.current_count }}/{{ shift.max_needed }}


### PR DESCRIPTION
These get displayed on the volunteer schedule under the role name for cases where we need specific details to be shown, its primarily intended for workshop helpers, where the volunteer requirements are incredibly variable from shift to shift.