### PR TITLE
Manual scheduling

### DIFF
--- a/apps/cfp/scheduler.py
+++ b/apps/cfp/scheduler.py
@@ -31,6 +31,8 @@ class Scheduler:
     def __init__(self):
         self.occurrences = {}
         self.venues = {}
+        # Occurrences that we couldn't feed to the scheduler because they're lacking information
+        self.unschedulable: list[Occurrence] = []
 
     def get_schedulable_occurrences(self, types: list[ScheduleItemType]) -> list[Occurrence]:
         """Fetch a list of Occurrences that the automatic scheduler should consider
@@ -119,12 +121,11 @@ class Scheduler:
                 ]
 
                 if len(venue_times) == 0:
-                    # FIXME: this happens when an Occurrence is constrained to a manually-scheduled venue, but
-                    # has not been assigned a time yet.
-                    # Manually-scheduled talks should still be sent to the automatic scheduler to take speaker
-                    # availability into account.
-                    # We should surface the number/list of these occurrences to the user who's running the scheduler.
+                    # This happens when things are manually scheduled outside
+                    # of a timeblock, or when we have no timeblocks of this
+                    # type set to be automatically schedulable.
                     app.logger.warning(f"Skipping scheduling occurrence {occurrence} - no allowed times.")
+                    self.unschedulable.append(occurrence)
                     continue
 
                 ## tag diversity currently disabled due to performance degredation

--- a/apps/cfp_review/schedule.py
+++ b/apps/cfp_review/schedule.py
@@ -120,14 +120,26 @@ def schedule() -> ResponseReturnValue:
 def run_scheduler():
     if request.method == "POST" and request.form.get("run"):
         scheduler = Scheduler()
+        result = None
         try:
             result = scheduler.run(AUTO_SCHEDULE_TYPES)
-            db.session.add(result)
-            db.session.commit()
-            return redirect(url_for(".potential_schedule", schedule_id=result.id))
         except slotmachine.Unsatisfiable as e:
             app.logger.exception("Unsatisfiable schedule")
             flash(f"Schedule was unsatisfiable :( {e}")
+        except Exception as e:
+            app.logger.exception("Scheduler failed")
+            flash(f"Scheduler failed: {e}")
+
+        if scheduler.unschedulable:
+            ids = ", ".join(str(o.id) for o in scheduler.unschedulable)
+            flash(
+                f"{len(scheduler.unschedulable)} occurrences unschedulable due to lack of times. May be manually scheduled outside a timeblock, or there are no automatic timeblocks of that type. Occurrence IDs: {ids}"
+            )
+
+        if result is not None:
+            db.session.add(result)
+            db.session.commit()
+            return redirect(url_for(".potential_schedule", schedule_id=result.id))
 
     return render_template("cfp_review/schedule/schedule_run.html")
 

--- a/apps/cfp_review/schedule_item.py
+++ b/apps/cfp_review/schedule_item.py
@@ -381,10 +381,22 @@ def update_occurrence(schedule_item_id: int, occurrence_id: int) -> ResponseRetu
 
         assert form.allowed_venue_ids.data is not None
         occurrence.allowed_venues = [venues_dict[v] for v in form.allowed_venue_ids.data]
-        db.session.commit()
-        return redirect(
-            url_for(".update_occurrence", schedule_item_id=schedule_item_id, occurrence_id=occurrence_id)
-        )
+
+        if (
+            occurrence.manually_scheduled
+            and occurrence.scheduled_time is not None
+            and occurrence.scheduled_duration is not None
+            and not occurrence.allowed_times(True)
+        ):
+            flash(
+                f"ERROR: Manually scheduled time outside any '{occurrence.schedule_item.human_type}' Time Blocks in the allowed venues"
+            )
+            db.session.rollback()
+        else:
+            db.session.commit()
+            return redirect(
+                url_for(".update_occurrence", schedule_item_id=schedule_item_id, occurrence_id=occurrence_id)
+            )
 
     if request.method != "POST":
         form.allowed_venue_ids.data = [v.id for v in occurrence.get_allowed_venues()]

--- a/models/content/schedule.py
+++ b/models/content/schedule.py
@@ -610,15 +610,20 @@ class Occurrence(BaseModel):
         This takes into account whether the Occurrence has been manually scheduled, but it doesn't
         take into account speaker availability.
         """
-        if self.manually_scheduled and self.scheduled_venue and self.scheduled_time:
-            # Occurrence is manually scheduled, so we only return the TimeBlock which it's scheduled in
-            for timeblock in self.scheduled_venue.time_blocks:
-                if timeblock.type == self.schedule_item.type and (
-                    timeblock.start <= self.scheduled_time < timeblock.end
-                ):
-                    yield timeblock
-                    break
-
+        if self.manually_scheduled and self.scheduled_time:
+            # Occurrence is manually scheduled at a specific time, so we only
+            # return TimeBlocks in venues that have a suitable timeblock at
+            # this time.
+            for venue in self.get_allowed_venues():
+                for timeblock in venue.time_blocks:
+                    if (
+                        timeblock.type == self.schedule_item.type
+                        and self.scheduled_end_time is not None
+                        and timeblock.start <= self.scheduled_time
+                        and self.scheduled_end_time <= timeblock.end
+                    ):
+                        yield timeblock
+                        break
         else:
             for venue in self.get_allowed_venues():
                 for timeblock in venue.time_blocks:
@@ -633,13 +638,21 @@ class Occurrence(BaseModel):
         """
         assert self.schedule_item.official_content
 
-        if self.manually_scheduled and self.scheduled_venue and self.scheduled_time:
-            # Manually scheduled - return a single time range which encompasses the scheduled time.
-            assert self.scheduled_end_time
-            return {self.scheduled_venue: [(self.scheduled_time, self.scheduled_end_time)]}
-
         result: dict[Venue, list[tuple[datetime, datetime]]] = defaultdict(list)
         for time_block in self.time_blocks():
+            if self.manually_scheduled and self.scheduled_time:
+                assert self.scheduled_end_time
+
+                # Manually scheduled - return a single time range which
+                # encompasses the scheduled time.
+                #
+                # If someone wants to restrict the venue, they do this by setting
+                # allowed_venues - this means we can restrict a talk to be at a
+                # specific time but allow for freedom of venue movement if
+                # nessecary to avoid over-constraining the problem.
+                result[time_block.venue].append((self.scheduled_time, self.scheduled_end_time))
+                continue
+
             if time_block.automatic != automatic:
                 continue
 

--- a/templates/cfp_review/schedule_item/occurrence.html
+++ b/templates/cfp_review/schedule_item/occurrence.html
@@ -34,8 +34,11 @@
                             {{ render_dl_field(form.scheduled_duration) }}
 
                             {{ render_dl_field(form.allowed_venue_ids) }}
+                            <dd><p class="help-block">The scheduler will only place this Occurrence in these venues. If you want to have this Occurrence in a specific venue, ensure it is the only one selected.</p></dd>
                             {{ render_dl_field(form.scheduled_venue_id) }}
                             {{ render_dl_field(form.scheduled_time) }}
+                            {{ render_dl_field(form.manually_scheduled) }}
+                            <dd><p class="help-block">Setting manually scheduled will disallow the scheduler from automatically moving this Occurrence to another time.</p></dd>
                         </dl>
                     </div>
                 </div>

--- a/tests/content/test_scheduling_timeblocks.py
+++ b/tests/content/test_scheduling_timeblocks.py
@@ -93,9 +93,9 @@ def test_occurrence_time_blocks(user, db):
     assert time_blocks[0].venue == venue3
     assert all(block.automatic is False for block in time_blocks)
 
-    occurrence.allowed_venues = []
     # Set the time and the "manually_scheduled" flag. Now this occurrence is pinned
     # to occur in the manual timeblock.
+    occurrence.allowed_venues = [venue3]
     occurrence.scheduled_time = parse("2026-07-17 15:00:00")
     occurrence.manually_scheduled = True
     db.session.commit()
@@ -158,6 +158,7 @@ def test_occurrence_allowed_times(user, db):
     # Now we manually schedule this occurrence.
     # This is scheduled outside the speaker's availability, but the manually-scheduled time takes priority.
     occurrence.manually_scheduled = True
+    occurrence.allowed_venues = [venue3]
     occurrence.scheduled_venue = venue3
     occurrence.scheduled_time = parse("2026-07-16 11:00:00")
     db.session.commit()


### PR DESCRIPTION
This restricts an Occurrence to only being allowed in the time slot it is already in by overriding availability. It does _not_ override the venue, because we can generally tolerate items being moved to another venue if we have no other option - if the content team need to restrict the time _and_ venue they can set "Allowed venues".

This also adds validation to ensure that people can't manually schedule things outside timeblocks, and surfaces warnings about talks not being scheduled in the automatic scheduling flow.