### PR TITLE
Promote video streaming to front page properly

### DIFF
--- a/templates/home/after-event.html
+++ b/templates/home/after-event.html
@@ -20,9 +20,14 @@ in making things.{% endblock %} {% block body %}
       making our non-profit event a success.
     </p>
     <p>
-      If you want to re-live EMF, you can find photos, videos, and more on our
-      <a href="https://www.emfcamp.org/wiki/2026-memories">memories</a> page. Talk
-      videos will be published as soon as we can make them available.
+      Missed some talks during the event? Don't worry!
+      <a href="https://emf.camp/watch">Catch up for free</a>, with
+      DRM-free video and audio. <i>Thanks to <a href="https://c3voc.de">C3VOC</a>
+      for providing streaming hosting and infrastructure!</i>
+    </p>
+    <p>
+      Have a fond memory you'd like to share with the commmunity? Read and add photos, 
+      videos, and more on our <a href="https://www.emfcamp.org/wiki/2026-memories">attendee memories</a> wiki page. 
       {# event_year fixme hardcoded above #}
     </p>
     <div class="well">

--- a/templates/home/after-event.html
+++ b/templates/home/after-event.html
@@ -27,7 +27,8 @@ in making things.{% endblock %} {% block body %}
     </p>
     <p>
       Have a fond memory you'd like to share with the commmunity? Read and add photos, 
-      videos, and more on our <a href="https://www.emfcamp.org/wiki/2026-memories">attendee memories</a> wiki page. 
+      videos, and more on our <a href="https://www.emfcamp.org/wiki/2026-memories">
+      attendee memories</a> wiki page. 
       {# event_year fixme hardcoded above #}
     </p>
     <div class="well">


### PR DESCRIPTION
Given that the talks are up in record time (<3 to the team + volunteers who made it happen), figured it was probably about time to update the page.