### PR TITLE
Feed all content to the scheduler for conflict avoidance

### DIFF
--- a/apps/cfp/scheduler.py
+++ b/apps/cfp/scheduler.py
@@ -34,7 +34,7 @@ class Scheduler:
         # Occurrences that we couldn't feed to the scheduler because they're lacking information
         self.unschedulable: list[Occurrence] = []
 
-    def get_schedulable_occurrences(self, types: list[ScheduleItemType]) -> list[Occurrence]:
+    def get_schedulable_occurrences(self) -> list[Occurrence]:
         """Fetch a list of Occurrences that the automatic scheduler should consider
 
         The scheduler needs to consider all official content, even content which is manually scheduled,
@@ -46,7 +46,6 @@ class Scheduler:
                 not_(Occurrence.cancelled),
                 Occurrence.schedule_item.has(
                     and_(
-                        ScheduleItem.type.in_(types),
                         ScheduleItem.official_content,
                         ScheduleItem.state != "cancelled",
                     )
@@ -60,10 +59,11 @@ class Scheduler:
 
         return list(occurrences)
 
-    def get_schedule_problem(self, types: list[ScheduleItemType] | None = None) -> SchedulingProblem:
-        if types is None:
-            types = ["talk", "workshop", "familyworkshop"]
-        occurrences = self.get_schedulable_occurrences(types)
+    def get_schedule_problem(self, types: list[ScheduleItemType]) -> SchedulingProblem:
+        # "types" are the content types to auto-schedule. All other types are
+        # fixed in place as if manually scheduled and present only for speaker
+        # conflict avoidance
+        occurrences = self.get_schedulable_occurrences()
 
         occurrences_by_type: dict[ScheduleItemType, list[Occurrence]] = defaultdict(list)
         for occurrence in occurrences:
@@ -89,7 +89,11 @@ class Scheduler:
                 key=lambda k: capacity_by_type[type][k],
                 reverse=True,
             )
-            split_count = int(len(occurrences_by_type[type]) / len(capacity_by_type[type]))
+            split_count = (
+                int(len(occurrences_by_type[type]) / len(capacity_by_type[type]))
+                if capacity_by_type[type]
+                else 0
+            )
 
             count = 0
             for occurrence in occurrences:
@@ -105,27 +109,41 @@ class Scheduler:
                 # capacity venue, because variable venue weightings cause
                 # serious performance degredation in slotmachine at this scale
 
-                current_venues = [
-                    v
-                    for v in ordered_venues
-                    if self.venues[v].capacity == self.venues[ordered_venues[0]].capacity
-                ]
-                allowed_times = occurrence.allowed_times(True)
-                venue_times = [
-                    VenueTimes(
-                        venue=venue.id,
-                        times=times,
-                        venue_weight=5 if venue.id in current_venues else 0,
-                    )
-                    for venue, times in allowed_times.items()
-                ]
+                if type in types:
+                    current_venues = [
+                        v
+                        for v in ordered_venues
+                        if self.venues[v].capacity == self.venues[ordered_venues[0]].capacity
+                    ]
+                    allowed_times = occurrence.allowed_times(True)
+                    venue_times = [
+                        VenueTimes(
+                            venue=venue.id,
+                            times=times,
+                            venue_weight=5 if venue.id in current_venues else 0,
+                        )
+                        for venue, times in allowed_times.items()
+                    ]
+                elif (
+                    occurrence.scheduled_venue and occurrence.scheduled_time and occurrence.scheduled_end_time
+                ):
+                    # Not being auto-scheduled: pin to its current venue and time.
+                    venue_times = [
+                        VenueTimes(
+                            venue=occurrence.scheduled_venue.id,
+                            times=[(occurrence.scheduled_time, occurrence.scheduled_end_time)],
+                        )
+                    ]
+                else:
+                    venue_times = []
 
                 if len(venue_times) == 0:
-                    # This happens when things are manually scheduled outside
-                    # of a timeblock, or when we have no timeblocks of this
-                    # type set to be automatically schedulable.
-                    app.logger.warning(f"Skipping scheduling occurrence {occurrence} - no allowed times.")
-                    self.unschedulable.append(occurrence)
+                    if type in types:
+                        # This happens when things are manually scheduled outside
+                        # of a timeblock, or when we have no timeblocks of this
+                        # type set to be automatically schedulable.
+                        app.logger.warning(f"Skipping scheduling occurrence {occurrence} - no allowed times.")
+                        self.unschedulable.append(occurrence)
                     continue
 
                 ## tag diversity currently disabled due to performance degredation
@@ -154,7 +172,7 @@ class Scheduler:
                     user_faves[user.id].append(occurrence)
 
                 # Shift to the next venue when we hit the division
-                if count > split_count:
+                if ordered_venues and count > split_count:
                     count = 0
                     ordered_venues.pop(0)
                 else:

--- a/apps/cfp_review/schedule.py
+++ b/apps/cfp_review/schedule.py
@@ -5,7 +5,7 @@ from collections import Counter, defaultdict
 from datetime import datetime, timedelta
 from io import BytesIO
 from itertools import combinations
-from typing import Any, get_args
+from typing import Any, cast, get_args
 
 import slotmachine
 from flask import current_app as app
@@ -31,11 +31,8 @@ from models.content.schedule import SCHEDULE_ITEM_INFOS, ScheduleItemInfo, Sched
 
 from . import cfp_review, schedule_required
 
-# Types of content that will be fed to the automatic scheduler. This is
-# incorrect because we _also_ need to feed other types to the scheduler in
-# locked positions to avoid speaker conflicts - it's here for now to ensure
-# that the slotmachine download is the same as the actual schedule-run button.
-AUTO_SCHEDULE_TYPES: list[ScheduleItemType] = ["talk", "workshop", "familyworkshop"]
+# Content types that are ticked by default for auto-scheduling
+DEFAULT_AUTO_SCHEDULE_TYPES: list[ScheduleItemType] = ["talk", "workshop", "familyworkshop"]
 
 
 @cfp_review.route("/schedule")
@@ -118,11 +115,21 @@ def schedule() -> ResponseReturnValue:
 @cfp_review.route("/schedule/run-scheduler", methods=["GET", "POST"])
 @schedule_required
 def run_scheduler():
+    type_options = [
+        {
+            "type": t,
+            "label": SCHEDULE_ITEM_INFOS[t].human_type if t in SCHEDULE_ITEM_INFOS else t,
+            "checked": t in DEFAULT_AUTO_SCHEDULE_TYPES,
+        }
+        for t in get_args(ScheduleItemType)
+    ]
+
     if request.method == "POST" and request.form.get("run"):
+        types = request.form.getlist("auto_type")
         scheduler = Scheduler()
         result = None
         try:
-            result = scheduler.run(AUTO_SCHEDULE_TYPES)
+            result = scheduler.run(types)
         except slotmachine.Unsatisfiable as e:
             app.logger.exception("Unsatisfiable schedule")
             flash(f"Schedule was unsatisfiable :( {e}")
@@ -141,14 +148,15 @@ def run_scheduler():
             db.session.commit()
             return redirect(url_for(".potential_schedule", schedule_id=result.id))
 
-    return render_template("cfp_review/schedule/schedule_run.html")
+    return render_template("cfp_review/schedule/schedule_run.html", type_options=type_options)
 
 
 @cfp_review.route("/schedule/run-scheduler/export.json")
 @schedule_required
 def run_scheduler_export() -> ResponseReturnValue:
     # Export the scheduling problem as JSON for debugging with slotmachine
-    problem = Scheduler().get_schedule_problem(AUTO_SCHEDULE_TYPES)
+    types = cast("list[ScheduleItemType]", request.args.getlist("auto_type")) or DEFAULT_AUTO_SCHEDULE_TYPES
+    problem = Scheduler().get_schedule_problem(types)
     json_str = json.dumps(problem.to_dict(), sort_keys=True, indent=4, separators=(",", ": "))
 
     now = datetime.now().isoformat()

--- a/templates/cfp_review/schedule/schedule_run.html
+++ b/templates/cfp_review/schedule/schedule_run.html
@@ -8,10 +8,22 @@
     <p>The scheduler may take a little while to run, but it's limited to 30 seconds.</p>
 </div>
 <form method="POST">
+    <fieldset style="margin-bottom: 2em;">
+        <h4>Content types to auto-schedule</h4>
+        <p class="help-block">
+            Checked types will be auto-scheduled, unchecked types are pinned in their current times/venues for conflict avoidance.
+        </p>
+        {% for opt in type_options %}
+        <label class="checkbox-inline">
+            <input type="checkbox" name="auto_type" value="{{ opt.type }}" {% if opt.checked %}checked{% endif %}>
+            {{ opt.label | capitalize }}
+        </label>
+        {% endfor %}
+    </fieldset>
     <button name="run" value="1" class="btn btn-primary">Run scheduler</button>
+    <button formaction="{{ url_for('.run_scheduler_export') }}" formmethod="get" class="btn">Download problem JSON</button>
 </form>
-<p class="help-block" style="margin-top: 2em;">
-    For debugging, you can
-    <a href="{{ url_for('.run_scheduler_export') }}">download the current scheduling problem as JSON</a> (<code>python -m slotmachine slotmachine-problem.json</code>).
+<p class="help-block" style="margin-top: 2em">
+    "Download problem JSON" exports the current scheduling problem for debugging with slotmachine (<code>python -m slotmachine slotmachine-problem.json</code>).
 </p>
 {% endblock %}


### PR DESCRIPTION
This feeds all official content to the scheduler, but with anything that we don't want to auto-schedule pinned in place as if it had been manually scheduled. This means we take all content into account when looking for speaker clashes.