### PR TITLE
Allow uploading a slotmachine solution

### DIFF
--- a/apps/cfp_review/schedule.py
+++ b/apps/cfp_review/schedule.py
@@ -199,6 +199,48 @@ def run_scheduler_export() -> ResponseReturnValue:
     )
 
 
+@cfp_review.route("/schedule/run-scheduler/import", methods=["POST"])
+@schedule_required
+def run_scheduler_import() -> ResponseReturnValue:
+    # Import a solution JSON produced by running slotmachine locally
+    file = request.files.get("solution")
+    if file is None or file.filename == "":
+        flash("Please select a solution JSON file to upload")
+        return redirect(url_for(".run_scheduler"))
+
+    try:
+        talks = [slotmachine.Talk.from_dict(t) for t in json.load(file)["talks"]]
+    except Exception as e:
+        flash(f"Could not parse solution file: {e}")
+        return redirect(url_for(".run_scheduler"))
+
+    potential_schedule = PotentialSchedule(scheduler_stats={"source": "local_import"})
+    errors = []
+    for talk in talks:
+        occurrence = db.session.get(Occurrence, talk.id)
+        venue = db.session.get(Venue, talk.venue) if talk.venue is not None else None
+        if occurrence is None:
+            errors.append(f"unknown occurrence ID {talk.id}")
+        elif talk.start_time is None or venue is None:
+            errors.append(f"occurrence {talk.id} is missing a time or venue")
+        else:
+            potential_schedule.scheduled_occurrences.append(
+                PotentialScheduleOccurrence(
+                    occurrence=occurrence,
+                    venue=venue,
+                    start_time=talk.start_time,
+                )
+            )
+
+    if errors:
+        flash(f"Import failed: {'; '.join(errors[:10])}")
+        return redirect(url_for(".run_scheduler"))
+
+    db.session.add(potential_schedule)
+    db.session.commit()
+    return redirect(url_for(".potential_schedule", schedule_id=potential_schedule.id))
+
+
 @cfp_review.route("/schedule/potential_schedule/<int:schedule_id>", methods=["GET", "POST"])
 @schedule_required
 def potential_schedule(schedule_id: int) -> ResponseReturnValue:

--- a/templates/cfp_review/schedule/potential_schedule.html
+++ b/templates/cfp_review/schedule/potential_schedule.html
@@ -10,7 +10,7 @@
         <dl class="dl-horizontal">
             <dt>Date</dt><dd>{{potential_schedule.created}}</dd>
             <dt>Total items</dt><dd>{{potential_schedule.scheduled_occurrences|length}}</dd>
-            {% if potential_schedule.scheduler_stats.source != 'schedule_tweaker' %}
+            {% if potential_schedule.scheduler_stats.timings %}
             <dt>Solution type</dt><dd>{{potential_schedule.scheduler_stats.solution_type}}</dd>
             <dt>Variables</dt><dd>{{potential_schedule.scheduler_stats.variables}}</dd>
             <dt>Solve time</dt><dd>{{potential_schedule.scheduler_stats.timings.solve}} s</dd>

--- a/templates/cfp_review/schedule/schedule_run.html
+++ b/templates/cfp_review/schedule/schedule_run.html
@@ -61,4 +61,14 @@
 <p class="help-block" style="margin-top: 2em">
     "Download problem JSON" exports the current scheduling problem for debugging with slotmachine (<code>python -m slotmachine slotmachine-problem.json</code>).
 </p>
+<h3>Upload local scheduler results</h3>
+<p class="help-block">
+    If you've run slotmachine locally on a downloaded problem file you can upload the solution to create a potential schedule (<code>python -m slotmachine slotmachine-problem.json solution.json</code>).
+</p>
+<form method="POST" action="{{ url_for('.run_scheduler_import') }}" enctype="multipart/form-data">
+    <fieldset style="margin-bottom: 1em;">
+        <input type="file" name="solution" accept=".json,application/json" required>
+    </fieldset>
+    <button class="btn btn-primary">Upload solution</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
This allows you to upload a slotmachine solution that was computed offline, allowing longer runtimes than we can permit on the main servers and use of higher-powered machines to compute them.

This is really only nessecary when we have a full schedule and actually want to compute optimal changes rather than taking the best feasible one we can find in the page timeout period.