### PR TITLE
Various fixes related to thing in invalid slots

### DIFF
--- a/apps/cfp/scheduler.py
+++ b/apps/cfp/scheduler.py
@@ -190,7 +190,7 @@ class Scheduler:
                     venue_times = [
                         VenueTimes(
                             venue=venue.id,
-                            times=times,
+                            times=[(start, end) for start, end in times],
                             venue_weight=fav_rank * capacity_rank[venue.capacity or 1],
                         )
                         for venue, times in allowed_times.items()

--- a/apps/cfp_review/schedule.py
+++ b/apps/cfp_review/schedule.py
@@ -26,7 +26,13 @@ from models.content import (
     Venue,
 )
 from models.content.potential_schedule import PotentialSchedule, PotentialScheduleOccurrence
-from models.content.schedule import SCHEDULE_ITEM_INFOS, ScheduleItemInfo, ScheduleItemState, ScheduleItemType
+from models.content.schedule import (
+    SCHEDULE_ITEM_INFOS,
+    ScheduleItemInfo,
+    ScheduleItemState,
+    ScheduleItemType,
+    merge_time_ranges,
+)
 
 from . import cfp_review, schedule_required
 
@@ -211,10 +217,22 @@ def potential_schedule(schedule_id: int) -> ResponseReturnValue:
         potential_schedule.state == "new" and latest is not None and latest.id == potential_schedule.id
     )
 
+    # Flag new slots which are no longer valid, because the schedule will fail to apply
+    invalid_slots = {
+        potential.occurrence_id
+        for potential in potential_schedule.changed_occurrences()
+        if potential.occurrence.scheduled_duration is not None
+        and not potential.occurrence.is_valid_slot(potential.start_time, potential.venue)
+    }
+
     if request.method == "POST":
         if request.form.get("apply") == "true":
             if not can_apply:
                 flash("Only the most recent potential schedule can be applied!")
+                return redirect(url_for(".potential_schedule", schedule_id=schedule_id))
+
+            if invalid_slots:
+                flash("This schedule contains invalid slots and cannot be applied!")
                 return redirect(url_for(".potential_schedule", schedule_id=schedule_id))
 
             # Work out who to notify before applying, while each occurrence
@@ -259,6 +277,7 @@ def potential_schedule(schedule_id: int) -> ResponseReturnValue:
         "cfp_review/schedule/potential_schedule.html",
         potential_schedule=potential_schedule,
         can_apply=can_apply,
+        invalid_slots=invalid_slots,
     )
 
 
@@ -421,6 +440,16 @@ def scheduler_update() -> ResponseReturnValue:
 
     if not occurrence.is_valid_slot(start_time, venue):
         return jsonify({"error": "Invalid slot"}), 400
+
+    # is_valid_slot only checks venue TimeBlocks, so also check the slot falls
+    # within the speaker's availability
+    availability = merge_time_ranges(
+        occurrence.schedule_item.availability_overrides or occurrence.availability
+    )
+    if availability and occurrence.scheduled_duration is not None:
+        end_time = start_time + timedelta(minutes=occurrence.scheduled_duration)
+        if not any(r.start <= start_time and end_time <= r.end for r in availability):
+            return jsonify({"error": "Outside speaker availability"}), 400
 
     changed = start_time != occurrence.scheduled_time or venue != occurrence.scheduled_venue
 

--- a/apps/cfp_review/sense_check.py
+++ b/apps/cfp_review/sense_check.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import selectinload
 
 from main import db
 from models.content import Occurrence, ScheduleItem, ScheduleItemType
+from models.content.schedule import merge_time_ranges
 
 from ..config import config
 from . import cfp_review, review_required
@@ -109,30 +110,54 @@ def not_sensible_reasons(
                 f"{note} is scheduled between 2am and 9am ({t.strftime(human_format)})"
             )
 
-        # -- Occurrence lies outside the allowed time periods.
-        if occurrence.schedule_item.official_content:
-            allowed_ranges = [
-                period
-                for automatic in (True, False)
-                for ranges in occurrence.allowed_times(automatic).values()
-                for period in ranges
-            ]
-            permitted_time = False
-            for start, end in allowed_ranges:
-                if t >= start and t <= end:
-                    permitted_time = True
-
-            if not permitted_time:
-                reasons[f"{reason_key}_outside_allowed_times"] = (
-                    f"{note} is outside allowed occurrence time periods"
-                )
-
     _check_timing(occurrence.potential_time, "Proposed start", "proposed_start")
     _check_timing(occurrence.scheduled_time, "Scheduled start", "scheduled_start")
     _check_timing(occurrence.potential_end_time, "Proposed end", "proposed_end")
     _check_timing(occurrence.scheduled_end_time, "Scheduled end", "scheduled_end")
 
-    # -- Occurrence overlaps another one by the same user.
+    # -- Occurrence is not in a valid slot in this venues timeblocks
+    if occurrence.scheduled_duration is not None:
+        for slot_key, slot_note, slot_time, slot_venue in (
+            ("proposed_slot_invalid", "Proposed", occurrence.potential_time, occurrence.potential_venue),
+            ("scheduled_slot_invalid", "Scheduled", occurrence.scheduled_time, occurrence.scheduled_venue),
+        ):
+            if slot_time and slot_venue and not occurrence.is_valid_slot(slot_time, slot_venue):
+                reasons[slot_key] = (
+                    f"{slot_note} slot ({slot_time.strftime(human_format)} in "
+                    f'"{slot_venue.name}") is outside the venue\'s '
+                    f"{occurrence.schedule_item.type} time blocks"
+                )
+
+    # -- Occurrence is outside the speaker's availability
+    availability = merge_time_ranges(
+        occurrence.schedule_item.availability_overrides or occurrence.schedule_item.availability
+    )
+    if availability:
+        for avail_key, avail_note, avail_start, avail_end in (
+            (
+                "proposed_outside_availability",
+                "Proposed",
+                occurrence.potential_time,
+                occurrence.potential_end_time,
+            ),
+            (
+                "scheduled_outside_availability",
+                "Scheduled",
+                occurrence.scheduled_time,
+                occurrence.scheduled_end_time,
+            ),
+        ):
+            if (
+                avail_start
+                and avail_end
+                and not any(r.start <= avail_start and avail_end <= r.end for r in availability)
+            ):
+                reasons[avail_key] = (
+                    f"{avail_note} time ({avail_start.strftime(human_format)} > "
+                    f"{avail_end.strftime(human_format)}) is outside speaker availability"
+                )
+
+    # -- Occurrence overlaps another one by the same presenter
     def get_occurrence_ranges(occurrence: Occurrence) -> dict[str, tuple[datetime, datetime]]:
         ranges = {}
         if occurrence.potential_time and occurrence.potential_end_time:
@@ -142,7 +167,12 @@ def not_sensible_reasons(
         return ranges
 
     occurrence_ranges = get_occurrence_ranges(occurrence)
-    for other_occurrence in occurrences_by_speaker[occurrence.schedule_item.user_id]:
+    other_occurrences = {
+        other
+        for presenter in occurrence.schedule_item.presenters
+        for other in occurrences_by_speaker[presenter.id]
+    }
+    for other_occurrence in other_occurrences:
         if other_occurrence == occurrence:
             continue
         other_ranges = get_occurrence_ranges(other_occurrence)
@@ -152,7 +182,7 @@ def not_sensible_reasons(
                     # Overlap.
                     reasons[f"{this_type}_overlap_{other_occurrence.id}_{other_type}"] = (
                         f"The {this_type} time ({this_start} > {this_end}) overlaps with a "
-                        f"{other_occurrence.schedule_item.type} by same user: {other_occurrence.schedule_item.title}'s "
+                        f"{other_occurrence.schedule_item.type} by same presenter: {other_occurrence.schedule_item.title}'s "
                         f"{other_type} time ({other_start} > {other_end})"
                     )
 
@@ -196,7 +226,8 @@ def sense_check():
 
     occurrences_by_speaker = defaultdict(set)
     for occurrence in occurrences_for_overlap:
-        occurrences_by_speaker[occurrence.schedule_item.user_id].add(occurrence)
+        for presenter in occurrence.schedule_item.presenters:
+            occurrences_by_speaker[presenter.id].add(occurrence)
 
     not_sensible_occurrences = []
     for occurrence in occurrences:

--- a/models/content/schedule.py
+++ b/models/content/schedule.py
@@ -109,20 +109,15 @@ def get_days_map():
     return {ed.strftime("%a").lower(): ed for ed in config.event_days}
 
 
-# Reduces the time periods to the smallest contiguous set we can
-def make_periods_contiguous(time_periods):
-    if not time_periods:
-        return []
-
-    time_periods.sort(key=lambda x: x.start)
-    contiguous_periods = [time_periods.pop(0)]
-    for time_period in time_periods:
-        if time_period.start <= contiguous_periods[-1].end and contiguous_periods[-1].end < time_period.end:
-            contiguous_periods[-1] = cfp_period(contiguous_periods[-1].start, time_period.end)
-            continue
-
-        contiguous_periods.append(time_period)
-    return contiguous_periods
+def merge_time_ranges(ranges: Iterable[TimeRange | ScheduleItemAvailability]) -> list[TimeRange]:
+    """Merge overlapping or adjacent time ranges, matching the scheduler's internal behaviour."""
+    merged: list[TimeRange] = []
+    for r in sorted(ranges, key=lambda r: (r.start, r.end)):
+        if merged and r.start <= merged[-1].end:
+            merged[-1] = TimeRange(merged[-1].start, max(merged[-1].end, r.end))
+        else:
+            merged.append(TimeRange(r.start, r.end))
+    return merged
 
 
 ScheduleItemType = Literal[
@@ -685,7 +680,7 @@ class Occurrence(BaseModel):
                     ):
                         yield timeblock
 
-    def allowed_times(self, automatic: bool) -> dict[Venue, list[tuple[datetime, datetime]]]:
+    def allowed_times(self, automatic: bool) -> dict[Venue, list[TimeRange]]:
         """Return a mapping of Venue -> time range for when this occurrence is allowed to be scheduled,
             which is the input into the automatic scheduler.
 
@@ -694,9 +689,9 @@ class Occurrence(BaseModel):
         """
         assert self.schedule_item.official_content
 
-        ranges = self.schedule_item.availability_overrides or self.availability
+        ranges = merge_time_ranges(self.schedule_item.availability_overrides or self.availability)
 
-        result: dict[Venue, list[tuple[datetime, datetime]]] = defaultdict(list)
+        result: dict[Venue, list[TimeRange]] = defaultdict(list)
         for time_block in self.time_blocks():
             if self.manually_scheduled and self.scheduled_time:
                 assert self.scheduled_end_time
@@ -708,7 +703,7 @@ class Occurrence(BaseModel):
                 # allowed_venues - this means we can restrict a talk to be at a
                 # specific time but allow for freedom of venue movement if
                 # nessecary to avoid over-constraining the problem.
-                result[time_block.venue].append((self.scheduled_time, self.scheduled_end_time))
+                result[time_block.venue].append(TimeRange(self.scheduled_time, self.scheduled_end_time))
                 continue
 
             if time_block.automatic != automatic:
@@ -716,16 +711,20 @@ class Occurrence(BaseModel):
 
             if not ranges:
                 # No availability provided, return all available timeblocks
-                result[time_block.venue].append((time_block.start, time_block.end))
+                result[time_block.venue].append(TimeRange(time_block.start, time_block.end))
                 continue
 
             for availability in ranges:
                 if availability.start <= time_block.end and availability.end >= time_block.start:
                     result[time_block.venue].append(
-                        (max(availability.start, time_block.start), min(availability.end, time_block.end))
+                        TimeRange(
+                            max(availability.start, time_block.start), min(availability.end, time_block.end)
+                        )
                     )
 
-        return result
+        # Adjacent timeblocks (or availability ranges split across them) can produce
+        # adjacent result ranges, so merge again per venue.
+        return {venue: merge_time_ranges(ranges) for venue, ranges in result.items()}
 
     def overlaps_with(self, other: Self) -> bool:
         this_start = self.potential_time or self.scheduled_time

--- a/templates/cfp_review/schedule/potential_schedule.html
+++ b/templates/cfp_review/schedule/potential_schedule.html
@@ -49,6 +49,9 @@
 {% if potential_schedule.state != 'new' %}
     <p>Note that this is showing the difference from the current schedule. If another proposed schedule has been applied, this will be wrong.</p>
 {% endif %}
+{% if invalid_slots %}
+    <p class="text-danger">{{ invalid_slots|length }} new slots no longer fall within a valid time block for the venue.</p>
+{% endif %}
 <table class="table table-default table-condensed">
     <tr>
         <th colspan="5"></th>
@@ -86,7 +89,7 @@
     </tr>
 {% for potential in potential_schedule.changed_occurrences() %}
     {% set occurrence = potential.occurrence %}
-    <tr>
+    <tr{% if potential.occurrence_id in invalid_slots %} class="danger"{% endif %}>
         <td>{{ occurrence.schedule_item.human_type | capitalize_add }}</td>
         <td>{{ occurrence.scheduled_duration or '--' }}</td>
         <td>
@@ -109,6 +112,7 @@
         </td>
         <td style="text-wrap:nowrap">
             {{ occurrence.potential_venue.name }}
+            {% if potential.occurrence_id in invalid_slots %}<span class="label label-danger">Invalid slot</span>{% endif %}
         </td>
         <td>
             {{ occurrence.potential_time.strftime('%A') }}


### PR DESCRIPTION
* Schedule tweaker stops you putting things in slots where the speaker is unavailable
* Time ranges are merged to allow schedule tweaker (etc) to permit talks crossing adjacent time ranges
* Sense check flags things outside venue timeblocks and outside speaker availability separately
* Proposed schedule view flags new venues that are invalid, and prevents you attempting to apply it