### PR TITLE
apps/schedule/frab_exporter: day index must start at 1

### DIFF
--- a/apps/schedule/frab_exporter.py
+++ b/apps/schedule/frab_exporter.py
@@ -96,7 +96,7 @@ class FrabExporter:
         filter = ScheduleFilter()
 
         data = {}
-        index = 0
+        index = 1
         for schedule_item in self.schedule_items:
             sid = _get_schedule_item_dict(filter, schedule_item)
             for occurrence in schedule_item.occurrences:


### PR DESCRIPTION
Validator says:
```
1:0: ERROR: Element 'day', attribute 'index': '0' is not a valid value of the atomic type 'xs:positiveInteger'.
1:0: ERROR: Element 'day', attribute 'index': Warning: No precomputed value available, the value was either invalid or something strange happened.
```