### PR TITLE
fix volunteer dashboard

### DIFF
--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Sequence
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from flask import (
     Response,
@@ -85,7 +85,7 @@ def redirect_next_or_schedule(message: str | None = None) -> ResponseReturnValue
 def public_dashboard():
     days = int(request.args.get("days", 1))
     refresh = int(request.args.get("refresh", 0))
-    now = datetime.now()
+    now = datetime.now(UTC)
     shifts = (
         db.session.query(Shift)
         .where(

--- a/apps/volunteer/schedule.py
+++ b/apps/volunteer/schedule.py
@@ -94,7 +94,7 @@ def public_dashboard():
             Shift.start < now + timedelta(days=days),
         )
         .order_by(Shift.start, Shift.venue_id)
-        .all()
+        .limit(100)
     )
 
     return render_template(


### PR DESCRIPTION
`datetime.now()` returns a naive datetime object, but `shift.local_start` is timezone-aware.

(I'm not sure why `datetime.utcnow()` didn't work for me in dev, but that's deprecated anyways).