### PR TITLE
Show volunteer overtime without (milli)seconds

### DIFF
--- a/templates/volunteer/role_admin/role.html
+++ b/templates/volunteer/role_admin/role.html
@@ -50,7 +50,7 @@
         <p>
           <strong>{{ active.user.volunteer.nickname }}</strong> {{ active.shift.local_start.strftime("%a %H:%M") }}&ndash;{{ active.shift.local_end.strftime("%H:%M") }}
           {% if now > active.shift.end %}
-              <br /><span class="overtime">{{ now - active.shift.end }} over</span>
+              <br /><span class="overtime">{{ (now - active.shift.end)|duration_hm }} over</span>
           {% endif %}
         </p>
         {{ state_selector(active) }}


### PR DESCRIPTION
see #2346 -- with this, times would show as rounded to the nearest minute like in other places, ie "2:12:47.318290" becomes "2h 12m"