### PR TITLE
Shift multipliers

### DIFF
--- a/apps/volunteer/role_admin.py
+++ b/apps/volunteer/role_admin.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 from decorator import decorator
 from flask import (
@@ -18,6 +19,7 @@ from flask_login import current_user
 from sqlalchemy import select
 from wtforms.fields import (
     BooleanField,
+    DecimalField,
     IntegerField,
     SelectField,
     StringField,
@@ -81,6 +83,11 @@ class ShiftTemplateForm(Form):
         "Max Volunteers",
         [InputRequired()],
         description="The maximum number of volunteers you can make use of.",
+    )
+    multiplier = DecimalField(
+        "Multiplier",
+        [InputRequired()],
+        description="Weight this shift to count more or less towards ticket vouchers.",
     )
     notes = TextAreaField(
         "Notes", [Optional()], description="Any notes you want on this template, not visible to attendees."
@@ -362,6 +369,7 @@ def update_shift(role_id: int, shift_id: int) -> ResponseReturnValue:
     shift.min_needed = int(request.form["min_needed"])
     shift.max_needed = int(request.form["max_needed"])
     shift.notes = request.form["notes"] if len(request.form["notes"].strip()) > 0 else None
+    shift.multiplier = Decimal(request.form["multiplier"])
     db.session.add(shift)
     db.session.commit()
 

--- a/css/volunteer_schedule.scss
+++ b/css/volunteer_schedule.scss
@@ -46,13 +46,28 @@
   }
 }
 
+.shift-multiplier {
+  display: inline-block;
+  padding: 0.25em 0.5em;
+  border-radius: 0.5em;
+  line-height: 1em;
+  color: $success-text;
+  background-color: $brand-2026-green;
+  vertical-align: middle;
+}
+
 table.shifts-table {
-  tr,
-  th,
-  td {
-    // !important because I'm a terrible (and very lazy) person
-    border-color: #4a4a4a !important;
-    vertical-align: middle !important;
+  tbody,
+  thead,
+  tfoot {
+    tr,
+    th,
+    td {
+      // !important because I'm a terrible (and very lazy) person
+      border-color: #4a4a4a;
+      vertical-align: middle;
+      padding: 10px 15px 10px;
+    }
   }
 
   td.hidden,
@@ -102,6 +117,7 @@ table.shifts-table {
       width: 1em;
       height: 1em;
       border-radius: 50%;
+      vertical-align: middle;
     }
   }
 
@@ -125,51 +141,45 @@ table.shifts-table {
 ul.key {
   list-style: none;
   padding-left: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: center;
+  row-gap: 4px;
+  column-gap: 8px;
 
   li {
-    display: flex;
+    display: contents;
+  }
+
+  .key-icon {
+    display: inline-flex;
     align-items: center;
-    gap: 8px;
-    margin-bottom: 4px;
-
-    &::before {
-      content: "";
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 1.5em;
-      height: 1.5em;
-      border-radius: 50%;
-      flex-shrink: 0;
-      font-size: 0.85em;
-      font-weight: bold;
-      color: white;
-    }
+    justify-content: center;
+    justify-self: center;
+    width: 1.5em;
+    height: 1.5em;
+    border-radius: 50%;
+    font-size: 0.85em;
+    font-weight: bold;
+    color: white;
   }
 
-  #key-shift-signed-up::before {
-    background-color: $brand-2026-light-blue;
-  }
-
-  #key-shift-conflict::before {
-    background-color: $brand-2026-coral;
-  }
-
-  #key-content-conflict::before {
-    background-color: $brand-2026-yellow;
-  }
-
-  #key-no-conflicts::before {
+  #key-no-conflicts .key-icon {
     background-color: $highlight-background;
   }
-
-  #key-understaffed::before {
-    content: "!";
+  #key-shift-signed-up .key-icon {
+    background-color: $brand-2026-light-blue;
+  }
+  #key-shift-conflict .key-icon {
     background-color: $brand-2026-coral;
   }
-
-  #key-staffed::before {
-    content: "✓";
+  #key-content-conflict .key-icon {
+    background-color: $brand-2026-yellow;
+  }
+  #key-understaffed .key-icon {
+    background-color: $brand-2026-coral;
+  }
+  #key-staffed .key-icon {
     background-color: $brand-2026-green;
   }
 }

--- a/migrations/versions/b34ee11a7db6_add_shift_multipliers.py
+++ b/migrations/versions/b34ee11a7db6_add_shift_multipliers.py
@@ -1,0 +1,42 @@
+"""Add shift multipliers
+
+Revision ID: b34ee11a7db6
+Revises: 3b07c4eea8ea
+Create Date: 2026-06-07 10:16:53.549323
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "b34ee11a7db6"
+down_revision = "07d0c7108150"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    with op.batch_alter_table("volunteer_shift", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("multiplier", sa.Numeric(), nullable=False, server_default="1"))
+
+    with op.batch_alter_table("volunteer_shift_version", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("multiplier", sa.Numeric(), autoincrement=False, nullable=True))
+
+    with op.batch_alter_table("volunteer_shift_template", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("multiplier", sa.Numeric(), nullable=False, server_default="1"))
+
+    with op.batch_alter_table("volunteer_shift_template_version", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("multiplier", sa.Numeric(), autoincrement=False, nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("volunteer_shift_version", schema=None) as batch_op:
+        batch_op.drop_column("multiplier")
+
+    with op.batch_alter_table("volunteer_shift", schema=None) as batch_op:
+        batch_op.drop_column("multiplier")
+
+    with op.batch_alter_table("volunteer_shift_template_version", schema=None) as batch_op:
+        batch_op.drop_column("multiplier")
+
+    with op.batch_alter_table("volunteer_shift_template", schema=None) as batch_op:
+        batch_op.drop_column("multiplier")

--- a/models/volunteer/shift.py
+++ b/models/volunteer/shift.py
@@ -1,6 +1,7 @@
 import enum
 from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 from math import ceil, floor
 from typing import TYPE_CHECKING, Self, TypedDict
 
@@ -155,6 +156,7 @@ class ShiftTemplate(BaseModel):
     changeover_time: Mapped[int] = mapped_column(default=15)
     min_needed: Mapped[int] = mapped_column(default=0)
     max_needed: Mapped[int] = mapped_column(default=0)
+    multiplier: Mapped[Decimal] = mapped_column(default=1)
     notes: Mapped[str] = mapped_column(default="")
 
     role: Mapped[Role] = relationship("Role", back_populates="shift_templates")
@@ -253,6 +255,7 @@ class ShiftTemplate(BaseModel):
                 venue=self.venue,
                 min_needed=self.min_needed,
                 max_needed=self.max_needed,
+                multiplier=self.multiplier,
                 start=(shift_start - timedelta(minutes=self.changeover_time))
                 .astimezone(pytz.utc)
                 .replace(tzinfo=None),
@@ -290,6 +293,10 @@ class Shift(BaseModel):
     min_needed: Mapped[int] = mapped_column(default=0)
     #: Maximum number of volunteers required for the shift
     max_needed: Mapped[int] = mapped_column(default=0)
+    #: Used to weight a shift's contribution towards voucher requirements,
+    #: either to accuont for shorter than usual shifts or to incentivise people
+    #: taking anti-social shits.
+    multiplier: Mapped[Decimal] = mapped_column(default=1)
 
     #: Role that this shift is filling
     role: Mapped[Role] = relationship(back_populates="shifts")
@@ -386,6 +393,7 @@ class Shift(BaseModel):
             "start_time": self.local_start.strftime("%H:%M"),
             "end": self.local_end.strftime("%Y-%m-%dT%H:%M:00"),
             "end_time": self.local_end.strftime("%H:%M"),
+            "multiplier": self.multiplier,
             "min_needed": self.min_needed,
             "max_needed": self.max_needed,
             "role": self.role.to_dict(),

--- a/templates/volunteer/role_admin/role.html
+++ b/templates/volunteer/role_admin/role.html
@@ -69,7 +69,12 @@
   <h3>Upcoming Shifts</h3>
   {% for shift in shifts %}
     <div class="role-admin-shift well content-well">
-      <h4 id="shift-{{ shift.id }}">{{ shift.local_start.strftime("%a %H:%M") }} - {{ shift.local_end.strftime("%H:%M") }} - {{ shift.venue.name }}</h4>
+      <h4 id="shift-{{ shift.id }}">
+        {{ shift.start.strftime("%a %H:%M") }} - {{ shift.end.strftime("%H:%M") }} - {{shift.venue.name }}
+        {% if shift.multiplier != 1 %}
+            {{ shift.multiplier }}×
+        {% endif %}
+      </h4>
       <form method="post" class="shift-editor" id="shift-editor-{{ shift.id }}" action="/volunteer/role/{{ shift.role_id }}/{{ shift.id }}">
         <div class="form-group">
           <label class="control-label" for="min_needed">Minimum Volunteers</label>
@@ -78,6 +83,10 @@
         <div class="form-group">
           <label class="control-label" for="max_needed">Maximum Volunteers</label>
           <input name="max_needed" type="number" class="form-control" value="{{ shift.max_needed }}">
+        </div>
+        <div class="form-group">
+        <label for="multiplier" class="control-label">Multiplier</label>
+        <input type="number" step="0.01" name="multiplier" class="form-control" value="{{ shift.multiplier }}">
         </div>
         <div class="form-group">
           <label class="control-label" for="notes">Notes</label>

--- a/templates/volunteer/role_admin/shift_templates.html
+++ b/templates/volunteer/role_admin/shift_templates.html
@@ -37,18 +37,25 @@ EMF Volunteer Role Admin
         </div>
         <div class="col-sm-7">
             <div class="row">
-                <div class="col-xs-6 form-group">
+                <div class="col-xs-4 form-group">
                     <label>Duration</label>
                     <div class="input-group">
                         {{ form.duration(class="form-control") }}
                         <span class="input-group-addon">min</span>
                     </div>
                 </div>
-                <div class="col-xs-6 form-group">
+                <div class="col-xs-4 form-group">
                     <label>Changeover</label>
                     <div class="input-group">
                         {{ form.changeover_time(class="form-control") }}
                         <span class="input-group-addon">min</span>
+                    </div>
+                </div>
+                <div class="col-xs-4 form-group">
+                    <label>Multiplier</label>
+                    <div class="input-group">
+                        {{ form.multiplier(class="form-control") }}
+                        <span class="input-group-addon">×</span>
                     </div>
                 </div>
             </div>

--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -87,7 +87,11 @@
                                         {{ hour }}{% if shift.end %} to {{ shift.end_time }}{% endif %}
                                     {% endif %}
                                 </td>
-                                <td class="conflicts" {% if shift.is_user_shift %}title="You're signed up for this shift"{% endif %}></td>
+                                <td class="conflicts" {% if shift.is_user_shift %}title="You're signed up for this shift"{% endif %}>
+                                    {% if shift.multiplier != 1 %}
+                                        <span class="shift-multiplier">{{ shift.multiplier.normalize() }}x</span>
+                                    {% endif %}
+                                </td>
                                 <td class="venue"><a href="{{ shift.venue.mapref }}">{{ shift.venue.name }}</a></td>
                                 <td class="role">
                                     {{ shift.role.name }}
@@ -122,12 +126,13 @@
     </div>
     <h3>Key</h3>
     <ul class="key">
-        <li id="key-no-conflicts">A shift with no schedule conflicts</li>
-        <li id="key-shift-signed-up">A shift you're signed up for</li>
-        <li id="key-shift-conflict">Conflicts with a shift you're signed up for</li>
-        <li id="key-content-conflict">Conflicts with content you're presenting or have favourited</li>
-        <li id="key-understaffed">Not enough people signed up</li>
-        <li id="key-staffed">Fully staffed</li>
+        <li id="key-no-conflicts"><span class="key-icon"></span>A shift with no schedule conflicts</li>
+        <li id="key-shift-signed-up"><span class="key-icon"></span>A shift you're signed up for</li>
+        <li id="key-shift-conflict"><span class="key-icon"></span>Conflicts with a shift you're signed up for</li>
+        <li id="key-content-conflict"><span class="key-icon"></span>Conflicts with content you're presenting or have favourited</li>
+        <li id="key-understaffed"><span class="key-icon">!</span>Not enough people signed up</li>
+        <li id="key-staffed"><span class="key-icon">✓</span>Fully staffed</li>
+        <li id="key-multiplier"><span class="shift-multiplier">2×</span>A shift that counts more or less towards voucher requirements</li>
     </ul>
 {% endblock %}
 {% block foot %}


### PR DESCRIPTION
These can be used to compensate for shifts that are much shorter than others (such as workshop steward shifts) or to incentivise people picking up otherwise unattractive shifts like late night ticket check-ins/early morning kitchen shifts.