### PR TITLE
Volunteer training

### DIFF
--- a/apps/volunteer/bar_training.py
+++ b/apps/volunteer/bar_training.py
@@ -136,12 +136,12 @@ def bar_training_page(page_name: str) -> ResponseReturnValue:
 @volunteer.route("/bar-training", methods=["GET", "POST"])
 @v_user_required
 def bar_training():
-    bar = Role.query.filter_by(slug="bar").one_or_none()
-    cybar = Role.query.filter_by(slug="cybar").one_or_none()
-    if bar is None or cybar is None:
+    bar_roles = Role.query.filter_by(uses_bar_training=True).all()
+    if len(bar_roles) == 0:
         abort(404)
+
     volunteer = Volunteer.get_for_user(current_user)
-    trained = bar in volunteer.trained_roles
+    trained = bar_roles[0] in volunteer.trained_roles
 
     training_json_path = app.config.get("BAR_TRAINING_JSON", "models/fixtures/training/bar.json")
     training_json = load_training_json(training_json_path)
@@ -159,8 +159,9 @@ def bar_training():
             flash("You answered all the questions correctly!")
         else:
             app.logger.info(f"{current_user} passed the bar training.")
-            bar.trained_volunteers.append(volunteer)
-            cybar.trained_volunteers.append(volunteer)
+            for role in bar_roles:
+                role.trained_volunteers.append(volunteer)
+
             db.session.commit()
             flash("Your completion of bar training has been saved.")
         return redirect(url_for(".bar_training"))

--- a/apps/volunteer/role_admin.py
+++ b/apps/volunteer/role_admin.py
@@ -96,6 +96,28 @@ class RoleForm(Form):
         widget=TextArea(),
         description="Displayed in the main role list when signing up.",
     )
+    requires_training = BooleanField(
+        "Requires training",
+        description="Whether volunteers need to complete training before they can sign up for shifts",
+    )
+    allows_self_training = BooleanField(
+        "Allows self training",
+        description="If enabled volunteers can declare they've read the training notes and are then considered trained, otherwise they need to be approved by a role admin.",
+    )
+    uses_bar_training = BooleanField(
+        "Uses bar training",
+        description="Should only be set for bar roles. Overrides all other training settings. Don't set this unless you know you need it and why.",
+    )
+    training_notes = StringField(
+        "Training notes",
+        [Optional()],
+        widget=TextArea(),
+        description="Details to be shown when a volunteer goes to the training page. If you allow self training a button declaring they've understood will be shown underneath, otherwise provide directions on how to get approved. (supports markdown)",
+    )
+    over_18_only = BooleanField(
+        "Over 18 only",
+        description="Whether we require volunteers to be over 18 for this role. Please use sparingly.",
+    )
     role_notes = StringField(
         "Role notes (supports markdown)",
         [Optional()],
@@ -216,7 +238,7 @@ def role_admin(role_id):
 def role_edit(role_id: int) -> ResponseReturnValue:
     """Allows editing details of a role."""
     role = get_or_404(db, Role, role_id)
-    form = RoleForm(request.form, obj=role)
+    form = RoleForm(obj=role)
     if request.method == "POST" and form.validate():
         form.populate_obj(role)
         db.session.add(role)

--- a/apps/volunteer/training.py
+++ b/apps/volunteer/training.py
@@ -1,77 +1,70 @@
 from flask import current_app as app
-from flask import flash, redirect, render_template, url_for
-from wtforms import BooleanField, FieldList, FormField, SubmitField
-from wtforms.validators import InputRequired
+from flask import flash, redirect, render_template, request, url_for
+from flask.typing import ResponseReturnValue
 
 from apps.volunteer.role_admin import role_admin_required
 from main import db
 from models.volunteer.role import Role
 from models.volunteer.volunteer import Volunteer
 
-from ..common.fields import HiddenIntegerField
-from ..common.forms import Form
 from . import volunteer
-
-
-class VolunteerSelectForm(Form):
-    volunteer_id = HiddenIntegerField("Volunteer ID", [InputRequired()])
-    trained = BooleanField("Volunteer")
-
-
-class TrainingForm(Form):
-    volunteers = FieldList(FormField(VolunteerSelectForm))
-    submit = SubmitField("Train these volunteers.")
-
-    def add_volunteers(self, volunteers):
-        # Don't add roles if some have already been set (this will get called
-        # on POST as well as GET)
-        if len(self.volunteers) == 0:
-            for v in volunteers:
-                self.volunteers.append_entry()
-                self.volunteers[-1].volunteer_id.data = v.id
-
-        volunteer_dict = {v.id: v for v in volunteers}
-        # Enrich the field data
-        for field in self.volunteers:
-            field._volunteer = volunteer_dict[field.volunteer_id.data]
-            field.label = field._volunteer.nickname
 
 
 @volunteer.route("/role-admin/<role_id>/train-users", methods=["GET", "POST"])
 @role_admin_required
-def train_users(role_id):
+def train_users(role_id: int) -> ResponseReturnValue:
     role = Role.get_by_id(role_id)
-    form = TrainingForm()
-    volunteers = Volunteer.query.join(Volunteer.interested_roles).filter(Role.id == role_id).all()
-    form.add_volunteers(volunteers)
 
-    if form.validate_on_submit():
-        changes = 0
-        for v in form.volunteers:
-            if v.trained.data and v._volunteer not in role.trained_volunteers:
-                changes += 1
-                role.trained_volunteers.append(v._volunteer)
+    volunteers = []
+    if request.method == "POST" and request.form["query"] != "":
+        volunteers = Volunteer.find_by_query(request.form["query"])
 
-            elif not v.trained.data and v._volunteer in role.trained_volunteers:
-                changes += 1
-                role.trained_volunteers.remove(v._volunteer)
+    # if form.validate_on_submit():
+    #     changes = 0
+    #     for v in form.volunteers:
+    #         if v.trained.data and v._volunteer not in role.trained_volunteers:
+    #             changes += 1
+    #             role.trained_volunteers.append(v._volunteer)
 
-        db.session.commit()
-        flash(f"Trained {changes} volunteers")
-        app.logger.info(f"Trained {changes} volunteers")
+    #         elif not v.trained.data and v._volunteer in role.trained_volunteers:
+    #             changes += 1
+    #             role.trained_volunteers.remove(v._volunteer)
 
-        return redirect(url_for(".train_users", role_id=role_id))
+    #     db.session.commit()
+    #     flash(f"Trained {changes} volunteers")
+    #     app.logger.info(f"Trained {changes} volunteers")
 
-    for v in role.trained_volunteers:
-        for f in form.volunteers:
-            if f.volunteer_id.data == v.id:
-                f.trained.data = True
-                break
+    #     return redirect(url_for(".train_users", role_id=role_id))
 
-    # Sort people who've been trained to the top then by nickname
-    form.volunteers = sorted(
-        form.volunteers,
-        key=lambda f: (-1 if f.trained.data else 1, f._volunteer.nickname),
+    return render_template(
+        "volunteer/training/train_users.html",
+        role=role,
+        query=request.form.get("query", ""),
+        volunteers=volunteers,
     )
 
-    return render_template("volunteer/training/train_users.html", role=role, form=form)
+
+@volunteer.route("/role-admin/<int:role_id>/train-users/<int:volunteer_id>", methods=["POST"])
+@role_admin_required
+def train_user(role_id: int, volunteer_id: int) -> ResponseReturnValue:
+    role = Role.get_by_id(role_id)
+    volunteer = Volunteer.get_by_id(volunteer_id)
+
+    role.trained_volunteers.append(volunteer)
+    db.session.commit()
+
+    flash(f"Marked {volunteer.nickname} trained")
+    return redirect(url_for(".train_users", role_id=role_id))
+
+
+@volunteer.route("/role-admin/<int:role_id>/train-users/<int:volunteer_id>/untrain", methods=["POST"])
+@role_admin_required
+def untrain_user(role_id: int, volunteer_id: int) -> ResponseReturnValue:
+    role = Role.get_by_id(role_id)
+    volunteer = Volunteer.get_by_id(volunteer_id)
+
+    role.trained_volunteers.remove(volunteer)
+    db.session.commit()
+
+    flash(f"Marked {volunteer.nickname} untrained")
+    return redirect(url_for(".train_users", role_id=role_id))

--- a/apps/volunteer/training.py
+++ b/apps/volunteer/training.py
@@ -1,13 +1,57 @@
-from flask import current_app as app
+from collections.abc import Sequence
+
 from flask import flash, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
+from flask_login import current_user
 
 from apps.volunteer.role_admin import role_admin_required
 from main import db
 from models.volunteer.role import Role
 from models.volunteer.volunteer import Volunteer
 
-from . import volunteer
+from . import v_user_required, volunteer
+
+
+@volunteer.route("/training")
+@v_user_required
+def training_index() -> ResponseReturnValue:
+    volunteer: Volunteer = current_user.volunteer
+
+    # We filter out roles that use bar training and just link that once because otherwise there'll
+    # be repeated roles that all link to the same training.
+    roles = (
+        volunteer.interested_roles.filter(Role.requires_training, Role.uses_bar_training == False)  # type: ignore
+        .order_by(Role.name)
+        .all()
+    )
+    return render_template(
+        "volunteer/training.html",
+        roles=roles,
+        include_bar=volunteer.over_18,
+        trained_roles=volunteer.trained_roles,
+    )
+
+
+@volunteer.route("/training/<int:role_id>", methods=["GET", "POST"])
+@v_user_required
+def training(role_id: int) -> ResponseReturnValue:
+    role = Role.get_by_id(role_id)
+    if not role.requires_training:
+        flash(f"{role.name} doesn't require any training.")
+        return redirect(url_for(".choose_role"))
+
+    if request.method == "GET":
+        return render_template("volunteer/role_training.html", role=role)
+
+    if not role.allows_self_training:
+        flash("Nice try. This role doesn't allow self training.")
+        return redirect(url_for(".training", role_id=role.id))
+
+    role.trained_volunteers.append(current_user.volunteer)
+    db.session.commit()
+
+    flash(f"Thanks! You're now trained for {role.name} and can sign up for shifts.")
+    return redirect("/volunteer")
 
 
 @volunteer.route("/role-admin/<role_id>/train-users", methods=["GET", "POST"])
@@ -15,7 +59,7 @@ from . import volunteer
 def train_users(role_id: int) -> ResponseReturnValue:
     role = Role.get_by_id(role_id)
 
-    volunteers = []
+    volunteers: Sequence[Volunteer] = []
     if request.method == "POST" and request.form["query"] != "":
         volunteers = Volunteer.find_by_query(request.form["query"])
 

--- a/migrations/versions/2e42f8a6c619_volunteer_self_training.py
+++ b/migrations/versions/2e42f8a6c619_volunteer_self_training.py
@@ -1,0 +1,40 @@
+"""volunteer self-training
+
+Revision ID: 2e42f8a6c619
+Revises: 9b784af36d7f
+Create Date: 2026-07-06 20:30:26.812626
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "2e42f8a6c619"
+down_revision = "9b784af36d7f"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    with op.batch_alter_table("volunteer_role", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("training_notes", sa.String(), nullable=False, server_default=""))
+        batch_op.add_column(
+            sa.Column("allows_self_training", sa.Boolean(), nullable=False, server_default="f")
+        )
+        batch_op.add_column(sa.Column("uses_bar_training", sa.Boolean(), nullable=False, server_default="f"))
+
+    with op.batch_alter_table("volunteer_role_version", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("training_notes", sa.String(), autoincrement=False, nullable=True))
+        batch_op.add_column(
+            sa.Column("allows_self_training", sa.Boolean(), autoincrement=False, nullable=True)
+        )
+        batch_op.add_column(sa.Column("uses_bar_training", sa.Boolean(), autoincrement=False, nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("volunteer_role_version", schema=None) as batch_op:
+        batch_op.drop_column("allows_self_training")
+        batch_op.drop_column("training_notes")
+
+    with op.batch_alter_table("volunteer_role", schema=None) as batch_op:
+        batch_op.drop_column("allows_self_training")
+        batch_op.drop_column("training_notes")

--- a/models/volunteer/role.py
+++ b/models/volunteer/role.py
@@ -47,6 +47,16 @@ class Role(BaseModel):
     over_18_only: Mapped[bool] = mapped_column(default=False)
     #: Whether the role requires training to perform
     requires_training: Mapped[bool] = mapped_column(default=False)
+    #: Whether this role is covered by the bar training. Roles that have this attribute
+    #: set will use the bar training page rather than the generic role training page,
+    #: and on completing bar training all roles with this attribute will be marked as
+    #: trained.
+    uses_bar_training: Mapped[bool] = mapped_column(default=False)
+    #: Some markdown which will be presented on the role's training page
+    training_notes: Mapped[str] = mapped_column(default="")
+    #: When True volunteers can declare themselves trained, if False they have to be
+    #: approved by a role admin.
+    allows_self_training: Mapped[bool] = mapped_column(default=False)
 
     team_id: Mapped[int] = mapped_column(ForeignKey("volunteer_team.id"))
     #: The team this role is under
@@ -124,7 +134,10 @@ class Role(BaseModel):
             "name": self.name,
             "description": self.description,
             "role_notes": self.role_notes,
+            "over_18_only": self.over_18_only,
             "requires_training": self.requires_training,
+            "allows_self_training": self.allows_self_training,
+            "training_notes": self.training_notes,
             "shifts_finalised": self.shifts_finalised,
         }
 
@@ -139,6 +152,12 @@ class Role(BaseModel):
     def formatted_role_notes(self) -> Markup | None:
         if self.role_notes:
             return Markup(markdown(self.role_notes, extensions=["markdown.extensions.nl2br"]))
+        return None
+
+    @property
+    def formatted_training_notes(self) -> Markup | None:
+        if self.training_notes:
+            return Markup(markdown(self.training_notes, extensions=["markdown.extensions.nl2br"]))
         return None
 
     @classmethod

--- a/models/volunteer/volunteer.py
+++ b/models/volunteer/volunteer.py
@@ -6,6 +6,7 @@ from flask_login import UserMixin
 from sqlalchemy import ARRAY, Column, ForeignKey, Integer, String, Table, select
 from sqlalchemy.ext.mutable import Mutable, MutableSet
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import or_
 
 from apps.config import config
 from main import db
@@ -123,6 +124,12 @@ class Volunteer(BaseModel, UserMixin):
     @classmethod
     def get_by_email(cls, email_address: str) -> Volunteer | None:
         return db.session.scalar(select(cls).where(cls.volunteer_email == email_address))
+
+    @classmethod
+    def find_by_query(cls, query: str) -> list[Volunteer]:
+        return db.session.scalars(
+            select(cls).where(or_(cls.volunteer_email.ilike(f"%{query}%"), cls.nickname.ilike(f"%{query}%")))
+        ).all()
 
     @classmethod
     def get_for_user(cls, user):

--- a/models/volunteer/volunteer.py
+++ b/models/volunteer/volunteer.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from flask_login import UserMixin
 from sqlalchemy import ARRAY, Column, ForeignKey, Integer, String, Table, select
@@ -17,6 +17,9 @@ from .. import BaseModel
 from .shift import ShiftEntry, ShiftEntryState
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
+
     from ..user import User
     from .role import Role, RoleAdmin, Team
 
@@ -126,7 +129,7 @@ class Volunteer(BaseModel, UserMixin):
         return db.session.scalar(select(cls).where(cls.volunteer_email == email_address))
 
     @classmethod
-    def find_by_query(cls, query: str) -> list[Volunteer]:
+    def find_by_query(cls, query: str) -> Sequence[Volunteer]:
         return db.session.scalars(
             select(cls).where(or_(cls.volunteer_email.ilike(f"%{query}%"), cls.nickname.ilike(f"%{query}%")))
         ).all()

--- a/templates/volunteer/_nav.html
+++ b/templates/volunteer/_nav.html
@@ -15,7 +15,7 @@
         {% if feature_enabled('VOLUNTEERS_SCHEDULE') %}
             {{ menuitem('Shift sign-up', '.schedule') }}
         {% endif %}
-        {{ menuitem('Bar Training', '.bar_training') }}
+        {{ menuitem('Training', '.training_index') }}
         {% if current_user.volunteer.trained_roles.all() | selectattr("slug", "==", "workshop-steward") | list %}
         {{ menuitem('Workshop Steward', 'schedule.workshop_steward_main') }}
         {% endif %}

--- a/templates/volunteer/role_admin/edit.html
+++ b/templates/volunteer/role_admin/edit.html
@@ -15,6 +15,14 @@
                 {{ form.hidden_tag() }}
                 {% call render_field(form.name, horizontal=9) %}{{ form.name.description }}{% endcall %}
                 {% call render_field(form.full_description_md, horizontal=9, style="height: 20em") %}{{ form.full_description_md.description }}{% endcall %}
+                {% call render_field(form.over_18_only, horizontal=9) %}{{ form.over_18_only.description }}{% endcall %}
+                {% call render_field(form.requires_training, horizontal=9) %}{{ form.requires_training.description }}{% endcall %}
+                <div id="training-only">
+                    {% call render_field(form.uses_bar_training, horizontal=9) %}{{ form.uses_bar_training.description }}{% endcall %}
+                    {% call render_field(form.allows_self_training, horizontal=9) %}{{ form.allows_self_training.description }}{% endcall %}
+                    {% call render_field(form.training_notes, horizontal=9, style="height: 20em") %}{{ form.training_notes.description }}{% endcall %}
+                </div>
+
                 {% call render_field(form.role_notes, horizontal=9, style="height: 20em") %}{{ form.role_notes.description }}{% endcall %}
                 {% call render_field(form.instructions_url, horizontal=9) %}{{ form.instructions_url.description }}{% endcall %}
                 {{ form.save(class_="btn btn-primary debounce pull-right") }}
@@ -23,3 +31,18 @@
     </div>
 
 {% endblock body %}
+{% block foot %}
+<script nonce="{{ csp_nonce }}">
+function showHideTrainingFields() {
+  requiresTraining = document.getElementById('requires_training').checked;
+  if (requiresTraining) {
+    document.getElementById('training-only').style.display = 'block';
+  } else {
+    document.getElementById('training-only').style.display = 'none';
+  }
+}
+
+document.getElementById('requires_training').addEventListener('change', showHideTrainingFields)
+showHideTrainingFields()
+</script>
+{% endblock %}

--- a/templates/volunteer/role_training.html
+++ b/templates/volunteer/role_training.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block title %}
+    EMF {{ role.name }} training
+{% endblock %}
+
+{% block body %}
+{% include "volunteer/_nav.html" %}
+
+    <h2>{{ role.name }} Training</h2>
+    {{ role.formatted_training_notes }}
+
+    {% if role.allows_self_training %}
+        <form method="post">
+            <button type="submit" class="btn btn-primary">I have read the notes above and recognise I'll look quite silly if I turn up and its obvious I haven't</button
+        </form>
+    {% endif %}
+{% endblock body %}

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -33,6 +33,7 @@
                     <li>{{ role.name }}</li>
                 {% endfor %}
             </ul>
+            <a href="{{ url_for('.training_index') }}">Go to training</a>
         </div>
     {% endif %}
 

--- a/templates/volunteer/training.html
+++ b/templates/volunteer/training.html
@@ -8,6 +8,11 @@
 {% include "volunteer/_nav.html" %}
 
     <h2>Training</h2>
+    <div class="well">
+        <p>If you haven't already please read the <a href="{{ url_for('.info') }}">volunteer handbook</a>
+           which covers important information for all volunteers such as what to do in case of emergencies
+           and how to get free food.</p>
+    </div>
     <p>Listed below you can find all the roles you've chosen which have training
        information attached so you can either complete the training or revisit it.</p>
 

--- a/templates/volunteer/training.html
+++ b/templates/volunteer/training.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block title %}
+    EMF volunteer training
+{% endblock %}
+
+{% block body %}
+{% include "volunteer/_nav.html" %}
+
+    <h2>Training</h2>
+    <p>Listed below you can find all the roles you've chosen which have training
+       information attached so you can either complete the training or revisit it.</p>
+
+    <ul>
+        {% if include_bar %}
+            <li>
+                <a href="{{ url_for('.bar_training') }}">Bar</a>
+                {% if trained_roles.all() | selectattr("uses_bar_training") | list %}
+                    - Trained
+                {% endif %}
+            </li>
+        {% endif %}
+        {% for role in roles %}
+            <li>
+                <a href="{{ url_for('.training', role_id=role.id) }}">{{ role.name }}</a>
+                {% if role in trained_roles %} - Trained{% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+{% endblock body %}

--- a/templates/volunteer/training/train_users.html
+++ b/templates/volunteer/training/train_users.html
@@ -1,27 +1,39 @@
 {% extends 'base.html' %}
+{% from "_formhelpers.html" import render_field %}
 
 {% block title %}
     Train users
 {% endblock %}
 {% block body %}
     {% include "volunteer/_nav.html" %}
-    <h2>Who have you trained?</h2>
-    <form method="post">
-        {{ form.hidden_tag() }}
+    <h2>{{ role.name }} Training</h2>
+    <div class="well">
+      <h3>Search for volunteers</h3>
+      <p>You can search by nickname or email address, partial matches are supported.</p>
+      <form method="post" class="form-inline">
+        <label for="query" class="sr-only">Email/nickname:</label>
+        <input type="text" class="form-control" value="{{ query }}" name="query">
+        <button type="submit" class="btn btn-default">Search</button>
+      </form>
+    </div>
 
-        {% for field in form.volunteers %}
-            {{ field.hidden_tag() }}
-            <div class="checkbox">
-                <label for="{{ field.trained.name }}">
-                    {{ field.trained()| safe }}
-                    <strong>{{ field._volunteer.nickname }}</strong>
-                </label>
-            </div>
-        {% endfor %}
-
-
-        <div class="form-group">
-            {{ form.submit(class_="btn btn-primary debounce") }}
-        </div>
-    </form>
+    {% if query != "" %}
+        <ul>
+            {% for volunteer in volunteers %}
+                <li>
+                    {% if volunteer in role.trained_volunteers %}
+                        <form method="post" action="{{ url_for('.untrain_user', role_id=role.id, volunteer_id=volunteer.id) }}">
+                            {{ volunteer.nickname }}
+                            <button type="submit" class="btn btn-small btn-danger">Untrain</button>
+                        </form>
+                    {% else %}
+                        <form method="post" action="{{ url_for('.train_user', role_id=role.id, volunteer_id=volunteer.id) }}">
+                            {{ volunteer.nickname }}
+                            <button type="submit" class="btn btn-small btn-primary">Train</button>
+                        </form>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
**Includes database migrations**

Update the training UI in role admin so that its driven by searching for partial names/email addresses rather than a giant list of every person who's expressed an interest in the role.

Add self training for some roles - this is less involved than the bar training and targeted at roles like workshop stewards where we want volunteers to read some further information and acknowledge that they've done so rather than run a full quiz. For roles where someone needs to approve the volunteer that page doesn't feature a button and instead just displays whatever guidance is available.

To support this I've also added a `uses_bar_training` attribute to roles which opts them into the bar training system - on completing bar training all roles that have opted in will be marked as trained at the same time rather than having a hardcoded list of slugs.