### PR TITLE
Add volunteer shift subscription and iCal download links

### DIFF
--- a/templates/volunteer/schedule.html
+++ b/templates/volunteer/schedule.html
@@ -151,6 +151,13 @@
         <li id="key-staffed"><span class="key-icon">✓</span>Fully staffed</li>
         <li id="key-multiplier"><span class="shift-multiplier">2×</span>A shift that counts more or less towards voucher requirements</li>
     </ul>
+
+    <div class="well">
+    <p>You can <a href="{{ webcal_url('.schedule_ical', token=token) }}">subscribe to your shifts in your calendar</a>
+       so it stays up to date, download it as an <a href="{{ url_for('.schedule_ical') }}?token={{ token }}">iCal file</a>.
+    </p>
+    </div>
+        
 {% endblock %}
 {% block foot %}
     <div class="modal fade" id="conflict-modal" tabindex="-1" role="dialog" aria-labelledby="conflict-modal-label">


### PR DESCRIPTION
Added a section for subscribing to shifts and downloading iCal file. Uses the existing functions and routes in apps/volunteer/schedule.py and just adds a href in an easy to access space.

For example, going to www.emfcamp.org/volunteer/schedule.ics will generate the current users volunteer shifts in an ics file. When viewed, the contents of the ics file match the shifts signed up for the user.

This is technically untested (as Im doing this on the drive to EMF), so I can't validate it. However *theoretically* it should be fine 🤞