### PR TITLE
Fix SQL exception when adding/removing favourites

### DIFF
--- a/apps/api/schedule.py
+++ b/apps/api/schedule.py
@@ -89,18 +89,13 @@ class FavouriteScheduleItem(Resource):
             abort(401)
 
         schedule_item = get_or_404(db, ScheduleItem, schedule_item_id)
-        current_state = schedule_item in current_user.favourites
 
         data = request.get_json()
         if data.get("state") is not None:
             new_state = bool(data["state"])
+            current_user.set_favourite(schedule_item, new_state)
         else:
-            new_state = not current_state
-
-        if new_state and not current_state:
-            current_user.favourites.append(schedule_item)
-        elif current_state and not new_state:
-            current_user.favourites.remove(schedule_item)
+            new_state = current_user.toggle_favourite(schedule_item)
 
         db.session.commit()
 

--- a/apps/schedule/base.py
+++ b/apps/schedule/base.py
@@ -195,10 +195,7 @@ def add_favourite() -> ResponseReturnValue:
 
     schedule_item_id = int(request.form["fave"])
     schedule_item = get_or_404(db, ScheduleItem, schedule_item_id)
-    if schedule_item in current_user.favourites:
-        current_user.favourites.remove(schedule_item)
-    else:
-        current_user.favourites.append(schedule_item)
+    current_user.toggle_favourite(schedule_item)
 
     db.session.commit()
     return redirect(url_for(".main_year", year=config.event_year) + f"#schedule-item-{schedule_item.id}")
@@ -210,10 +207,7 @@ def favourites() -> ResponseReturnValue:
     if (request.method == "POST") and current_user.is_authenticated:
         schedule_item_id = int(request.form["fave"])
         schedule_item = get_or_404(db, ScheduleItem, schedule_item_id)
-        if schedule_item in current_user.favourites:
-            current_user.favourites.remove(schedule_item)
-        else:
-            current_user.favourites.append(schedule_item)
+        current_user.toggle_favourite(schedule_item)
 
         db.session.commit()
         return redirect(url_for(".favourites") + f"#schedule-item-{schedule_item.id}")
@@ -318,12 +312,10 @@ def item_current(year: int, schedule_item_id: int, slug: str | None = None) -> R
         if schedule_item_form.validate_on_submit():
             msg = None
             if schedule_item_form.toggle_favourite.data:
-                if is_fave:
-                    current_user.favourites.remove(schedule_item)
-                    msg = f'Removed "{schedule_item.title}" from favourites'
-                else:
-                    current_user.favourites.append(schedule_item)
+                if current_user.toggle_favourite(schedule_item):
                     msg = f'Added "{schedule_item.title}" to favourites'
+                else:
+                    msg = f'Removed "{schedule_item.title}" from favourites'
 
             db.session.commit()
             if msg:

--- a/models/user.py
+++ b/models/user.py
@@ -14,7 +14,8 @@ from typing import TYPE_CHECKING, Literal, cast
 from flask import current_app as app
 from flask import session
 from flask_login import AnonymousUserMixin, UserMixin
-from sqlalchemy import Column, ForeignKey, Index, Integer, Table, func, select, text
+from sqlalchemy import Column, ForeignKey, Index, Integer, Table, delete, func, select, text
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -541,6 +542,30 @@ class User(BaseModel, UserMixin):
                 return entry
         return None
 
+    def set_favourite(self, schedule_item: ScheduleItem, state: bool) -> None:
+        """Add or remove a ScheduleItem from this user's favourites."""
+        if state:
+            # Upsert to avoid integrity errors on concurrent requests
+            db.session.execute(
+                insert(FavouriteScheduleItem)
+                .values(user_id=self.id, schedule_item_id=schedule_item.id)
+                .on_conflict_do_nothing()
+            )
+        else:
+            db.session.execute(
+                delete(FavouriteScheduleItem).where(
+                    FavouriteScheduleItem.c.user_id == self.id,
+                    FavouriteScheduleItem.c.schedule_item_id == schedule_item.id,
+                )
+            )
+        db.session.expire(self, ["favourites"])
+
+    def toggle_favourite(self, schedule_item: ScheduleItem) -> bool:
+        """Toggle whether a ScheduleItem is in this user's favourites, returning the new state."""
+        new_state = schedule_item not in self.favourites
+        self.set_favourite(schedule_item, new_state)
+        return new_state
+
     @property
     def google_wallet_pass_url(self) -> str:
         # Avoid circular import
@@ -600,5 +625,5 @@ def load_anonymous_user():
 
 
 from .content.cfp import Proposal
-from .content.schedule import ScheduleItem
+from .content.schedule import FavouriteScheduleItem, ScheduleItem
 from .product import ProductView, Voucher

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -3,6 +3,8 @@ from io import BytesIO
 from cairosvg import svg2png
 from PIL import Image
 
+login_link_re = r"(https?://[^\s/]*/login[^\s]*)"
+
 
 def render_svg(svg):
     # pyzbar fails to decode qr codes under 52x52 and epc qr codes under 72x72

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@
 import datetime
 import os
 import os.path
+import re
 import shutil
 
 import pytest
+from flask import g, has_app_context
 from flask_mailman import Mail
 from freezegun import freeze_time
 from sqlalchemy import text
@@ -16,6 +18,7 @@ from main import create_app
 from main import db as db_obj
 from models.site_state import SiteState
 from models.user import User
+from tests._utils import login_link_re
 
 
 @pytest.fixture(scope="module")
@@ -103,6 +106,14 @@ def app_factory(cache):
     freezer.stop()
 
 
+@pytest.fixture(autouse=True)
+def reset_login_cache():
+    """Clear flask-login's cached user, so it does not leak between tests."""
+    if has_app_context():
+        g.pop("_login_user", None)
+    yield
+
+
 @pytest.fixture
 def client(app):
     "Yield a test HTTP client for the app"
@@ -141,3 +152,14 @@ def outbox(app):
     mail = Mail(app)
     mail.get_connection()
     yield mail.outbox
+
+
+@pytest.fixture
+def logged_in_client(client, user, outbox):
+    """Yield a test HTTP client logged in as the test user"""
+    client.post("/login", data={"email": user.email})
+    match = re.search(login_link_re, outbox[0].body)
+    assert match is not None
+    client.get(match.group(0))
+
+    yield client

--- a/tests/test_favourites.py
+++ b/tests/test_favourites.py
@@ -1,0 +1,181 @@
+import pytest
+from sqlalchemy import delete, select
+
+from apps.config import config
+from models.content.schedule import FavouriteScheduleItem, ScheduleItem
+from models.user import User
+
+
+@pytest.fixture(scope="module")
+def schedule_item(db):
+    schedule_item = ScheduleItem(
+        type="talk",
+        user=User("favourites_speaker@example.com", "A Speaker"),
+        title="A talk to favourite",
+        description="A description",
+    )
+    db.session.add(schedule_item)
+    db.session.commit()
+
+    return schedule_item
+
+
+@pytest.fixture(autouse=True)
+def no_favourites(db):
+    db.session.execute(delete(FavouriteScheduleItem))
+    db.session.commit()
+
+
+@pytest.fixture
+def line_up_enabled(app):
+    """Enable the LINE_UP feature flag, which the favourites page is gated on."""
+    old_value = app.config.get("LINE_UP", False)
+    app.config["LINE_UP"] = True
+    yield
+    app.config["LINE_UP"] = old_value
+
+
+def favourite_rows(db, user, schedule_item):
+    return db.session.execute(
+        select(FavouriteScheduleItem).where(
+            FavouriteScheduleItem.c.user_id == user.id,
+            FavouriteScheduleItem.c.schedule_item_id == schedule_item.id,
+        )
+    ).all()
+
+
+def insert_favourite_row(db, user, schedule_item):
+    db.session.execute(
+        FavouriteScheduleItem.insert().values(user_id=user.id, schedule_item_id=schedule_item.id)
+    )
+    db.session.commit()
+
+
+def item_url(schedule_item):
+    return f"/schedule/{config.event_year}/{schedule_item.id}-{schedule_item.slug}"
+
+
+def last_flash(client):
+    with client.session_transaction() as session:
+        return session["_flashes"][-1][1]
+
+
+def test_toggle_favourite(db, user, schedule_item):
+    assert user.toggle_favourite(schedule_item) is True
+    db.session.commit()
+    assert schedule_item in user.favourites
+
+    assert user.toggle_favourite(schedule_item) is False
+    db.session.commit()
+    assert schedule_item not in user.favourites
+
+
+def test_set_favourite(db, user, schedule_item):
+    user.set_favourite(schedule_item, True)
+    db.session.commit()
+    assert schedule_item in user.favourites
+
+    user.set_favourite(schedule_item, False)
+    db.session.commit()
+    assert schedule_item not in user.favourites
+
+
+def test_add_favourite_that_already_exists(db, user, schedule_item):
+    insert_favourite_row(db, user, schedule_item)
+
+    user.set_favourite(schedule_item, True)
+    db.session.commit()
+
+    assert len(favourite_rows(db, user, schedule_item)) == 1
+
+
+def test_remove_favourite_that_no_longer_exists(db, user, schedule_item):
+    user.set_favourite(schedule_item, False)
+    db.session.commit()
+
+    assert schedule_item not in user.favourites
+
+
+def test_toggle_favourite_that_already_exists(db, user, schedule_item):
+    insert_favourite_row(db, user, schedule_item)
+
+    assert user.toggle_favourite(schedule_item) is False
+    db.session.commit()
+
+    assert schedule_item not in user.favourites
+
+
+def test_favourite_api_requires_login(client, schedule_item):
+    rv = client.get(f"/api/schedule-item/{schedule_item.id}/favourite")
+    assert rv.status_code == 401
+
+    rv = client.put(f"/api/schedule-item/{schedule_item.id}/favourite", json={})
+    assert rv.status_code == 401
+
+
+def test_favourite_api_toggle(db, logged_in_client, user, schedule_item):
+    url = f"/api/schedule-item/{schedule_item.id}/favourite"
+
+    rv = logged_in_client.get(url)
+    assert rv.json == {"is_favourite": False}
+
+    rv = logged_in_client.put(url, json={})
+    assert rv.json == {"is_favourite": True}
+    assert len(favourite_rows(db, user, schedule_item)) == 1
+
+    rv = logged_in_client.put(url, json={})
+    assert rv.json == {"is_favourite": False}
+    assert len(favourite_rows(db, user, schedule_item)) == 0
+
+
+def test_favourite_api_set_state_is_idempotent(db, logged_in_client, user, schedule_item):
+    url = f"/api/schedule-item/{schedule_item.id}/favourite"
+
+    for _ in range(2):
+        rv = logged_in_client.put(url, json={"state": True})
+        assert rv.json == {"is_favourite": True}
+    assert len(favourite_rows(db, user, schedule_item)) == 1
+
+    for _ in range(2):
+        rv = logged_in_client.put(url, json={"state": False})
+        assert rv.json == {"is_favourite": False}
+    assert len(favourite_rows(db, user, schedule_item)) == 0
+
+
+def test_add_favourite_view_requires_login(client, schedule_item):
+    rv = client.post("/schedule/add-favourite", data={"fave": schedule_item.id})
+    assert rv.status_code == 401
+
+
+def test_add_favourite_view_toggles(db, logged_in_client, user, schedule_item):
+    rv = logged_in_client.post("/schedule/add-favourite", data={"fave": schedule_item.id})
+    assert rv.status_code == 302
+    assert len(favourite_rows(db, user, schedule_item)) == 1
+
+    rv = logged_in_client.post("/schedule/add-favourite", data={"fave": schedule_item.id})
+    assert rv.status_code == 302
+    assert len(favourite_rows(db, user, schedule_item)) == 0
+
+
+def test_favourites_page_toggles(db, logged_in_client, user, schedule_item, line_up_enabled):
+    rv = logged_in_client.post("/favourites", data={"fave": schedule_item.id})
+    assert rv.status_code == 302
+    assert len(favourite_rows(db, user, schedule_item)) == 1
+
+    rv = logged_in_client.post("/favourites", data={"fave": schedule_item.id})
+    assert rv.status_code == 302
+    assert len(favourite_rows(db, user, schedule_item)) == 0
+
+
+def test_item_page_toggles_favourite(db, logged_in_client, user, schedule_item):
+    url = item_url(schedule_item)
+
+    rv = logged_in_client.post(url, data={"toggle_favourite": "Favourite"})
+    assert rv.status_code == 302
+    assert len(favourite_rows(db, user, schedule_item)) == 1
+    assert last_flash(logged_in_client) == f'Added "{schedule_item.title}" to favourites'
+
+    rv = logged_in_client.post(url, data={"toggle_favourite": "Favourite"})
+    assert rv.status_code == 302
+    assert len(favourite_rows(db, user, schedule_item)) == 0
+    assert last_flash(logged_in_client) == f'Removed "{schedule_item.title}" from favourites'

--- a/tests/test_users_app.py
+++ b/tests/test_users_app.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-login_link_re = r"(https?://[^\s/]*/login[^\s]*)"
+from tests._utils import login_link_re
 
 
 def test_login(user, client, outbox):


### PR DESCRIPTION
closes #2357

Added two helper methods on `User`, one to set a favourite and one to toggle (for convenience). The setter upserts when adding a favourite and safely deletes when dropping it, so we should be good on race conditions (`DELETE ... WHERE ...` is idempotent, so I don't think we need the row lock mentioned in the issue).

I added an autouse fixture to `conftest.py` to clear the logged in user set by `flask-login`, as it was leaking between tests, as `app` is a module scoped fixture that keeps its context (including the user) between tests. I'm more of a Django dev and don't know what current practice is in Flask; if you want me to drop this part and work around it in my tests, say the word.