### PR TITLE
More volunteer tweaks

### DIFF
--- a/apps/volunteer/role_admin.py
+++ b/apps/volunteer/role_admin.py
@@ -112,7 +112,7 @@ class RoleForm(Form):
         "Training notes",
         [Optional()],
         widget=TextArea(),
-        description="Details to be shown when a volunteer goes to the training page. If you allow self training a button declaring they've understood will be shown underneath, otherwise provide directions on how to get approved. (supports markdown)",
+        description="Details to be shown when a volunteer goes to the training page. If you allow self training a button declaring they've understood will be shown underneath, otherwise they can just read them. (supports markdown)",
     )
     over_18_only = BooleanField(
         "Over 18 only",

--- a/apps/volunteer/training.py
+++ b/apps/volunteer/training.py
@@ -20,7 +20,13 @@ def training_index() -> ResponseReturnValue:
     # We filter out roles that use bar training and just link that once because otherwise there'll
     # be repeated roles that all link to the same training.
     roles = (
-        volunteer.interested_roles.filter(Role.requires_training, Role.uses_bar_training == False)  # type: ignore
+        volunteer.interested_roles.filter(  # type: ignore
+            or_(
+                Role.training_notes.is_(None),
+                Role.training_notes != "",
+                and_(Role.requires_training == True, Role.uses_bar_training == False),
+            )
+        )
         .order_by(Role.name)
         .all()
     )
@@ -36,7 +42,7 @@ def training_index() -> ResponseReturnValue:
 @v_user_required
 def training(role_id: int) -> ResponseReturnValue:
     role = Role.get_by_id(role_id)
-    if not role.requires_training:
+    if not role.requires_training and (role.training_notes is None or role.training_notes.strip() == ""):
         flash(f"{role.name} doesn't require any training.")
         return redirect(url_for(".choose_role"))
 

--- a/apps/volunteer/training.py
+++ b/apps/volunteer/training.py
@@ -17,24 +17,27 @@ from . import v_user_required, volunteer
 def training_index() -> ResponseReturnValue:
     volunteer: Volunteer = current_user.volunteer
 
-    # We filter out roles that use bar training and just link that once because otherwise there'll
-    # be repeated roles that all link to the same training.
-    roles = (
-        volunteer.interested_roles.filter(  # type: ignore
-            or_(
-                Role.training_notes.is_(None),
-                Role.training_notes != "",
-                and_(Role.requires_training == True, Role.uses_bar_training == False),
-            )
-        )
-        .order_by(Role.name)
-        .all()
-    )
+    if volunteer.is_volunteer_admin:
+        all_roles = volunteer.administered_roles
+    else:
+        all_roles = volunteer.interested_roles
+
+    roles = [
+        role
+        for role in all_roles
+        if (role.training_notes is not None and role.training_notes != "")
+        or (role.requires_training and not role.uses_bar_training)
+    ]
+
+    if volunteer.over_18:
+        bar_roles = [role for role in all_roles if role.uses_bar_training]
+        if bar_roles:
+            roles.append(bar_roles[0])
+
     return render_template(
         "volunteer/training.html",
-        roles=roles,
-        include_bar=volunteer.over_18,
-        trained_roles=volunteer.trained_roles,
+        roles=sorted(roles, key=lambda r: r.name),
+        trained_roles=volunteer.trained_roles.all(),  # type: ignore
     )
 
 

--- a/models/user.py
+++ b/models/user.py
@@ -515,6 +515,11 @@ class User(BaseModel, UserMixin):
         """Whether the user has a ticket to the event."""
         return self.admission_tickets_held > 0
 
+    @property
+    def is_checked_in(self) -> bool:
+        """Whether the user has checked in an admission ticket at the gate."""
+        return any(t.redeemed for t in self.get_owned_tickets(paid=True, type="admission_ticket"))
+
     def check_will_have_ticket(self) -> bool:
         return self.will_have_ticket or self.has_admission_ticket
 

--- a/models/volunteer/volunteer.py
+++ b/models/volunteer/volunteer.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, TypeVar
 
 from flask_login import UserMixin
@@ -187,6 +187,10 @@ class Volunteer(BaseModel, UserMixin):
         """Returns the earliest and latest time at which this volunteer can take a shift."""
         if self.registered_for_buildup:
             return (buildup.buildup_start(), buildup.teardown_end())
+
+        if self.user.is_checked_in and datetime.now() <= config.event_start:
+            # Checked-in attendees are on site from Day 0 at the earliest.
+            return (config.event_start - timedelta(days=1), config.event_end)
 
         return (config.event_start, config.event_end)
 

--- a/models/volunteer/volunteer.py
+++ b/models/volunteer/volunteer.py
@@ -165,6 +165,17 @@ class Volunteer(BaseModel, UserMixin):
         return role_ids
 
     @property
+    def administered_roles(self) -> Sequence[Role]:
+        from models.volunteer.role import Role
+
+        if self.user.has_permission("volunteer:manager") or self.user.has_permission("volunteer:admin"):
+            return db.session.scalars(select(Role).order_by(Role.name)).all()
+
+        return db.session.scalars(
+            select(Role).where(Role.id.in_(self.administered_role_ids)).order_by(Role.name)
+        ).all()
+
+    @property
     def administered_team_ids(self) -> set[int]:
         """Team IDs this user can administer."""
         return {t.id for t in self.administered_teams}

--- a/templates/volunteer/role_admin/edit.html
+++ b/templates/volunteer/role_admin/edit.html
@@ -20,8 +20,8 @@
                 <div id="training-only">
                     {% call render_field(form.uses_bar_training, horizontal=9) %}{{ form.uses_bar_training.description }}{% endcall %}
                     {% call render_field(form.allows_self_training, horizontal=9) %}{{ form.allows_self_training.description }}{% endcall %}
-                    {% call render_field(form.training_notes, horizontal=9, style="height: 20em") %}{{ form.training_notes.description }}{% endcall %}
                 </div>
+                {% call render_field(form.training_notes, horizontal=9, style="height: 20em") %}{{ form.training_notes.description }}{% endcall %}
 
                 {% call render_field(form.role_notes, horizontal=9, style="height: 20em") %}{{ form.role_notes.description }}{% endcall %}
                 {% call render_field(form.instructions_url, horizontal=9) %}{{ form.instructions_url.description }}{% endcall %}

--- a/templates/volunteer/training.html
+++ b/templates/volunteer/training.html
@@ -17,17 +17,13 @@
        information attached so you can either complete the training or revisit it.</p>
 
     <ul>
-        {% if include_bar %}
-            <li>
-                <a href="{{ url_for('.bar_training') }}">Bar</a>
-                {% if trained_roles.all() | selectattr("uses_bar_training") | list %}
-                    - Trained
-                {% endif %}
-            </li>
-        {% endif %}
         {% for role in roles %}
             <li>
-                <a href="{{ url_for('.training', role_id=role.id) }}">{{ role.name }}</a>
+                {% if role.uses_bar_training %}
+                    <a href="{{ url_for('.bar_training') }}">{{ role.name }}</a>
+                {% else %}
+                    <a href="{{ url_for('.training', role_id=role.id) }}">{{ role.name }}</a>
+                {% endif %}
                 {% if role in trained_roles %} - Trained{% endif %}
             </li>
         {% endfor %}

--- a/tests/volunteer/test_volunteer.py
+++ b/tests/volunteer/test_volunteer.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta
+
+import pytest
+from freezegun import freeze_time
+
+from apps.config import config
+from main import db
+from models.basket import Basket
+from models.payment import BankPayment
+from models.product import Price, PriceTier, Product, ProductGroup
+from models.volunteer import buildup
+from models.volunteer.buildup import BuildupVolunteer
+
+
+@pytest.fixture
+def admission_tier(db):
+    group = ProductGroup(type="admissions", name="test-admissions-group")
+    db.session.add(group)
+    product = Product(name="test-admission-product", parent=group)
+    tier = PriceTier(name="test-admission-tier", parent=product)
+    price = Price(price_tier=tier, currency="GBP", price_int=100)
+    db.session.add(price)
+    db.session.flush()
+    return tier
+
+
+def buy_admission_ticket(tier, user, *, redeem):
+    basket = Basket(user, "GBP", None)
+    basket[tier] = 1
+    basket.create_purchases()
+    basket.ensure_purchase_capacity()
+    payment = basket.create_payment(BankPayment)
+    db.session.add(payment)
+    db.session.flush()
+
+    purchase = payment.purchases[0]
+    purchase.state = "paid"
+    if redeem:
+        purchase.product.set_attribute("is_redeemable", True)
+        purchase.redeem()
+    db.session.flush()
+    return purchase
+
+
+def test_permitted_shift_times_default(volunteer):
+    assert volunteer.permitted_shift_times == (config.event_start, config.event_end)
+
+
+def test_permitted_shift_times_buildup(db, user, volunteer):
+    db.session.add(
+        BuildupVolunteer(user_id=user.id, arrival_date=datetime.now(), departure_date=datetime.now())
+    )
+    db.session.flush()
+
+    assert volunteer.permitted_shift_times == (buildup.buildup_start(), buildup.teardown_end())
+
+
+def test_permitted_shift_times_checked_in(admission_tier, user, volunteer):
+    buy_admission_ticket(admission_tier, user, redeem=True)
+
+    assert volunteer.permitted_shift_times == (
+        config.event_start - timedelta(days=1),
+        config.event_end,
+    )
+
+
+def test_permitted_shift_times_not_checked_in(admission_tier, user, volunteer):
+    buy_admission_ticket(admission_tier, user, redeem=False)
+
+    assert volunteer.permitted_shift_times == (config.event_start, config.event_end)
+
+
+def test_permitted_shift_times_buildup_and_checked_in(db, admission_tier, user, volunteer):
+    db.session.add(
+        BuildupVolunteer(user_id=user.id, arrival_date=datetime.now(), departure_date=datetime.now())
+    )
+    db.session.flush()
+    buy_admission_ticket(admission_tier, user, redeem=True)
+
+    assert volunteer.permitted_shift_times == (buildup.buildup_start(), buildup.teardown_end())
+
+
+def test_permitted_shift_times_checked_in_after_event_start(admission_tier, user, volunteer):
+    buy_admission_ticket(admission_tier, user, redeem=True)
+
+    with freeze_time(config.event_start + timedelta(hours=1)):
+        assert volunteer.permitted_shift_times == (config.event_start, config.event_end)


### PR DESCRIPTION
Saving this to merge tomorrow once I've reviewed on some sleep.

- Allow setting training notes even if you don't require people to read them so the kitchen can publish the stuff they tell people in person for review.
- Volunteer admins see their own roles on the training page, even if its not one of their chosen volunteer roles.
- People who have a checked in ticket can sign up for shifts on Day 0 even if they're not registered for build, so that early village arrivals/installations/etc can sign up for shifts once they're set up.