### PR TITLE
Only try to push images in upstream repo

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -29,11 +29,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      # Only the upstream repo can push to the emfcamp registry
+      PUSH: ${{ github.repository_owner == 'emfcamp' }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Login to GitHub Container Registry
+        if: env.PUSH == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -49,7 +54,7 @@ jobs:
       - name: Build and push base image
         uses: docker/build-push-action@v7
         with:
-          push: true
+          push: ${{ env.PUSH }}
           tags: ghcr.io/emfcamp/website-base:latest
           file: ./docker/Dockerfile.base
           platforms: linux/amd64,linux/arm64
@@ -57,7 +62,7 @@ jobs:
       - name: Build and push base-dev image
         uses: docker/build-push-action@v7
         with:
-          push: true
+          push: ${{ env.PUSH }}
           tags: ghcr.io/emfcamp/website-base-dev:latest
           file: ./docker/Dockerfile.base-dev
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      # Only the upstream repo can push to the emfcamp registry
+      PUSH: ${{ github.repository_owner == 'emfcamp' }}
     steps:
       - uses: actions/checkout@v7
       - name: Login to GitHub Container Registry
+        if: env.PUSH == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -40,8 +44,10 @@ jobs:
         run: docker build -t ghcr.io/emfcamp/website-static:latest -f ./docker/static/Dockerfile ./docker/static/
       - name: Publish static image
         # Push static first so it hopefully gets pulled first
+        if: env.PUSH == 'true'
         run: docker push ghcr.io/emfcamp/website-static:latest
       - name: Publish app image
+        if: env.PUSH == 'true'
         run: docker push ghcr.io/emfcamp/website:latest
 
   build-docs:


### PR DESCRIPTION
Since opening my fork, every couple of days, I got notifications that the build for `rixx/Website` failed because it could not push the `emfcamp/Website` docker image. If I got the weird GitHub actions stringy bash/yaml/typing right, this should only try to push from the upstream repo, but still build on forks to see if the build works.