### PR TITLE
Adjust wording for drop-in workshops

### DIFF
--- a/templates/schedule/item.html
+++ b/templates/schedule/item.html
@@ -143,12 +143,12 @@
   <tr>
   {% endif %}
   <tr>
-    <td><b>Drop-in</b></td>
+    <td><b>Drop-in workshop</b></td>
     <td>
       {% if schedule_item.attributes.drop_in %}
-      Drop-in workshop
+      Yes
       {% else %}
-      Not a drop-in workshop
+      No
       {% endif %}
     </td>
   <tr>


### PR DESCRIPTION
Reducing this to a simple "yes" and "no" makes it clearer. Currently it's a bit wordy:

<img width="369" height="53" alt="Screenshot 2026-07-09 at 20 38 17" src="https://github.com/user-attachments/assets/75bcc972-fcd1-44f5-b089-4219d137bbae" />
