### PR TITLE
Add "uses_lottery"

### DIFF
--- a/apps/schedule/data.py
+++ b/apps/schedule/data.py
@@ -149,7 +149,7 @@ def _get_occurrence_dict(filter: ScheduleFilter, occurrence: Occurrence) -> Occu
         venue=occurrence.scheduled_venue.name,
         latlon=occurrence.scheduled_venue.latlon,
         map_link=occurrence.scheduled_venue.map_link,
-        uses_lottery=bool(occurrence.lottery),
+        uses_lottery=occurrence.uses_lottery(),
         video_privacy=occurrence.video_privacy,
         recording_lost=occurrence.video_recording_lost,
     )

--- a/models/content/schedule.py
+++ b/models/content/schedule.py
@@ -542,6 +542,18 @@ class Occurrence(BaseModel):
     proposal: AssociationProxy[Proposal | None] = association_proxy("schedule_item", "proposal")
     user: AssociationProxy[User] = association_proxy("schedule_item", "user")
 
+    def uses_lottery(self) -> bool:
+        if not isinstance(self.schedule_item.attributes, WorkshopAttributes):
+            return False
+
+        if self.schedule_item.attributes.drop_in:
+            return False
+
+        if self.lottery:
+            return self.lottery.state != "closed"
+
+        return False
+
     @validates("scheduled_duration")
     def validate_scheduled_duration(self, key: str, value: int | None) -> int | None:
         """SQLAlchemy validator to ensure duration is a multiple of the slot duration."""


### PR DESCRIPTION
this more correctly indicates when an occurrence uses the lottery system which fixes some display bugs in the schedule where dropin and closed workshops were showing the "request tickets" button